### PR TITLE
Handle error response normally

### DIFF
--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -3,7 +3,7 @@ class UtilsMixin:
     @staticmethod
     def check_response_for_error(response: dict, process: str) -> None:
         if response.get("error") is not None:
-            raise Exception(f"error {process}: {response.get('error')}")
+            raise Exception(response.get('error'))
 
     @staticmethod
     def check_response_for_result(response: dict, process: str) -> None:


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Handle error response normally within the exception.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

When the exception got hit, then you can do something with the error.

## What is your testing strategy?

I've test it within my python FastHTML app. Now I can use the error to display a toast message.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
