### PR TITLE
lock working for async recv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # surrealdb-version: ["v2.1.0", "v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour
-        surrealdb-version: ["v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour
+        surrealdb-version: ["v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour and v2.1.0 does not support async batching
     name: Python ${{ matrix.python-version }} - SurrealDB ${{ matrix.surrealdb-version }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        surrealdb-version: ["v2.1.0", "v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour
+        # surrealdb-version: ["v2.1.0", "v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour
+        surrealdb-version: ["v2.1.1", "v2.1.2", "v2.1.3", "v2.1.4"] # v2.0.0 has different UPSERT behaviour
     name: Python ${{ matrix.python-version }} - SurrealDB ${{ matrix.surrealdb-version }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,17 +42,18 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run unit tests (HTTP)
+      - name: Run unit tests
         run: python -m unittest discover -s tests
         env:
           PYTHONPATH: ./src
           SURREALDB_URL: http://localhost:8000
+          SURREALDB_VERSION: ${{ matrix.surrealdb-version }}
 
-      - name: Run unit tests (WebSocket)
-        run: python -m unittest discover -s tests
-        env:
-          PYTHONPATH: ./src
-          SURREALDB_URL: ws://localhost:8000
+#      - name: Run unit tests (WebSocket)
+#        run: python -m unittest discover -s tests
+#        env:
+#          PYTHONPATH: ./src
+#          SURREALDB_URL: ws://localhost:8000
 
 
 

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -188,9 +188,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
             if ":" in thing:
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
-        message = RequestMessage(
-            RequestMethod.CREATE, collection=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.CREATE, collection=thing, data=data)
         self.id = message.id
         response = await self._send(message, "create")
         self.check_response_for_result(response, "create")
@@ -208,9 +206,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def insert(
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.INSERT, collection=table, params=data
-        )
+        message = RequestMessage(RequestMethod.INSERT, collection=table, params=data)
         self.id = message.id
         response = await self._send(message, "insert")
         self.check_response_for_result(response, "insert")
@@ -236,9 +232,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def merge(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.MERGE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.MERGE, record_id=thing, data=data)
         self.id = message.id
         response = await self._send(message, "merge")
         self.check_response_for_result(response, "merge")
@@ -247,9 +241,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def patch(
         self, thing: Union[str, RecordID, Table], data: Optional[List[dict]] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.PATCH, collection=thing, params=data
-        )
+        message = RequestMessage(RequestMethod.PATCH, collection=thing, params=data)
         self.id = message.id
         response = await self._send(message, "patch")
         self.check_response_for_result(response, "patch")
@@ -265,9 +257,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def update(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPDATE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPDATE, record_id=thing, data=data)
         self.id = message.id
         response = await self._send(message, "update")
         self.check_response_for_result(response, "update")
@@ -283,9 +273,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def upsert(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPSERT, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPSERT, record_id=thing, data=data)
         self.id = message.id
         response = await self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -98,16 +98,19 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.token = token
 
     async def authenticate(self) -> None:
-        message = RequestMessage(self.id, RequestMethod.AUTHENTICATE, token=self.token)
+        message = RequestMessage(RequestMethod.AUTHENTICATE, token=self.token)
+        self.id = message.id
         return await self._send(message, "authenticating")
 
     async def invalidate(self) -> None:
-        message = RequestMessage(self.id, RequestMethod.INVALIDATE)
+        message = RequestMessage(RequestMethod.INVALIDATE)
+        self.id = message.id
         await self._send(message, "invalidating")
         self.token = None
 
     async def signup(self, vars: Dict) -> str:
-        message = RequestMessage(self.id, RequestMethod.SIGN_UP, data=vars)
+        message = RequestMessage(RequestMethod.SIGN_UP, data=vars)
+        self.id = message.id
         response = await self._send(message, "signup")
         self.check_response_for_result(response, "signup")
         self.token = response["result"]
@@ -115,7 +118,6 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
 
     async def signin(self, vars: dict) -> dict:
         message = RequestMessage(
-            self.id,
             RequestMethod.SIGN_IN,
             username=vars.get("username"),
             password=vars.get("password"),
@@ -124,24 +126,26 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
             namespace=vars.get("namespace"),
             variables=vars.get("variables"),
         )
+        self.id = message.id
         response = await self._send(message, "signing in")
         self.check_response_for_result(response, "signing in")
         self.token = response["result"]
         return response["result"]
 
     async def info(self) -> dict:
-        message = RequestMessage(self.id, RequestMethod.INFO)
+        message = RequestMessage(RequestMethod.INFO)
+        self.id = message.id
         response = await self._send(message, "getting database information")
         self.check_response_for_result(response, "getting database information")
         return response["result"]
 
     async def use(self, namespace: str, database: str) -> None:
         message = RequestMessage(
-            self.token,
             RequestMethod.USE,
             namespace=namespace,
             database=database,
         )
+        self.id = message.id
         _ = await self._send(message, "use")
         self.namespace = namespace
         self.database = database
@@ -152,11 +156,11 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         for key, value in self.vars.items():
             params[key] = value
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = await self._send(message, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
@@ -167,11 +171,11 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         for key, value in self.vars.items():
             params[key] = value
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = await self._send(message, "query", bypass=True)
         return response
 
@@ -185,8 +189,9 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
         message = RequestMessage(
-            self.id, RequestMethod.CREATE, collection=thing, data=data
+            RequestMethod.CREATE, collection=thing, data=data
         )
+        self.id = message.id
         response = await self._send(message, "create")
         self.check_response_for_result(response, "create")
         return response["result"]
@@ -194,7 +199,8 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def delete(
         self, thing: Union[str, RecordID, Table]
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.DELETE, record_id=thing)
+        message = RequestMessage(RequestMethod.DELETE, record_id=thing)
+        self.id = message.id
         response = await self._send(message, "delete")
         self.check_response_for_result(response, "delete")
         return response["result"]
@@ -203,8 +209,9 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT, collection=table, params=data
+            RequestMethod.INSERT, collection=table, params=data
         )
+        self.id = message.id
         response = await self._send(message, "insert")
         self.check_response_for_result(response, "insert")
         return response["result"]
@@ -213,8 +220,9 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT_RELATION, table=table, params=data
+            RequestMethod.INSERT_RELATION, table=table, params=data
         )
+        self.id = message.id
         response = await self._send(message, "insert_relation")
         self.check_response_for_result(response, "insert_relation")
         return response["result"]
@@ -229,8 +237,9 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.MERGE, record_id=thing, data=data
+            RequestMethod.MERGE, record_id=thing, data=data
         )
+        self.id = message.id
         response = await self._send(message, "merge")
         self.check_response_for_result(response, "merge")
         return response["result"]
@@ -239,14 +248,16 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[List[dict]] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.PATCH, collection=thing, params=data
+            RequestMethod.PATCH, collection=thing, params=data
         )
+        self.id = message.id
         response = await self._send(message, "patch")
         self.check_response_for_result(response, "patch")
         return response["result"]
 
     async def select(self, thing: str) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.SELECT, params=[thing])
+        message = RequestMessage(RequestMethod.SELECT, params=[thing])
+        self.id = message.id
         response = await self._send(message, "select")
         self.check_response_for_result(response, "select")
         return response["result"]
@@ -255,14 +266,16 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPDATE, record_id=thing, data=data
+            RequestMethod.UPDATE, record_id=thing, data=data
         )
