### PR TITLE
CI testing refactor

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests
         env:
           SURREALDB_URL: "http://localhost:8000"
-        run: export PYTHONPATH="./src" && python -m unittest discover -s tests
+        run: export DOCKER_RUN="TRUE" && export PYTHONPATH="./src" && python -m unittest discover -s tests
 
 
 

--- a/tests/unit_tests/connections/invalidate/test_async_http.py
+++ b/tests/unit_tests/connections/invalidate/test_async_http.py
@@ -1,5 +1,5 @@
 from unittest import main, IsolatedAsyncioTestCase
-
+import os
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 
 
@@ -25,7 +25,16 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
         _ = await self.connection.signin(self.vars_params)
         _ = await self.connection.use(namespace=self.namespace, database=self.database_name)
 
-    async def test_invalidate(self):
+    async def running_through_docker(self):
+        _ = await self.connection.invalidate()
+        with self.assertRaises(Exception) as context:
+            _ = await self.connection.query("CREATE user:jaime SET name = 'Jaime';")
+        self.assertEqual(
+            "IAM error: Not enough permissions" in str(context.exception),
+            True
+        )
+
+    async def running_through_binary(self):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.assertEqual(1, len(outcome))
         outcome = await self.main_connection.query("SELECT * FROM user;")
@@ -39,6 +48,12 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(1, len(outcome))
 
         await self.main_connection.query("DELETE user;")
+
+    async def test_invalidate(self):
+        if os.environ.get("DOCKER_RUN") == "TRUE":
+            await self.running_through_docker()
+        else:
+            await self.running_through_binary()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_async_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_async_ws.py
@@ -15,20 +15,32 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         }
         self.database_name = "test_db"
         self.namespace = "test_ns"
+        self.main_connection = AsyncWsSurrealConnection(self.url)
+        _ = await self.main_connection.signin(self.vars_params)
+        _ = await self.main_connection.use(namespace=self.namespace, database=self.database_name)
+        await self.main_connection.query("DELETE user;")
+        _ = await self.main_connection.query_raw("CREATE user:jaime SET name = 'Jaime';")
+
         self.connection = AsyncWsSurrealConnection(self.url)
         _ = await self.connection.signin(self.vars_params)
         _ = await self.connection.use(namespace=self.namespace, database=self.database_name)
 
     async def test_invalidate(self):
-        _ = await self.connection.invalidate()
-        with self.assertRaises(Exception) as context:
-            _ = await self.connection.query("CREATE user:jaime SET name = 'Jaime';")
-        self.assertEqual(
-            "IAM error: Not enough permissions" in str(context.exception),
-            True
-        )
-        await self.connection.socket.close()
+        outcome = await self.connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+        outcome = await self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
 
+        _ = await self.connection.invalidate()
+
+        outcome = await self.connection.query("SELECT * FROM user;")
+        self.assertEqual(0, len(outcome))
+        outcome = await self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+
+        await self.main_connection.query("DELETE user;")
+        await self.main_connection.close()
+        await self.connection.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_async_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_async_ws.py
@@ -1,5 +1,5 @@
 from unittest import main, IsolatedAsyncioTestCase
-
+import os
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 
 
@@ -25,7 +25,16 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         _ = await self.connection.signin(self.vars_params)
         _ = await self.connection.use(namespace=self.namespace, database=self.database_name)
 
-    async def test_invalidate(self):
+    async def running_through_docker(self):
+        _ = await self.connection.invalidate()
+        with self.assertRaises(Exception) as context:
+            _ = await self.connection.query("CREATE user:jaime SET name = 'Jaime';")
+        self.assertEqual(
+            "IAM error: Not enough permissions" in str(context.exception),
+            True
+        )
+
+    async def running_through_binary(self):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.assertEqual(1, len(outcome))
         outcome = await self.main_connection.query("SELECT * FROM user;")
@@ -39,8 +48,12 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(1, len(outcome))
 
         await self.main_connection.query("DELETE user;")
-        await self.main_connection.close()
-        await self.connection.close()
+
+    async def test_invalidate(self):
+        if os.environ.get("DOCKER_RUN") == "TRUE":
+            await self.running_through_docker()
+        else:
+            await self.running_through_binary()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_blocking_http.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_http.py
@@ -15,18 +15,30 @@ class TestAsyncHttpSurrealConnection(TestCase):
         }
         self.database_name = "test_db"
         self.namespace = "test_ns"
+        self.main_connection = BlockingHttpSurrealConnection(self.url)
+        _ = self.main_connection.signin(self.vars_params)
+        _ = self.main_connection.use(namespace=self.namespace, database=self.database_name)
+        self.main_connection.query("DELETE user;")
+        _ = self.main_connection.query_raw("CREATE user:jaime SET name = 'Jaime';")
+
         self.connection = BlockingHttpSurrealConnection(self.url)
         _ = self.connection.signin(self.vars_params)
         _ = self.connection.use(namespace=self.namespace, database=self.database_name)
 
     def test_invalidate(self):
+        outcome = self.connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+        outcome = self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+
         _ = self.connection.invalidate()
