### PR TITLE
Consistently define `SurrealException` base class (once)

### DIFF
--- a/python_package/surrealdb/exceptions.py
+++ b/python_package/surrealdb/exceptions.py
@@ -1,0 +1,10 @@
+class SurrealException(Exception):
+    """Base exception for SurrealDB client library."""
+
+
+class SurrealAuthenticationException(SurrealException):
+    """Exception raised for errors with SurrealDB authentication."""
+
+
+class SurrealPermissionException(SurrealException):
+    """Exception raised for errors with SurrealDB permissions."""

--- a/python_package/surrealdb/http.py
+++ b/python_package/surrealdb/http.py
@@ -22,14 +22,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 import httpx
 
+from .exceptions import SurrealException
+
 if TYPE_CHECKING:
     from types import TracebackType
 
 __all__ = ("SurrealHTTP",)
-
-
-class SurrealException(Exception):
-    """Base exception for SurrealDB client library."""
 
 
 @dataclass(frozen=True)

--- a/python_package/surrealdb/ws.py
+++ b/python_package/surrealdb/ws.py
@@ -18,11 +18,17 @@ from __future__ import annotations
 
 import enum
 import json
-import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from uuid import uuid4
 
 import pydantic
 import websockets
+
+from .exceptions import (
+    SurrealAuthenticationException,
+    SurrealException,
+    SurrealPermissionException,
+)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -40,21 +46,7 @@ def generate_uuid() -> str:
     Returns:
         A UUID as a string.
     """
-    return str(uuid.uuid4())
-
-
-# ------------------------------------------------------------------------
-# Exceptions
-class SurrealException(Exception):
-    """Base exception for SurrealDB client library."""
-
-
-class SurrealAuthenticationException(SurrealException):
-    """Exception raised for errors with the SurrealDB authentication."""
-
-
-class SurrealPermissionException(SurrealException):
-    """Exception raised for errors with the SurrealDB permissions."""
+    return str(uuid4())
 
 
 # ------------------------------------------------------------------------
@@ -354,10 +346,7 @@ class Surreal:
             Request(
                 id=generate_uuid(),
                 method="let",
-                params=(
-                    key,
-                    value,
-                ),
+                params=(key, value),
             ),
         )
         success: ResponseSuccess = _validate_response(
@@ -377,10 +366,7 @@ class Surreal:
             Request(
                 id=generate_uuid(),
                 method="let",
-                params=(
-                    key,
-                    value,
-                ),
+                params=(key, value),
             ),
         )
         success: ResponseSuccess = _validate_response(


### PR DESCRIPTION
## What is the motivation?

Ensuring that there aren't two different/competing `SurrealException` definitions. The two definitions have the same name but are different objects, which can lead to various issues/gremlins.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)

## What does this change do?

Establishes a single location for (and definition of) the core Surreal exception classes.
This ensures that there is only _one_ `SurrealException` base class.

## What is your testing strategy?

Unit tests.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

