### PR TITLE
Fix authentication error

### DIFF
--- a/surrealdb/clients/http.py
+++ b/surrealdb/clients/http.py
@@ -68,7 +68,7 @@ class HTTPClient:
             base_url=self._url,
             auth=httpx.BasicAuth(
                 username=self._username,
-                password=self._username,
+                password=self._password,
             ),
             headers={
                 "NS": self._namespace,


### PR DESCRIPTION
Fixes an authentication issue. There was a typo which caused the value for `username` to be used for the `password` argument.