### PR TITLE
tests: test ordering of concurrent query in async mode

### DIFF
--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -26,9 +26,9 @@ class TestAsyncWsSurrealConnection(IsolatedAsyncioTestCase):
 
     async def test_batch(self):
         async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(self.connection.query("select $p**2 as ret from {}", dict(p=num))) for num in range(5)]
+            tasks = [tg.create_task(self.connection.query("RETURN sleep(duration::from::millis($d)) or $p**2", dict(d=10 if num%2 else 0, p=num))) for num in range(5)]
 
-        outcome = [t.result()[0]["ret"] for t in tasks]
+        outcome = [t.result() for t in tasks]
         self.assertEqual([0, 1, 4, 9, 16], outcome)
         await self.connection.socket.close()
 


### PR DESCRIPTION
## What is the motivation?

Following #164 and discussion with @maxwellflitton , extend async tests to catch concurrent response ordering error 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Add a test showing that current lock mechanism fails with concurrent queries taking different time to finish.

## What is your testing strategy?

It's a test ;-)

## Is this related to any issues?

#164 and async mode of this library in general

## Have you read the [Contributing Guidelines]?

- [X] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
