### PR TITLE
Feature message multiplexing

### DIFF
--- a/surrealdb/__init__.py
+++ b/surrealdb/__init__.py
@@ -15,5 +15,12 @@ limitations under the License.
 """
 from .http import SurrealHTTP
 from .ws import Surreal
+from .common import (
+    SurrealException,
+)
 
-__all__ = ("Surreal", "SurrealHTTP")
+__all__ = [
+    "SurrealHTTP",
+    "Surreal",
+    "SurrealException",
+]

--- a/surrealdb/common.py
+++ b/surrealdb/common.py
@@ -1,0 +1,21 @@
+import pydantic
+import uuid
+from typing import Any, Optional, Tuple
+
+# ------------------------------------------------------------------------
+# ID
+
+
+def generate_uuid() -> str:
+    """Generate a UUID.
+
+    Returns:
+        A UUID as a string.
+    """
+    return str(uuid.uuid4())
+
+
+# ------------------------------------------------------------------------
+# Exceptions
+class SurrealException(Exception):
+    """Base exception for SurrealDB client library."""

--- a/surrealdb/http.py
+++ b/surrealdb/http.py
@@ -19,14 +19,10 @@ import json
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type
-
+from .common import SurrealException
 import httpx
 
 __all__ = ("SurrealHTTP",)
-
-
-class SurrealException(Exception):
-    """Base exception for SurrealDB client library."""
 
 
 @dataclass(frozen=True)

--- a/surrealdb/ws.py
+++ b/surrealdb/ws.py
@@ -19,7 +19,7 @@ import enum
 import json
 import uuid
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, AsyncIterator
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pydantic
 import websockets

--- a/surrealdb/ws.py
+++ b/surrealdb/ws.py
@@ -187,11 +187,11 @@ class LiveStream:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         # Teardown connection using query ID
+        self.client.client_state = ConnectionState.CONNECTED
         if self.query_id:
             await self.client._send_receive(
                 Request(id=generate_uuid(), method="kill", params=(self.query_id,))
             )
-        self.client.client_state = ConnectionState.CONNECTED
     
     def __aiter__(self):
         return self


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To allow the use of the same WS connection for multiple queries at the same time (thread safety) and multiplexing of incoming live query results from multiple streams.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Provides for use of a connection manager to route incoming requests from the web socket, and handles ensuring every request is replied to with the actual response rather than just the first one to come in.

This is additional implementation on top of #78 

## Is this related to any issues?

#34 #78 

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
