### PR TITLE
Fix:  Websocket "close" connection and RPC listen exception bug

### DIFF
--- a/surrealdb/connection_ws.py
+++ b/surrealdb/connection_ws.py
@@ -50,7 +50,7 @@ class WebsocketConnection(Connection):
         await self.send(METHOD_UNSET, key)
 
     async def close(self):
-        if self._receiver_task:
+        if self._receiver_task and not self._receiver_task.cancelled():
             self._receiver_task.cancel()
 
         if self._ws:
@@ -108,7 +108,7 @@ class WebsocketConnection(Connection):
                     continue
                 await queue.put(response_data.get("result"))
             except asyncio.CancelledError:
-                self._logger.info("Stopped listening for RPC responses")
+                self._logger.info("Task cancelled. Stopped listening for RPC responses")
                 break
             except Exception as e:
                 self._logger.error(e)

--- a/surrealdb/connection_ws.py
+++ b/surrealdb/connection_ws.py
@@ -16,7 +16,9 @@ class WebsocketConnection(Connection):
     async def connect(self):
         try:
             self._ws = await connect(
-                self._base_url + "/rpc", subprotocols=[Subprotocol("cbor")], max_size=1048576
+                self._base_url + "/rpc",
+                subprotocols=[Subprotocol("cbor")],
+                max_size=1048576,
             )
             self._receiver_task = asyncio.create_task(self._listen_to_ws(self._ws))
         except Exception as e:
@@ -106,7 +108,7 @@ class WebsocketConnection(Connection):
                     continue
                 await queue.put(response_data.get("result"))
             except asyncio.CancelledError:
-                self._logger.info(f"Stopped listening for RPC responses")
+                self._logger.info("Stopped listening for RPC responses")
                 break
             except Exception as e:
                 self._logger.error(e)

--- a/surrealdb/connection_ws.py
+++ b/surrealdb/connection_ws.py
@@ -16,7 +16,7 @@ class WebsocketConnection(Connection):
     async def connect(self):
         try:
             self._ws = await connect(
-                self._base_url + "/rpc", subprotocols=[Subprotocol("cbor")]
+                self._base_url + "/rpc", subprotocols=[Subprotocol("cbor")], max_size=1048576
             )
             self._receiver_task = asyncio.create_task(self._listen_to_ws(self._ws))
         except Exception as e:
@@ -108,5 +108,6 @@ class WebsocketConnection(Connection):
             except asyncio.CancelledError:
                 self._logger.info(f"Stopped listening for RPC responses")
                 break
-            except Exception:
+            except Exception as e:
+                self._logger.error(e)
                 continue


### PR DESCRIPTION
## What is the motivation?
Fix https://github.com/surrealdb/surrealdb.py/issues/138. Send errors to queues and continue listening for RPC messages. Remove task stop that causes the issue raised.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

<!-- Provide a description of what this pull request does. -->

## What is your testing strategy?

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Is this related to any issues?

<!-- If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here. -->

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
