### PR TITLE
Add LiveStream class for managing live queries

### DIFF
--- a/surrealdb/ws.py
+++ b/surrealdb/ws.py
@@ -19,7 +19,7 @@ import enum
 import json
 import uuid
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, AsyncIterator
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pydantic
 import websockets

--- a/surrealdb/ws.py
+++ b/surrealdb/ws.py
@@ -187,11 +187,11 @@ class LiveStream:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # Teardown connection using query ID
+        self.client.client_state = ConnectionState.CONNECTED
         if self.query_id:
             await self.client._send_receive(
                 Request(id=generate_uuid(), method="kill", params=(self.query_id,))
             )
-        self.client.client_state = ConnectionState.CONNECTED
     
     def __aiter__(self):
         return self


### PR DESCRIPTION
## What is the motivation?

To Add support for Live Query result fetching

<!-- Provide information on the motivation for why you have made this change. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

This change implements initial support for live queries and listening to the result stream rather than simply returning the live query ID as the SDK currently does.

Note that the limitation of one live query per Surreal class instance and associated required connection state changes is a result of the current implementation choice to use the connection in a blocking way with _send_receive. Multiplexing of multiple live query streams is possible with custom listener handling routing for received messages and use of callbacks but represents a fundamental change to the way this SDK currently operates which is why I chose not to implement it.

## Is this related to any issues?

<!-- If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here. -->

#34 

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
