### PR TITLE
Increasing the size of the WebSocket

### DIFF
--- a/surrealdb/ws.py
+++ b/surrealdb/ws.py
@@ -189,7 +189,7 @@ class Surreal:
 
     """
 
-    def __init__(self, url: Optional[str] = None, token: Optional[str] = None, max_size: Optional[int] = None) -> None:        
+    def __init__(self, url: Optional[str] = None, token: Optional[str] = None, max_size: Optional[int] = 2**20) -> None:        
         self.url = url
         self.token = token
         self.max_size = max_size
@@ -243,9 +243,7 @@ class Surreal:
             self.url
         if max_size is not None:
             self.max_size = max_size
-        else:
-            # default max size is 1MB
-            self.max_size = 2**20
+        
         # helping people when they type the url in wrong
         if "http" in self.url:
             self.url = self.url.replace("http://", "ws://")


### PR DESCRIPTION
## What is the motivation?

WebSocket only handles 1MB of data and I'm getting this error message `sent 1009 (message too large); no closed frames received` when I try to do a `SELECT * FROM my_table` when `my_table` had more than 1 MB of data.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

These changes allow the user to specify what is the max size of the data that the WebSocket connection to the SurrealDB will be capable to handle.

## What is your testing strategy?

- Create a table on SurrealDB with more than 1 MB of data.
- Run the script above, that start the connection to SurrealDB with a limit of 3 MB instead of the 1 MB default.

```python
import asyncio
from surrealdb import Surreal

DB = Surreal()

async def main():
    await DB.connect("ws://localhost:8000/rpc", max_size=3000000)
    await DB.signin({"user": "root", "pass": "root"})
    await DB.use(database="test", namespace="test")

    try:
        data = await DB.select("tipi")
    except Exception as e:
        data = str(e) 
    print(data)
        
if __name__ == '__main__':
    asyncio.run(main())
```

This script will print on the terminal all data from your table, but if you remove the `max_size` parameter from `connect` method the max size handle will be only 1 MB as default.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