+        self.id = message.id
         response = await self._send(message, "update")
         self.check_response_for_result(response, "update")
         return response["result"]
 
     async def version(self) -> str:
-        message = RequestMessage(self.id, RequestMethod.VERSION)
+        message = RequestMessage(RequestMethod.VERSION)
+        self.id = message.id
         response = await self._send(message, "getting database version")
         self.check_response_for_result(response, "getting database version")
         return response["result"]
@@ -271,8 +284,9 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPSERT, record_id=thing, data=data
+            RequestMethod.UPSERT, record_id=thing, data=data
         )
+        self.id = message.id
         response = await self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")
         return response["result"]

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -364,9 +364,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"insert_relation not implemented for: {self}")
 
-    async def live(
-        self, table: Union[str, Table], diff: bool = False
-    ) -> UUID:
+    async def live(self, table: Union[str, Table], diff: bool = False) -> UUID:
         """Initiates a live query for a specified table name.
 
         Args:
@@ -383,9 +381,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"live not implemented for: {self}")
 
-    async def subscribe_live(
-        self, query_uuid: Union[str, UUID]
-    ) -> Queue:
+    async def subscribe_live(self, query_uuid: Union[str, UUID]) -> Queue:
         """Returns a queue that receives notification messages from a running live query.
 
         Args:

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -7,7 +7,7 @@ from surrealdb.data.types.table import Table
 
 class AsyncTemplate:
 
-    async def connect(self, url: str) -> Coroutine[Any, Any, None]:
+    async def connect(self, url: str) -> None:
         """Connects to a local or remote database endpoint.
 
         Args:
@@ -18,17 +18,17 @@ class AsyncTemplate:
             # Connect to a remote endpoint
             await db.connect('https://cloud.surrealdb.com/rpc');
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"connect not implemented for: {self}")
 
-    async def close(self) -> Coroutine[Any, Any, None]:
+    async def close(self) -> None:
         """Closes the persistent connection to the database.
 
         Example:
             await db.close()
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"close not implemented for: {self}")
 
-    async def use(self, namespace: str, database: str) -> Coroutine[Any, Any, None]:
+    async def use(self, namespace: str, database: str) -> None:
         """Switch to a specific namespace and database.
 
         Args:
@@ -38,9 +38,9 @@ class AsyncTemplate:
         Example:
             await db.use('test', 'test')
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"use not implemented for: {self}")
 
-    async def authenticate(self, token: str) -> Coroutine[Any, Any, None]:
+    async def authenticate(self, token: str) -> None:
         """Authenticate the current connection with a JWT token.
 
         Args:
@@ -51,7 +51,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"authenticate not implemented for: {self}")
 
-    async def invalidate(self) -> Coroutine[Any, Any, None]:
+    async def invalidate(self) -> None:
         """Invalidate the authentication for the current connection.
 
         Example:
@@ -59,7 +59,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"invalidate not implemented for: {self}")
 
-    async def signup(self, vars: Dict) -> Coroutine[Any, Any, str]:
+    async def signup(self, vars: Dict) -> str:
         """Sign this connection up to a specific authentication scope.
         [See the docs](https://surrealdb.com/docs/sdk/python/methods/signup)
 
@@ -81,7 +81,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"signup not implemented for: {self}")
 
-    async def signin(self, vars: Dict) -> Coroutine[Any, Any, str]:
+    async def signin(self, vars: Dict) -> str:
         """Sign this connection in to a specific authentication scope.
         [See the docs](https://surrealdb.com/docs/sdk/python/methods/signin)
 
@@ -94,9 +94,9 @@ class AsyncTemplate:
                 password: 'surrealdb',
             })
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"signin not implemented for: {self}")
 
-    async def let(self, key: str, value: Any) -> Coroutine[Any, Any, None]:
+    async def let(self, key: str, value: Any) -> None:
         """Assign a value as a variable for this connection.
 
         Args:
@@ -115,7 +115,7 @@ class AsyncTemplate:
         """
         raise NotImplementedError(f"let not implemented for: {self}")
 
-    async def unset(self, key: str) -> Coroutine[Any, Any, None]:
+    async def unset(self, key: str) -> None:
         """Removes a variable for this connection.
 
         Args:
@@ -124,11 +124,11 @@ class AsyncTemplate:
         Example:
             await db.unset('name')
         """
-        raise NotImplementedError(f"let not implemented for: {self}")
+        raise NotImplementedError(f"unset not implemented for: {self}")
 
     async def query(
         self, query: str, vars: Optional[Dict] = None
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Run a unset of SurrealQL statements against the database.
 
         Args:
@@ -145,7 +145,7 @@ class AsyncTemplate:
 
     async def select(
         self, thing: Union[str, RecordID, Table]
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Select all records in a table (or other entity),
         or a specific record, in the database.
 
@@ -158,13 +158,13 @@ class AsyncTemplate:
         Example:
             db.select('person')
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"select not implemented for: {self}")
 
     async def create(
         self,
         thing: Union[str, RecordID, Table],
         data: Optional[Union[List[dict], dict]] = None,
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Create a record in the database.
 
         This function will run the following query in the database:
@@ -181,7 +181,7 @@ class AsyncTemplate:
 
     async def update(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Update all records in a table, or a specific record, in the database.
 
         This function replaces the current document / record data with the
@@ -207,11 +207,11 @@ class AsyncTemplate:
                         },
                 })
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"update not implemented for: {self}")
 
     async def upsert(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Insert records into the database, or to update them if they exist.
 
 
@@ -239,7 +239,7 @@ class AsyncTemplate:
 
     async def merge(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Modify by deep merging all records in a table, or a specific record, in the database.
 
         This function merges the current document / record data with the
@@ -267,11 +267,11 @@ class AsyncTemplate:
                     })
 
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"merge not implemented for: {self}")
 
     async def patch(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Apply JSON Patch changes to all records, or a specific record, in the database.
 
         This function patches the current document / record data with
@@ -296,11 +296,11 @@ class AsyncTemplate:
                 { 'op': "remove", "path": "/temp" },
             ])
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"patch not implemented for: {self}")
 
     async def delete(
         self, thing: Union[str, RecordID, Table]
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """Delete all records in a table, or a specific record, from the database.
 
         This function will run the following query in the database:
@@ -324,11 +324,11 @@ class AsyncTemplate:
         Example:
             await db.info()
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"info not implemented for: {self}")
 
     async def insert(
         self, table: Union[str, Table], data: Union[List[dict], dict]
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """
         Inserts one or multiple records in the database.
 
@@ -343,11 +343,11 @@ class AsyncTemplate:
             await db.insert('person', [{ name: 'Tobie'}, { name: 'Jaime'}])
 
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"insert not implemented for: {self}")
 
     async def insert_relation(
         self, table: Union[str, Table], data: Union[List[dict], dict]
-    ) -> Coroutine[Any, Any, Union[List[dict], dict]]:
+    ) -> Union[List[dict], dict]:
         """
         Inserts one or multiple relations in the database.
 
@@ -362,11 +362,11 @@ class AsyncTemplate:
             await db.insert_relation('likes', { in: person:1, id: 'object', out: person:2})
 
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"insert_relation not implemented for: {self}")
 
     async def live(
         self, table: Union[str, Table], diff: bool = False
-    ) -> Coroutine[Any, Any, UUID]:
+    ) -> UUID:
         """Initiates a live query for a specified table name.
 
         Args:
@@ -381,11 +381,11 @@ class AsyncTemplate:
         Example:
             await db.live('person')
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"live not implemented for: {self}")
 
     async def subscribe_live(
         self, query_uuid: Union[str, UUID]
-    ) -> Coroutine[Any, Any, Queue]:
+    ) -> Queue:
         """Returns a queue that receives notification messages from a running live query.
 
         Args:
