### PR TITLE
Fix websocket exception handling

### DIFF
--- a/surrealdb/clients/ws.py
+++ b/surrealdb/clients/ws.py
@@ -126,8 +126,7 @@ class WebsocketClient:
 
             response = RPCResponse(**json_response)
 
-            if request_future is not None:
-                request_future.set_result(response)
+            request_future.set_result(response)
 
     async def _send(
         self,

--- a/surrealdb/clients/ws.py
+++ b/surrealdb/clients/ws.py
@@ -110,7 +110,7 @@ class WebsocketClient:
             if request_future is None:
                 # SurrealDB returned an answer to a non existent operation
                 raise SurrealWebsocketException(
-                    "Invalid operation id recived from server"
+                    "Invalid operation id received from server"
                 )
 
             if msg.type == WSMsgType.ERROR:

--- a/surrealdb/clients/ws.py
+++ b/surrealdb/clients/ws.py
@@ -104,19 +104,28 @@ class WebsocketClient:
 
     async def _receive_task(self) -> None:
         async for msg in self._ws:
-            if msg.type == WSMsgType.ERROR:
-                raise SurrealWebsocketException(msg.data)
-
             json_response: Dict[str, Any] = jsonlib.loads(msg.data)
+            request_future = self._response_futures.pop(json_response["id"], None)
+
+            if request_future is None:
+                # SurrealDB returned an answer to a non existent operation
+                raise SurrealWebsocketException(
+                    "Invalid operation id recived from server"
+                )
+
+            if msg.type == WSMsgType.ERROR:
+                request_future.set_exception(SurrealWebsocketException(msg.data))
+                continue
 
             error = json_response.get("error")
+
             if error is not None:
                 error = RPCError(**error)
-                raise SurrealWebsocketException(error.message)
+                request_future.set_exception(SurrealWebsocketException(error.message))
+                continue
 
             response = RPCResponse(**json_response)
 
-            request_future = self._response_futures.pop(response.id, None)
             if request_future is not None:
                 request_future.set_result(response)
 


### PR DESCRIPTION
When `surrealdb` would return an error, the exception would get raised in the scope of the connection handler.

This fix causes the exception to be passed to the future, so it can be handled by the user.