-        with self.assertRaises(Exception) as context:
-            _ = self.connection.query("CREATE user:jaime SET name = 'Jaime';")
-        self.assertEqual(
-            "IAM error: Not enough permissions" in str(context.exception),
-            True
-        )
+
+        outcome = self.connection.query("SELECT * FROM user;")
+        self.assertEqual(0, len(outcome))
+        outcome = self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+
+        self.main_connection.query("DELETE user;")
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_blocking_http.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_http.py
@@ -1,5 +1,5 @@
 from unittest import main, TestCase
-
+import os
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 
 
@@ -25,7 +25,16 @@ class TestAsyncHttpSurrealConnection(TestCase):
         _ = self.connection.signin(self.vars_params)
         _ = self.connection.use(namespace=self.namespace, database=self.database_name)
 
-    def test_invalidate(self):
+    def running_through_docker(self):
+        _ = self.connection.invalidate()
+        with self.assertRaises(Exception) as context:
+            _ = self.connection.query("CREATE user:jaime SET name = 'Jaime';")
+        self.assertEqual(
+            "IAM error: Not enough permissions" in str(context.exception),
+            True
+        )
+
+    def running_through_binary(self):
         outcome = self.connection.query("SELECT * FROM user;")
         self.assertEqual(1, len(outcome))
         outcome = self.main_connection.query("SELECT * FROM user;")
@@ -39,6 +48,12 @@ class TestAsyncHttpSurrealConnection(TestCase):
         self.assertEqual(1, len(outcome))
 
         self.main_connection.query("DELETE user;")
+
+    def test_invalidate(self):
+        if os.environ.get("DOCKER_RUN") == "TRUE":
+            self.running_through_docker()
+        else:
+            self.running_through_binary()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_blocking_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_ws.py
@@ -1,11 +1,11 @@
-from unittest import main, IsolatedAsyncioTestCase
+from unittest import main, TestCase
 
-from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 
-class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
+class TestAsyncWsSurrealConnection(TestCase):
 
-    async def asyncSetUp(self):
+    def setUp(self):
         self.url = "ws://localhost:8000"
         self.password = "root"
         self.username = "root"
@@ -15,20 +15,32 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         }
         self.database_name = "test_db"
         self.namespace = "test_ns"
-        self.connection = AsyncWsSurrealConnection(self.url)
-        _ = await self.connection.signin(self.vars_params)
-        _ = await self.connection.use(namespace=self.namespace, database=self.database_name)
+        self.main_connection = BlockingWsSurrealConnection(self.url)
+        _ = self.main_connection.signin(self.vars_params)
+        _ = self.main_connection.use(namespace=self.namespace, database=self.database_name)
+        self.main_connection.query("DELETE user;")
+        _ = self.main_connection.query_raw("CREATE user:jaime SET name = 'Jaime';")
 
-    async def test_invalidate(self):
-        _ = await self.connection.invalidate()
-        with self.assertRaises(Exception) as context:
-            _ = await self.connection.query("CREATE user:jaime SET name = 'Jaime';")
-        self.assertEqual(
-            "IAM error: Not enough permissions" in str(context.exception),
-            True
-        )
-        await self.connection.socket.close()
+        self.connection = BlockingWsSurrealConnection(self.url)
+        _ = self.connection.signin(self.vars_params)
+        _ = self.connection.use(namespace=self.namespace, database=self.database_name)
 
+    def test_invalidate(self):
+        outcome = self.connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+        outcome = self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+
+        _ = self.connection.invalidate()
+
+        outcome = self.connection.query("SELECT * FROM user;")
+        self.assertEqual(0, len(outcome))
+        outcome = self.main_connection.query("SELECT * FROM user;")
+        self.assertEqual(1, len(outcome))
+
+        self.main_connection.query("DELETE user;")
+        self.main_connection.close()
+        self.connection.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/invalidate/test_blocking_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_ws.py
@@ -1,5 +1,5 @@
 from unittest import main, TestCase
-
+import os
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 
@@ -25,7 +25,7 @@ class TestAsyncWsSurrealConnection(TestCase):
         _ = self.connection.signin(self.vars_params)
         _ = self.connection.use(namespace=self.namespace, database=self.database_name)
 
-    def test_invalidate(self):
+    def running_through_binary(self):
         outcome = self.connection.query("SELECT * FROM user;")
         self.assertEqual(1, len(outcome))
         outcome = self.main_connection.query("SELECT * FROM user;")
@@ -41,6 +41,23 @@ class TestAsyncWsSurrealConnection(TestCase):
         self.main_connection.query("DELETE user;")
         self.main_connection.close()
         self.connection.close()
+
+    def running_through_docker(self):
+        _ = self.connection.invalidate()
+        with self.assertRaises(Exception) as context:
+            _ = self.connection.query("CREATE user:jaime SET name = 'Jaime';")
+        self.assertEqual(
+            "IAM error: Not enough permissions" in str(context.exception),
+            True
+        )
+        self.main_connection.close()
+        self.connection.close()
+
+    def test_invalidate(self):
+        if os.environ.get("DOCKER_RUN") == "TRUE":
+            self.running_through_docker()
+        else:
+            self.running_through_binary()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
invalidate doesn't raise errors one requests afterwards, they just don't get enacted, so the tests have been updated to support this.