@@ -397,9 +397,9 @@ class AsyncTemplate:
         Example:
             await db.subscribe_live(UUID)
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"subscribe_live not implemented for: {self}")
 
-    async def kill(self, query_uuid: Union[str, UUID]) -> Coroutine[Any, Any, None]:
+    async def kill(self, query_uuid: Union[str, UUID]) -> None:
         """Kills a running live query by it's UUID.
 
         Args:
@@ -409,4 +409,4 @@ class AsyncTemplate:
             await db.kill(UUID)
 
         """
-        raise NotImplementedError(f"query not implemented for: {self}")
+        raise NotImplementedError(f"kill not implemented for: {self}")

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -1,9 +1,10 @@
 """
 A basic async connection to a SurrealDB instance.
 """
+
 import asyncio
 import uuid
-from asyncio import Queue
+from asyncio import Queue, Task, Future, AbstractEventLoop
 from typing import Optional, Any, Dict, Union, List, AsyncGenerator
 from uuid import UUID
 
@@ -45,67 +46,81 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self.raw_url: str = f"{self.url.raw_url}/rpc"
         self.host: Optional[str] = self.url.hostname
         self.port: Optional[int] = self.url.port
-        self.id: str = str(uuid.uuid4())
         self.token: Optional[str] = None
         self.socket = None
-        self.lock = asyncio.Lock()
-        self.ref = dict()
+        self.loop: AbstractEventLoop|None = None
+        self.qry:dict[str, Future] = {}
+        self.recv_task:Task[None]|None = None
+        self.live_queues:dict[str, list] = {}
+
+    async def _recv_task(self):
+        assert self.socket
+        async for data in self.socket:
+            response = decode(data)
+            if (response_id := response.get("id")):
+                if fut := self.qry.get(response_id):
+                    fut.set_result(response)
+            else:
+                live_id = str(response['result']['id'])
+                for queue in self.live_queues.get(live_id, []):
+                    queue.put_nowait(response['result'])
 
     async def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
     ) -> dict:
         await self.connect()
         assert (
-            self.socket is not None
+            self.socket is not None and self.loop is not None
         )  # will always not be None as the self.connect ensures there's a connection
 
+        # setup future to wait for response
+        fut = self.loop.create_future()
         query_id = message.id
-        await self.socket.send(message.WS_CBOR_DESCRIPTOR)
+        self.qry[query_id] = fut
+        try:
+            # correlate mesage to query, send and forget it
+            await self.socket.send(message.WS_CBOR_DESCRIPTOR)
+            del message
 
-        async with self.lock:
-            response = decode(await self.socket.recv())
-        self.ref[response["id"]] = response
-
-        # wait for ID to be returned
-        while self.ref.get(query_id) is None:
-            await asyncio.sleep(0)  # The await simply yields to the executor to avoid deadlocks
-
-        # set the response and clean up
-        response = self.ref[query_id]
-        del self.ref[query_id]
+            # wait for response
+            response = await fut
+        finally:
+            del self.qry[query_id]
 
         if bypass is False:
             self.check_response_for_error(response, process)
         return response
 
     async def connect(self, url: Optional[str] = None) -> None:
+        if self.socket:
+            return
+
         # overwrite params if passed in
         if url is not None:
             self.url = Url(url)
             self.raw_url = f"{self.url.raw_url}/rpc"
             self.host = self.url.hostname
             self.port = self.url.port
-        if self.socket is None:
-            self.socket = await websockets.connect(
-                self.raw_url,
-                max_size=None,
-                subprotocols=[websockets.Subprotocol("cbor")],
-            )
+
+        self.socket = await websockets.connect(
+            self.raw_url,
+            max_size=None,
+            subprotocols=[websockets.Subprotocol("cbor")],
+        )
+        self.loop = asyncio.get_running_loop()
+        self.recv_task = asyncio.create_task(self._recv_task())
 
     async def authenticate(self, token: str) -> dict:
         message = RequestMessage(RequestMethod.AUTHENTICATE, token=token)
-        self.id = message.id
         return await self._send(message, "authenticating")
 
     async def invalidate(self) -> None:
         message = RequestMessage(RequestMethod.INVALIDATE)
-        self.id = message.id
         await self._send(message, "invalidating")
         self.token = None
 
     async def signup(self, vars: Dict) -> str:
         message = RequestMessage(RequestMethod.SIGN_UP, data=vars)
-        self.id = message.id
         response = await self._send(message, "signup")
         self.check_response_for_result(response, "signup")
         return response["result"]
@@ -120,7 +135,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             namespace=vars.get("namespace"),
             variables=vars.get("variables"),
         )
-        self.id = message.id
         response = await self._send(message, "signing in")
         self.check_response_for_result(response, "signing in")
         self.token = response["result"]
@@ -128,7 +142,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
 
     async def info(self) -> Optional[dict]:
         message = RequestMessage(RequestMethod.INFO)
-        self.id = message.id
         outcome = await self._send(message, "getting database information")
         self.check_response_for_result(outcome, "getting database information")
         return outcome["result"]
@@ -139,7 +152,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             namespace=namespace,
             database=database,
         )
-        self.id = message.id
         await self._send(message, "use")
 
     async def query(self, query: str, params: Optional[dict] = None) -> dict:
@@ -150,7 +162,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             query=query,
             params=params,
         )
-        self.id = message.id
         response = await self._send(message, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
@@ -163,32 +174,27 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             query=query,
             params=params,
         )
-        self.id = message.id
         response = await self._send(message, "query", bypass=True)
         return response
 
     async def version(self) -> str:
         message = RequestMessage(RequestMethod.VERSION)
-        self.id = message.id
         response = await self._send(message, "getting database version")
         self.check_response_for_result(response, "getting database version")
         return response["result"]
 
     async def let(self, key: str, value: Any) -> None:
         message = RequestMessage(RequestMethod.LET, key=key, value=value)
-        self.id = message.id
         await self._send(message, "letting")
 
     async def unset(self, key: str) -> None:
         message = RequestMessage(RequestMethod.UNSET, params=[key])
-        self.id = message.id
         await self._send(message, "unsetting")
 
     async def select(
         self, thing: Union[str, RecordID, Table]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(RequestMethod.SELECT, params=[thing])
-        self.id = message.id
         response = await self._send(message, "select")
         self.check_response_for_result(response, "select")
         return response["result"]
@@ -205,7 +211,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.CREATE, collection=thing, data=data
         )
-        self.id = message.id
         response = await self._send(message, "create")
         self.check_response_for_result(response, "create")
         return response["result"]
@@ -216,7 +221,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.UPDATE, record_id=thing, data=data
         )
-        self.id = message.id
         response = await self._send(message, "update")
         self.check_response_for_result(response, "update")
         return response["result"]
@@ -227,7 +231,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.MERGE, record_id=thing, data=data
         )
-        self.id = message.id
         response = await self._send(message, "merge")
         self.check_response_for_result(response, "merge")
         return response["result"]
