### PR TITLE
Make Surreal.set call Surreal.let

### DIFF
--- a/python_package/surrealdb/ws.py
+++ b/python_package/surrealdb/ws.py
@@ -373,20 +373,7 @@ class Surreal:
             key: Specifies the name of the variable.
             value: Assigns the value to the variable name.
         """
-        response = await self._send_receive(
-            Request(
-                id=generate_uuid(),
-                method="let",
-                params=(
-                    key,
-                    value,
-                ),
-            ),
-        )
-        success: ResponseSuccess = _validate_response(
-            response, SurrealPermissionException
-        )
-        return success.result
+        return await self.let(key, value)
 
     async def query(
         self, sql: str, vars: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## What is the motivation?
Reducing code duplication. Removes risk of forgetting to change `set` when changing `let`

## Type of Change
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

The `Surreal.set` function is documented with ```"""Alias for `let`"""```. This PR changes the contents of the `set` function to call `let`, instead of containing `let`'s copy-pasta code.

## What is your testing strategy?

No functionality has changed. 

mypy OK
pre-commit OK
./scripts/run_tests.sh OK
manual testing OK

## Is this related to any issues?

No. 
Small change, didn't see a need for an issue.

## Have you read the [Contributing Guidelines]?

- [X] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
