### PR TITLE
Fix return types of some `Surreal` methods

### DIFF
--- a/python_package/surrealdb/ws.py
+++ b/python_package/surrealdb/ws.py
@@ -421,7 +421,9 @@ class Surreal:
         success: ResponseSuccess = _validate_response(response)
         return success.result
 
-    async def select(self, thing: str) -> List[Dict[str, Any]]:
+    async def select(
+        self, thing: str
+    ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]:
         """
         Select all records in a table (or other entity),
         or a specific record, in the database.
@@ -450,7 +452,7 @@ class Surreal:
 
     async def create(
         self, thing: str, data: Optional[Dict[str, Any]] = None
-    ) -> List[Dict[str, Any]]:
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
         Create a record in the database.
 
@@ -488,7 +490,7 @@ class Surreal:
 
     async def update(
         self, thing: str, data: Optional[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
         Update all records in a table, or a specific record, in the database.
 
@@ -529,7 +531,7 @@ class Surreal:
 
     async def merge(
         self, thing: str, data: Optional[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
         Modify by deep merging all records in a table, or a specific record, in the database.
 
@@ -610,7 +612,9 @@ class Surreal:
         )
         return success.result
 
-    async def delete(self, thing: str) -> List[Dict[str, Any]]:
+    async def delete(
+        self, thing: str
+    ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]:
         """
         Delete all records in a table, or a specific record, from the database.
 


### PR DESCRIPTION
Change some return types from `List[Dict, Any]` to `Unions[Dict[str, Any], List[Dict, Any]]`, or the Optional[...], variant of that.

## What is the motivation?

Fix the currently incomplete/wrong return type annotations of some `Surreal` (WS/RPC client) methods.
Improving developer experience of users.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Changes the return type of some methods from `List[Dict[str, Any]]` to
-  `Union[Dict[str, Any], List[Dict[str, Any]]]` for `create`, `update`, and `merge`
-  `Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]` for `select` and `delete`

## What is your testing strategy?

pre-commit (ruff linter, ruff formatter) returned OK
`./scripts/run_tests.sh` returned OK

## Is this related to any issues?

<!-- If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here. -->

## Have you read the [Contributing Guidelines]?

- [ ] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
