### PR TITLE
Fix the `Surreal.patch` method

### DIFF
--- a/python_package/surrealdb/ws.py
+++ b/python_package/surrealdb/ws.py
@@ -571,8 +571,10 @@ class Surreal:
         return success.result
 
     async def patch(
-        self, thing: str, data: Optional[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self,
+        thing: str,
+        data: Optional[List[Dict[str, Any]]],
+    ) -> Union[dict[str, Any], List[Dict[str, Any]]]:
         """
         Apply JSON Patch changes to all records, or a specific record, in the database.
 
@@ -598,6 +600,7 @@ class Surreal:
                 { 'op': "remove", "path": "/temp" },
             ])
         """
+        data = data or []
         response = await self._send_receive(
             Request(
                 id=generate_uuid(),


### PR DESCRIPTION
Change request method type from "modify" to "patch". And fix type annotations.

## What is the motivation?

`Surreal.patch` is currently not usable.
Fixing type annotations improved developer experience. 

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

1. Changes the `Surreal.patch` request method type from "modify" to "patch"
2. Changes the `Surreal.patch`'s `data` parameter type to `Optional[List[Dict[str, Any]]]`
3. Changes the `Surreal.patch` return type to `Union[dict[str, Any], List[Dict[str, Any]]]`

## What is your testing strategy?

`mypy` OK
`pre-commit` OK
`./scripts/run_tests.sh` OK
manual testing OK

## Is this related to any issues?

Yes: https://github.com/surrealdb/surrealdb.py/issues/99

## Have you read the [Contributing Guidelines]?

- [X] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