@@ -238,7 +241,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.PATCH, collection=thing, params=data
         )
-        self.id = message.id
         response = await self._send(message, "patch")
         self.check_response_for_result(response, "patch")
         return response["result"]
@@ -247,7 +249,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(RequestMethod.DELETE, record_id=thing)
-        self.id = message.id
         response = await self._send(message, "delete")
         self.check_response_for_result(response, "delete")
         return response["result"]
@@ -258,7 +259,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.INSERT, collection=table, params=data
         )
-        self.id = message.id
         response = await self._send(message, "insert")
         self.check_response_for_result(response, "insert")
         return response["result"]
@@ -269,7 +269,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.INSERT_RELATION, table=table, params=data
         )
-        self.id = message.id
         response = await self._send(message, "insert_relation")
         self.check_response_for_result(response, "insert_relation")
         return response["result"]
@@ -279,41 +278,29 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             RequestMethod.LIVE,
             table=table,
         )
-        self.id = message.id
         response = await self._send(message, "live")
         self.check_response_for_result(response, "live")
-        return response["result"]
+        uuid = response["result"]
+        assert uuid not in self.live_queues
+        self.live_queues[str(uuid)] = []
+        return uuid
 
-    async def subscribe_live(
+    def subscribe_live(
         self, query_uuid: Union[str, UUID]
-    ) -> AsyncGenerator[dict, None]:
+    ) -> Queue:
         result_queue = Queue()
-
-        async def listen_live():
-            """
-            Listen for live updates from the WebSocket and put them into the queue.
-            """
-            try:
-                while True:
-                    response = decode(await self.socket.recv())
-                    if response.get("result", {}).get("id") == query_uuid:
-                        await result_queue.put(response["result"]["result"])
-            except Exception as e:
-                print("Error in live subscription:", e)
-                await result_queue.put({"error": str(e)})
-
-        asyncio.create_task(listen_live())
-
-        while True:
-            result = await result_queue.get()
-            if "error" in result:
-                raise Exception(f"Error in live subscription: {result['error']}")
-            yield result
+        suid = str(query_uuid)
+        self.live_queues[suid].append(result_queue)
+        async def _iter():
+            while True:
+                ret = await result_queue.get()
+                yield ret['result']
+        return _iter()
 
     async def kill(self, query_uuid: Union[str, UUID]) -> None:
         message = RequestMessage(RequestMethod.KILL, uuid=query_uuid)
-        self.id = message.id
         await self._send(message, "kill")
