### PR TITLE
Add support for creation of record links

### DIFF
--- a/examples/http_client_example.py
+++ b/examples/http_client_example.py
@@ -14,6 +14,8 @@ limitations under the License.
 import asyncio
 
 from surrealdb.clients.http import HTTPClient
+from surrealdb.models import response
+from surrealdb.models.link import RecordLink
 
 # import the http client
 
@@ -81,6 +83,21 @@ async def upsert_one():
     print(response)
 
 
+async def create_record_link():
+    """Create a record with a record-link"""
+    table = "hospital"
+    custom_id = "customidhere"
+    record_with_link = {
+        "location": "down under",
+        "friendlyHospital": RecordLink(id=f"{table}:{custom_id}"),
+    }
+    await client.create_all(table, record_with_link)
+    response = await client.execute(
+        f'SELECT * FROM {table} WHERE location="down under" FETCH friendlyHospital'
+    )
+    print(response)
+
+
 async def delete_all():
     """Delete all records in a table."""
     table = "hospital"
@@ -109,6 +126,7 @@ async def run_all():
     await select_one()
     await replace_one()
     await upsert_one()
+    await create_record_link()
     await delete_one()
     await delete_all()
     await my_query()

--- a/surrealdb/common/json.py
+++ b/surrealdb/common/json.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Any
+from typing import Any, Iterable
 from typing import Union
 
 
@@ -28,13 +28,21 @@ __all__ = (
 )
 
 
-def dumps(obj: Any, **kwargs: Any) -> str:
-    """Serialize an object to a JSON string."""
-    result = jsonlib.dumps(obj, **kwargs)
-    if isinstance(result, bytes):
-        result = result.decode("utf-8")
-
-    return result
+def dumps(obj: Any) -> str:
+    """Serialize an object to a SurrealDB string."""
+    if any(isinstance(obj, t) for t in [int, float]):
+        return repr(obj)
+    elif isinstance(obj, str):
+        return f'"{obj}"'
+    elif hasattr(obj, "id"):
+        return obj.id
+    elif isinstance(obj, dict):
+        if obj.get("id") is not None:
+            return obj["id"]
+        return "{" + ", ".join(f"{k}: {dumps(v)}" for k, v in obj.items()) + "}"
+    elif isinstance(obj, Iterable):
+        return f'[{", ".join(dumps(v) for v in obj)}]'
+    raise Exception(f"Object is not json serializable: {repr(obj)}")
 
 
 def loads(content: Union[bytes, str], **kwargs: Any) -> Any:

--- a/surrealdb/models/link.py
+++ b/surrealdb/models/link.py
@@ -1,0 +1,25 @@
+"""
+Copyright © SurrealDB Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from dataclasses import dataclass
+
+__all__ = ("RecordLink",)
+
+
+@dataclass(frozen=True)
+class RecordLink:
+    """Used to represent a record link when making queries to surrealdb"""
+
+    id: str


### PR DESCRIPTION
# Problem:

Currently surrealdb does not allow the creation of record links when creating, upserting or replacing records. This is caused by the use of simple json parsers that do not handle record links.

# Solution:

A new encoder, that encodes objects to valid surreal queries instead of json.

If a nested object has a `id` key or attribute, it will be encoded as a *record link*.