### PR TITLE
Add support for compact duration tags in CBOR decoder

### DIFF
--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -121,6 +121,9 @@ def tag_decoder(decoder, tag, shareable_index=None):
     elif tag.tag == constants.TAG_DURATION:
         return Duration.parse(tag.value[0], tag.value[1])
 
+    elif tag.tag == constants.TAG_DURATION_COMPACT:
+        return Duration.parse(tag.value[0])
+
     elif tag.tag == constants.TAG_DATETIME_COMPACT:
         return DateTimeCompact.parse(tag.value[0], tag.value[1])
 


### PR DESCRIPTION
## What is the motivation?

```py
File ".venv/lib/python3.13/site-packages/surrealdb/data/cbor.py",                     
   line 128, in tag_decoder                                                                                       
       raise BufferError("no decoder for tag", tag.tag)                             
   BufferError: ('no decoder for tag', 14)
```

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Allow compact durations to be parsed in CBOR.

## What is your testing strategy?

I have created a table with a duration field. Then I create and request a record with this field.

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Is this related to any issues?

<!-- If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here. -->
https://discord.com/channels/902568124350599239/1013528064023601303/1335499686861078550

## Have you read the [Contributing Guidelines]?

- [X] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