+        self.live_queues.pop(str(query_uuid), None)
 
     async def upsert(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
@@ -321,22 +308,28 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(
             RequestMethod.UPSERT, record_id=thing, data=data
         )
-        self.id = message.id
         response = await self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")
         return response["result"]
 
     async def close(self):
-        await self.socket.close()
+        if self.recv_task:
+            self.recv_task.cancel()
+            try:
+                await self.recv_task
+            except asyncio.CancelledError:
+                pass
+
+        if self.socket is not None:
+            await self.socket.close()
+
 
     async def __aenter__(self) -> "AsyncWsSurrealConnection":
         """
         Asynchronous context manager entry.
         Initializes a websocket connection and returns the connection instance.
         """
-        self.socket = await websockets.connect(
-            self.raw_url, max_size=None, subprotocols=[websockets.Subprotocol("cbor")]
-        )
+        await self.connect()
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
@@ -344,5 +337,4 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         Asynchronous context manager exit.
         Closes the websocket connection upon exiting the context.
         """
-        if self.socket is not None:
-            await self.socket.close()
+        await self.close()

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -1,11 +1,9 @@
 """
 A basic async connection to a SurrealDB instance.
 """
-
 import asyncio
-import uuid
 from asyncio import Queue, Task, Future, AbstractEventLoop
-from typing import Optional, Any, Dict, Union, List, AsyncGenerator
+from typing import Optional, Any, Dict, Union, List
 from uuid import UUID
 
 import websockets

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -147,9 +147,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
             if ":" in thing:
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
-        message = RequestMessage(
-            RequestMethod.CREATE, collection=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.CREATE, collection=thing, data=data)
         self.id = message.id
         response = self._send(message, "create")
         self.check_response_for_result(response, "create")
@@ -165,9 +163,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def insert(
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.INSERT, collection=table, params=data
-        )
+        message = RequestMessage(RequestMethod.INSERT, collection=table, params=data)
         self.id = message.id
         response = self._send(message, "insert")
         self.check_response_for_result(response, "insert")
@@ -193,9 +189,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def merge(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.MERGE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.MERGE, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "merge")
         self.check_response_for_result(response, "merge")
@@ -204,9 +198,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def patch(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict[Any, Any]] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.PATCH, collection=thing, params=data
-        )
+        message = RequestMessage(RequestMethod.PATCH, collection=thing, params=data)
         self.id = message.id
         response = self._send(message, "patch")
         self.check_response_for_result(response, "patch")
@@ -222,9 +214,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def update(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPDATE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPDATE, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "update")
         self.check_response_for_result(response, "update")
@@ -240,9 +230,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def upsert(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPSERT, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPSERT, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -57,16 +57,19 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.token = token
 
     def authenticate(self, token: str) -> dict:
-        message = RequestMessage(self.id, RequestMethod.AUTHENTICATE, token=token)
+        message = RequestMessage(RequestMethod.AUTHENTICATE, token=token)
+        self.id = message.id
         return self._send(message, "authenticating")
 
     def invalidate(self) -> None:
-        message = RequestMessage(self.id, RequestMethod.INVALIDATE)
+        message = RequestMessage(RequestMethod.INVALIDATE)
+        self.id = message.id
         self._send(message, "invalidating")
         self.token = None
 
     def signup(self, vars: Dict) -> str:
-        message = RequestMessage(self.id, RequestMethod.SIGN_UP, data=vars)
+        message = RequestMessage(RequestMethod.SIGN_UP, data=vars)
+        self.id = message.id
         response = self._send(message, "signup")
         self.check_response_for_result(response, "signup")
         self.token = response["result"]
@@ -74,7 +77,6 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
 
     def signin(self, vars: dict) -> str:
         message = RequestMessage(
-            self.id,
             RequestMethod.SIGN_IN,
             username=vars.get("username"),
             password=vars.get("password"),
@@ -83,24 +85,26 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
             namespace=vars.get("namespace"),
             variables=vars.get("variables"),
         )
+        self.id = message.id
         response = self._send(message, "signing in")
         self.check_response_for_result(response, "signing in")
         self.token = response["result"]
         return str(response["result"])
 
     def info(self):
-        message = RequestMessage(self.id, RequestMethod.INFO)
+        message = RequestMessage(RequestMethod.INFO)
+        self.id = message.id
         response = self._send(message, "getting database information")
         self.check_response_for_result(response, "getting database information")
         return response["result"]
 
     def use(self, namespace: str, database: str) -> None:
         message = RequestMessage(
-            self.token,
             RequestMethod.USE,
             namespace=namespace,
             database=database,
         )
+        self.id = message.id
         _ = self._send(message, "use")
         self.namespace = namespace
         self.database = database
@@ -111,11 +115,11 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         for key, value in self.vars.items():
             params[key] = value
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = self._send(message, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
@@ -126,11 +130,11 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         for key, value in self.vars.items():
             params[key] = value
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = self._send(message, "query", bypass=True)
         return response
 
@@ -144,14 +148,16 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
         message = RequestMessage(
-            self.id, RequestMethod.CREATE, collection=thing, data=data
+            RequestMethod.CREATE, collection=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "create")
         self.check_response_for_result(response, "create")
         return response["result"]
 
     def delete(self, thing: Union[str, RecordID, Table]) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.DELETE, record_id=thing)
+        message = RequestMessage(RequestMethod.DELETE, record_id=thing)
+        self.id = message.id
         response = self._send(message, "delete")
         self.check_response_for_result(response, "delete")
         return response["result"]
@@ -160,8 +166,9 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT, collection=table, params=data
+            RequestMethod.INSERT, collection=table, params=data
         )
+        self.id = message.id
         response = self._send(message, "insert")
         self.check_response_for_result(response, "insert")
         return response["result"]
@@ -170,8 +177,9 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT_RELATION, table=table, params=data
+            RequestMethod.INSERT_RELATION, table=table, params=data
         )
+        self.id = message.id
         response = self._send(message, "insert_relation")
         self.check_response_for_result(response, "insert_relation")
         return response["result"]
@@ -186,8 +194,9 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.MERGE, record_id=thing, data=data
+            RequestMethod.MERGE, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "merge")
         self.check_response_for_result(response, "merge")
         return response["result"]
@@ -196,14 +205,16 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict[Any, Any]] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.PATCH, collection=thing, params=data
+            RequestMethod.PATCH, collection=thing, params=data
         )
+        self.id = message.id
         response = self._send(message, "patch")
         self.check_response_for_result(response, "patch")
         return response["result"]
 
     def select(self, thing: Union[str, RecordID, Table]) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.SELECT, params=[thing])
+        message = RequestMessage(RequestMethod.SELECT, params=[thing])
+        self.id = message.id
         response = self._send(message, "select")
         self.check_response_for_result(response, "select")
         return response["result"]
@@ -212,14 +223,16 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPDATE, record_id=thing, data=data
+            RequestMethod.UPDATE, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "update")
         self.check_response_for_result(response, "update")
         return response["result"]
 
     def version(self) -> str:
-        message = RequestMessage(self.id, RequestMethod.VERSION)
+        message = RequestMessage(RequestMethod.VERSION)
+        self.id = message.id
         response = self._send(message, "getting database version")
         self.check_response_for_result(response, "getting database version")
         return response["result"]
@@ -228,8 +241,9 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPSERT, record_id=thing, data=data
+            RequestMethod.UPSERT, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")
         return response["result"]

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -62,23 +62,25 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         return response
 
     def authenticate(self, token: str) -> dict:
-        message = RequestMessage(self.id, RequestMethod.AUTHENTICATE, token=token)
+        message = RequestMessage(RequestMethod.AUTHENTICATE, token=token)
+        self.id = message.id
         return self._send(message, "authenticating")
 
     def invalidate(self) -> None:
-        message = RequestMessage(self.id, RequestMethod.INVALIDATE)
+        message = RequestMessage(RequestMethod.INVALIDATE)
+        self.id = message.id
         self._send(message, "invalidating")
         self.token = None
 
     def signup(self, vars: Dict) -> str:
-        message = RequestMessage(self.id, RequestMethod.SIGN_UP, data=vars)
+        message = RequestMessage(RequestMethod.SIGN_UP, data=vars)
+        self.id = message.id
         response = self._send(message, "signup")
         self.check_response_for_result(response, "signup")
         return response["result"]
 
     def signin(self, vars: Dict[str, Any]) -> str:
         message = RequestMessage(
-            self.id,
             RequestMethod.SIGN_IN,
             username=vars.get("username"),
             password=vars.get("password"),
@@ -87,35 +89,37 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             namespace=vars.get("namespace"),
             variables=vars.get("variables"),
         )
+        self.id = message.id
         response = self._send(message, "signing in")
         self.check_response_for_result(response, "signing in")
         self.token = response["result"]
         return response["result"]
 
     def info(self) -> dict:
-        message = RequestMessage(self.id, RequestMethod.INFO)
+        message = RequestMessage(RequestMethod.INFO)
+        self.id = message.id
         response = self._send(message, "getting database information")
         self.check_response_for_result(response, "getting database information")
         return response["result"]
 
     def use(self, namespace: str, database: str) -> None:
         message = RequestMessage(
-            self.id,
             RequestMethod.USE,
             namespace=namespace,
             database=database,
         )
+        self.id = message.id
         self._send(message, "use")
 
     def query(self, query: str, params: Optional[dict] = None) -> dict:
         if params is None:
             params = {}
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = self._send(message, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
@@ -124,30 +128,34 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         if params is None:
             params = {}
         message = RequestMessage(
-            self.id,
             RequestMethod.QUERY,
             query=query,
             params=params,
         )
+        self.id = message.id
         response = self._send(message, "query", bypass=True)
         return response
 
     def version(self) -> str:
-        message = RequestMessage(self.id, RequestMethod.VERSION)
+        message = RequestMessage(RequestMethod.VERSION)
+        self.id = message.id
         response = self._send(message, "getting database version")
         self.check_response_for_result(response, "getting database version")
         return response["result"]
 
     def let(self, key: str, value: Any) -> None:
-        message = RequestMessage(self.id, RequestMethod.LET, key=key, value=value)
+        message = RequestMessage(RequestMethod.LET, key=key, value=value)
+        self.id = message.id
         self._send(message, "letting")
 
     def unset(self, key: str) -> None:
-        message = RequestMessage(self.id, RequestMethod.UNSET, params=[key])
+        message = RequestMessage(RequestMethod.UNSET, params=[key])
+        self.id = message.id
         self._send(message, "unsetting")
 
     def select(self, thing: Union[str, RecordID, Table]) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.SELECT, params=[thing])
+        message = RequestMessage(RequestMethod.SELECT, params=[thing])
+        self.id = message.id
         response = self._send(message, "select")
         self.check_response_for_result(response, "select")
         return response["result"]
@@ -162,28 +170,31 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
         message = RequestMessage(
-            self.id, RequestMethod.CREATE, collection=thing, data=data
+            RequestMethod.CREATE, collection=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "create")
         self.check_response_for_result(response, "create")
         return response["result"]
 
     def live(self, table: Union[str, Table], diff: bool = False) -> UUID:
         message = RequestMessage(
-            self.id,
             RequestMethod.LIVE,
             table=table,
         )
+        self.id = message.id
         response = self._send(message, "live")
         self.check_response_for_result(response, "live")
         return response["result"]
 
     def kill(self, query_uuid: Union[str, UUID]) -> None:
-        message = RequestMessage(self.id, RequestMethod.KILL, uuid=query_uuid)
+        message = RequestMessage(RequestMethod.KILL, uuid=query_uuid)
+        self.id = message.id
         self._send(message, "kill")
 
     def delete(self, thing: Union[str, RecordID, Table]) -> Union[List[dict], dict]:
-        message = RequestMessage(self.id, RequestMethod.DELETE, record_id=thing)
+        message = RequestMessage(RequestMethod.DELETE, record_id=thing)
+        self.id = message.id
         response = self._send(message, "delete")
         self.check_response_for_result(response, "delete")
         return response["result"]
@@ -192,8 +203,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT, collection=table, params=data
+            RequestMethod.INSERT, collection=table, params=data
         )
+        self.id = message.id
         response = self._send(message, "insert")
         self.check_response_for_result(response, "insert")
         return response["result"]
@@ -202,8 +214,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.INSERT_RELATION, table=table, params=data
+            RequestMethod.INSERT_RELATION, table=table, params=data
         )
+        self.id = message.id
         response = self._send(message, "insert_relation")
         self.check_response_for_result(response, "insert_relation")
         return response["result"]
@@ -212,8 +225,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.MERGE, record_id=thing, data=data
+            RequestMethod.MERGE, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "merge")
         self.check_response_for_result(response, "merge")
         return response["result"]
@@ -222,8 +236,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[List[dict]] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.PATCH, collection=thing, params=data
+            RequestMethod.PATCH, collection=thing, params=data
         )
+        self.id = message.id
         response = self._send(message, "patch")
         self.check_response_for_result(response, "patch")
         return response["result"]
@@ -261,8 +276,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPDATE, record_id=thing, data=data
+            RequestMethod.UPDATE, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "update")
         self.check_response_for_result(response, "update")
         return response["result"]
@@ -271,8 +287,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
         message = RequestMessage(
-            self.id, RequestMethod.UPSERT, record_id=thing, data=data
+            RequestMethod.UPSERT, record_id=thing, data=data
         )
+        self.id = message.id
         response = self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")
         return response["result"]

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -169,9 +169,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             if ":" in thing:
                 buffer = thing.split(":")
                 thing = RecordID(table_name=buffer[0], identifier=buffer[1])
-        message = RequestMessage(
-            RequestMethod.CREATE, collection=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.CREATE, collection=thing, data=data)
         self.id = message.id
         response = self._send(message, "create")
         self.check_response_for_result(response, "create")
@@ -202,9 +200,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def insert(
         self, table: Union[str, Table], data: Union[List[dict], dict]
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.INSERT, collection=table, params=data
-        )
+        message = RequestMessage(RequestMethod.INSERT, collection=table, params=data)
         self.id = message.id
         response = self._send(message, "insert")
         self.check_response_for_result(response, "insert")
@@ -224,9 +220,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def merge(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.MERGE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.MERGE, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "merge")
         self.check_response_for_result(response, "merge")
@@ -235,9 +229,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def patch(
         self, thing: Union[str, RecordID, Table], data: Optional[List[dict]] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.PATCH, collection=thing, params=data
-        )
+        message = RequestMessage(RequestMethod.PATCH, collection=thing, params=data)
         self.id = message.id
         response = self._send(message, "patch")
         self.check_response_for_result(response, "patch")
@@ -275,9 +267,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def update(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPDATE, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPDATE, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "update")
         self.check_response_for_result(response, "update")
@@ -286,9 +276,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def upsert(
         self, thing: Union[str, RecordID, Table], data: Optional[Dict] = None
     ) -> Union[List[dict], dict]:
-        message = RequestMessage(
-            RequestMethod.UPSERT, record_id=thing, data=data
-        )
+        message = RequestMessage(RequestMethod.UPSERT, record_id=thing, data=data)
         self.id = message.id
         response = self._send(message, "upsert")
         self.check_response_for_result(response, "upsert")

--- a/src/surrealdb/connections/socket_state.py
+++ b/src/surrealdb/connections/socket_state.py
@@ -1,0 +1,9 @@
+
+
+# singleton
+
+# dict for sockets
+
+# socket with smart reference counter
+
+#

--- a/src/surrealdb/connections/socket_state.py
+++ b/src/surrealdb/connections/socket_state.py
@@ -1,9 +1,0 @@
-
-
-# singleton
-
-# dict for sockets
-
-# socket with smart reference counter
-
-#

--- a/src/surrealdb/request_message/message.py
+++ b/src/surrealdb/request_message/message.py
@@ -1,3 +1,5 @@
+import uuid
+
 from surrealdb.request_message.descriptors.cbor_ws import WsCborDescriptor
 from surrealdb.request_message.methods import RequestMethod
 
@@ -6,7 +8,7 @@ class RequestMessage:
 
     WS_CBOR_DESCRIPTOR = WsCborDescriptor()
 
-    def __init__(self, id_for_request, method: RequestMethod, **kwargs) -> None:
-        self.id = id_for_request
+    def __init__(self, method: RequestMethod, **kwargs) -> None:
+        self.id = str(uuid.uuid4())
         self.method = method
         self.kwargs = kwargs

--- a/tests/unit_tests/connections/authenticate/test_async_ws.py
+++ b/tests/unit_tests/connections/authenticate/test_async_ws.py
@@ -21,7 +21,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
     async def test_authenticate(self):
         outcome = await self.connection.authenticate(token=self.connection.token)
-        await self.connection.socket.close()
 
 
 

--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -1,0 +1,37 @@
+import asyncio
+from unittest import main, IsolatedAsyncioTestCase
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+
+
+class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.url = "ws://localhost:8000"
+        self.password = "root"
+        self.username = "root"
+        self.vars_params = {
+            "username": self.username,
+            "password": self.password,
+        }
+        self.database_name = "test_db"
+        self.namespace = "test_ns"
+        self.data = {
+            "username": self.username,
+            "password": self.password,
+        }
+        self.connection = AsyncWsSurrealConnection(self.url)
+        _ = await self.connection.signin(self.vars_params)
+        _ = await self.connection.use(namespace=self.namespace, database=self.database_name)
+
+    async def test_batch(self):
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(self.connection.query("select $p**2 as ret from {}", dict(p=num))) for num in range(5)]
+
+        outcome = [t.result()[0]["ret"] for t in tasks]
+        self.assertEqual([0, 1, 4, 9, 16], outcome)
+        await self.connection.socket.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -26,9 +26,9 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
     async def test_batch(self):
         async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(self.connection.query("select $p**2 as ret from {}", dict(p=num))) for num in range(5)]
+            tasks = [tg.create_task(self.connection.query("RETURN sleep(duration::from::millis($d)) or $p**2", dict(d=10 if num%2 else 0, p=num))) for num in range(5)]
 
-        outcome = [t.result()[0]["ret"] for t in tasks]
+        outcome = [t.result() for t in tasks]
         self.assertEqual([0, 1, 4, 9, 16], outcome)
         await self.connection.socket.close()
 

--- a/tests/unit_tests/connections/create/test_async_ws.py
+++ b/tests/unit_tests/connections/create/test_async_ws.py
@@ -35,7 +35,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             1
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_string_with_data(self):
         outcome = await self.connection.create("user", self.data)
@@ -53,7 +52,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.username, outcome[0]["username"])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_string_with_data_and_id(self):
         first_outcome = await self.connection.create("user:tobie", self.data)
@@ -73,7 +71,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.username, outcome[0]["username"])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_record_id(self):
         record_id = RecordID("user",1)
@@ -87,7 +84,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         )
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_record_id_with_data(self):
         record_id = RecordID("user", 1)
@@ -107,7 +103,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.username, outcome[0]["username"])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_table(self):
         table = Table("user")
@@ -120,7 +115,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         )
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_create_table_with_data(self):
         table = Table("user")
@@ -139,7 +133,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.username, outcome[0]["username"])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 

--- a/tests/unit_tests/connections/delete/test_async_ws.py
+++ b/tests/unit_tests/connections/delete/test_async_ws.py
@@ -43,14 +43,12 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.check_no_change(outcome)
         outcome = await self.connection.query("SELECT * FROM user;")
         self.assertEqual(outcome, [])
-        await self.connection.socket.close()
 
     async def test_delete_record_id(self):
         first_outcome = await self.connection.delete(self.record_id)
         self.check_no_change(first_outcome)
         outcome = await self.connection.query("SELECT * FROM user;")
         self.assertEqual(outcome, [])
-        await self.connection.socket.close()
 
     async def test_delete_table(self):
         await self.connection.query("CREATE user:jaime SET name = 'Jaime';")
@@ -59,7 +57,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(2, len(first_outcome))
         outcome = await self.connection.query("SELECT * FROM user;")
         self.assertEqual(outcome, [])
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/info/test_async_ws.py
+++ b/tests/unit_tests/connections/info/test_async_ws.py
@@ -21,7 +21,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
     async def test_info(self):
         outcome = await self.connection.info()
-        await self.connection.socket.close()
         #  TODO => confirm that the info is what we expect
 
 

--- a/tests/unit_tests/connections/insert/test_async_ws.py
+++ b/tests/unit_tests/connections/insert/test_async_ws.py
@@ -46,7 +46,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             2
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_insert_record_id_result_error(self):
         record_id = RecordID("user","tobie")
@@ -59,7 +58,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             True
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/insert_relation/test_async_ws.py
+++ b/tests/unit_tests/connections/insert_relation/test_async_ws.py
@@ -76,7 +76,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         )
         await self.connection.query("DELETE user;")
         await self.connection.query("DELETE likes;")
-        await self.connection.socket.close()
 
     async def test_insert_relation_record_id(self):
         data = {
@@ -94,7 +93,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         )
         await self.connection.query("DELETE user;")
         await self.connection.query("DELETE likes;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/let/test_async_ws.py
+++ b/tests/unit_tests/connections/let/test_async_ws.py
@@ -30,7 +30,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query('SELECT * FROM person WHERE name.first = $name.first')
         self.assertEqual({'first': 'Tobie', 'last': 'Morgan Hitchcock'}, outcome[0]["name"])
         await self.connection.query("DELETE person;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/live/test_async_http.py
+++ b/tests/unit_tests/connections/live/test_async_http.py
@@ -26,7 +26,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.live("user")
         self.assertEqual(UUID, type(outcome))
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/live/test_async_ws.py
+++ b/tests/unit_tests/connections/live/test_async_ws.py
@@ -26,7 +26,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.live("user")
         self.assertEqual(UUID, type(outcome))
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/merge/test_async_ws.py
+++ b/tests/unit_tests/connections/merge/test_async_ws.py
@@ -51,7 +51,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_merge_string_with_data(self):
         first_outcome = await self.connection.merge("user:tobie", self.data)
@@ -59,7 +58,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_merge_record_id(self):
         first_outcome = await self.connection.merge(self.record_id)
@@ -67,7 +65,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_merge_record_id_with_data(self):
         outcome = await self.connection.merge(self.record_id, self.data)
@@ -77,7 +74,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             outcome[0]
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_merge_table(self):
         table = Table("user")
@@ -87,7 +83,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.check_no_change(outcome[0])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_merge_table_with_data(self):
         table = Table("user")
@@ -96,7 +91,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/patch/test_async_ws.py
+++ b/tests/unit_tests/connections/patch/test_async_ws.py
@@ -43,7 +43,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_patch_record_id_with_data(self):
         outcome = await self.connection.patch(self.record_id, self.data)
@@ -51,7 +50,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_patch_table_with_data(self):
         table = Table("user")
@@ -60,7 +58,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/query/test_async_http.py
+++ b/tests/unit_tests/connections/query/test_async_http.py
@@ -55,7 +55,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             ]
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/query/test_async_ws.py
+++ b/tests/unit_tests/connections/query/test_async_ws.py
@@ -55,7 +55,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             ]
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/select/test_async_ws.py
+++ b/tests/unit_tests/connections/select/test_async_ws.py
@@ -42,7 +42,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
         await self.connection.query("DELETE user;")
         await self.connection.query("DELETE users;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/signin/test_async_ws.py
+++ b/tests/unit_tests/connections/signin/test_async_ws.py
@@ -47,8 +47,6 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
         self.assertIsNotNone(response)
         _ = await self.connection.query("DELETE user;")
         _ = await self.connection.query("REMOVE TABLE user;")
-        await self.connection.socket.close()
-        await connection.socket.close()
 
     async def test_signin_namespace(self):
         connection = AsyncWsSurrealConnection(self.url)
@@ -61,8 +59,6 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
         self.assertIsNotNone(response)
         _ = await self.connection.query("DELETE user;")
         _ = await self.connection.query("REMOVE TABLE user;")
-        await self.connection.socket.close()
-        await connection.socket.close()
 
     async def test_signin_database(self):
         connection = AsyncWsSurrealConnection(self.url)
@@ -76,8 +72,6 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
         self.assertIsNotNone(response)
         _ = await self.connection.query("DELETE user;")
         _ = await self.connection.query("REMOVE TABLE user;")
-        await self.connection.socket.close()
-        await connection.socket.close()
 
     async def test_signin_record(self):
         vars = {
@@ -99,8 +93,6 @@ class TestAsyncHttpSurrealConnection(IsolatedAsyncioTestCase):
 
         await self.connection.query("DELETE user;")
         await self.connection.query("REMOVE TABLE user;")
-        await self.connection.socket.close()
-        await connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/subscribe_live/test_async_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_async_ws.py
@@ -50,8 +50,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
         # Cleanup the subscription
         await self.pub_connection.query("DELETE user;")
-        await self.pub_connection.socket.close()
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/unset/test_async_ws.py
+++ b/tests/unit_tests/connections/unset/test_async_ws.py
@@ -38,7 +38,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual([], outcome)
 
         await self.connection.query("DELETE person;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/update/test_async_ws.py
+++ b/tests/unit_tests/connections/update/test_async_ws.py
@@ -51,7 +51,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_update_string_with_data(self):
         first_outcome = await self.connection.update("user:tobie", self.data)
@@ -59,7 +58,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_update_record_id(self):
         first_outcome = await self.connection.update(self.record_id)
@@ -67,7 +65,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_update_record_id_with_data(self):
         outcome = await self.connection.update(self.record_id, self.data)
@@ -77,7 +74,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
             outcome[0]
         )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_update_table(self):
         table = Table("user")
@@ -87,7 +83,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.check_no_change(outcome[0])
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_update_table_with_data(self):
         table = Table("user")
@@ -96,7 +91,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/upsert/test_async_ws.py
+++ b/tests/unit_tests/connections/upsert/test_async_ws.py
@@ -52,7 +52,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         # self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_upsert_string_with_data(self):
         first_outcome = await self.connection.upsert("user:tobie", self.data)
@@ -60,7 +59,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         # self.check_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_upsert_record_id(self):
         first_outcome = await self.connection.upsert(self.record_id)
@@ -68,7 +66,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         outcome = await self.connection.query("SELECT * FROM user;")
         # self.check_no_change(outcome[0])
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_upsert_record_id_with_data(self):
         outcome = await self.connection.upsert(self.record_id, self.data)
@@ -78,7 +75,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         #     outcome[0]
         # )
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_upsert_table(self):
         table = Table("user")
@@ -89,7 +85,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         # self.check_no_change(outcome[1], random_id=True)
 
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
     async def test_upsert_table_with_data(self):
         table = Table("user")
@@ -99,7 +94,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
         self.assertEqual(2, len(outcome))
         # self.check_change(outcome[0], random_id=True)
         await self.connection.query("DELETE user;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/connections/version/test_async_ws.py
+++ b/tests/unit_tests/connections/version/test_async_ws.py
@@ -21,7 +21,6 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
     async def test_version(self):
         self.assertEqual(str, type(await self.connection.version()))
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/data_types/test_datetimes.py
+++ b/tests/unit_tests/data_types/test_datetimes.py
@@ -76,7 +76,6 @@ class TestAsyncWsSurrealConnectionDatetime(IsolatedAsyncioTestCase):
 
         # Cleanup
         await self.connection.query("DELETE datetime_tests;")
-        await self.connection.socket.close()
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
+++ b/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
@@ -7,19 +7,19 @@ from surrealdb.request_message.methods import RequestMethod
 class TestWsCborAdapter(TestCase):
 
     def test_use_pass(self):
-        message = RequestMessage(1, RequestMethod.USE, namespace="ns", database="db")
+        message = RequestMessage(RequestMethod.USE, namespace="ns", database="db")
         outcome = message.WS_CBOR_DESCRIPTOR
         self.assertIsInstance(outcome, bytes)
 
     def test_use_fail(self):
-        message = RequestMessage(1, RequestMethod.USE, namespace="ns", database=1)
+        message = RequestMessage(RequestMethod.USE, namespace="ns", database=1)
         with self.assertRaises(ValueError) as context:
             message.WS_CBOR_DESCRIPTOR
         self.assertEqual(
             "Invalid schema for Cbor WS encoding for use: {'params': [{1: ['must be of string type']}]}",
             str(context.exception)
         )
-        message = RequestMessage(1, RequestMethod.USE, namespace="ns")
+        message = RequestMessage(RequestMethod.USE, namespace="ns")
         with self.assertRaises(ValueError) as context:
             message.WS_CBOR_DESCRIPTOR
         self.assertEqual(
@@ -28,18 +28,17 @@ class TestWsCborAdapter(TestCase):
         )
 
     def test_info_pass(self):
-        message = RequestMessage(1, RequestMethod.INFO)
+        message = RequestMessage(RequestMethod.INFO)
         outcome = message.WS_CBOR_DESCRIPTOR
         self.assertIsInstance(outcome, bytes)
 
     def test_version_pass(self):
-        message = RequestMessage(1, RequestMethod.VERSION)
+        message = RequestMessage(RequestMethod.VERSION)
         outcome = message.WS_CBOR_DESCRIPTOR
         self.assertIsInstance(outcome, bytes)
 
     def test_signin_pass_root(self):
         message = RequestMessage(
-            1,
             RequestMethod.SIGN_IN,
             username="user",
             password="pass"
@@ -49,7 +48,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_signin_pass_root_with_none(self):
         message = RequestMessage(
-            1,
             RequestMethod.SIGN_IN,
             username="username",
             password="pass",
@@ -62,7 +60,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_signin_pass_account(self):
         message = RequestMessage(
-            1,
             RequestMethod.SIGN_IN,
             username="username",
             password="pass",
@@ -75,7 +72,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_authenticate_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.AUTHENTICATE,
             token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJTdXJyZWFsREIiLCJpYXQiOjE1MTYyMzkwMjIsIm5iZiI6MTUxNjIzOTAyMiwiZXhwIjoxODM2NDM5MDIyLCJOUyI6InRlc3QiLCJEQiI6InRlc3QiLCJTQyI6InVzZXIiLCJJRCI6InVzZXI6dG9iaWUifQ.N22Gp9ze0rdR06McGj1G-h2vu6a6n9IVqUbMFJlOxxA"
         )
@@ -84,7 +80,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_invalidate_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.INVALIDATE
         )
         outcome = message.WS_CBOR_DESCRIPTOR
@@ -92,7 +87,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_let_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.LET,
             key="key",
             value="value"
@@ -102,7 +96,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_unset_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.UNSET,
             params=["one", "two", "three"]
         )
@@ -111,7 +104,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_live_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.LIVE,
             table="person"
         )
@@ -120,7 +112,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_kill_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.KILL,
             uuid="0189d6e3-8eac-703a-9a48-d9faa78b44b9"
         )
@@ -129,7 +120,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_query_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.QUERY,
             query="query"
         )
@@ -138,7 +128,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_create_pass_params(self):
         message = RequestMessage(
-            1,
             RequestMethod.CREATE,
             collection="person",
             data={"table": "table"}
@@ -148,7 +137,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_insert_pass_dict(self):
         message = RequestMessage(
-            1,
             RequestMethod.INSERT,
             collection="table",
             params={"key": "value"}
@@ -158,7 +146,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_insert_pass_list(self):
         message = RequestMessage(
-            1,
             RequestMethod.INSERT,
             collection="table",
             params=[{"key": "value"}, {"key": "value"}]
@@ -168,7 +155,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_patch_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.PATCH,
             collection="table",
             params=[{"key": "value"}, {"key": "value"}]
@@ -178,7 +164,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_select_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.SELECT,
             params=["table", "user"],
         )
@@ -187,7 +172,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_update_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.UPDATE,
             record_id="test",
             data={"table": "table"}
@@ -197,7 +181,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_upsert_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.UPSERT,
             record_id="test",
             data={"table": "table"}
@@ -207,7 +190,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_merge_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.MERGE,
             record_id="test",
             data={"table": "table"}
@@ -217,7 +199,6 @@ class TestWsCborAdapter(TestCase):
 
     def test_delete_pass(self):
         message = RequestMessage(
-            1,
             RequestMethod.DELETE,
             record_id="test",
         )

--- a/tests/unit_tests/request_message/test_request_message.py
+++ b/tests/unit_tests/request_message/test_request_message.py
@@ -9,7 +9,7 @@ class TestRequestMessage(TestCase):
         self.method = RequestMethod.USE
 
     def test_init(self):
-        request_message = RequestMessage(1, self.method, one="two", three="four")
+        request_message = RequestMessage(self.method, one="two", three="four")
 
         self.assertEqual(request_message.method, self.method)
         self.assertEqual(request_message.kwargs, {"one": "two", "three": "four"})


### PR DESCRIPTION
async batching is now supported with the following unit test:

```python
class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):

    async def asyncSetUp(self):
        self.url = "ws://localhost:8000"
        self.password = "root"
        self.username = "root"
        self.vars_params = {
            "username": self.username,
            "password": self.password,
        }
        self.database_name = "test_db"
        self.namespace = "test_ns"
        self.data = {
            "username": self.username,
            "password": self.password,
        }
        self.connection = AsyncWsSurrealConnection(self.url)
        _ = await self.connection.signin(self.vars_params)
        _ = await self.connection.use(namespace=self.namespace, database=self.database_name)

    async def test_batch(self):
        async with asyncio.TaskGroup() as tg:
            tasks = [tg.create_task(self.connection.query("select $p**2 as ret from {}", dict(p=num))) for num in range(5)]

        outcome = [t.result()[0]["ret"] for t in tasks]
        self.assertEqual([0, 1, 4, 9, 16], outcome)
        await self.connection.socket.close()

```