### PR TITLE
fix: handle error in async ws

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,9 @@ disable_error_code = ["return-value", "return-type"]
 [[tool.mypy.overrides]]
 module = "cerberus.*"
 ignore_missing_imports = true
+
+[dependency-groups]
+dev = [
+    "black>=25.1.0",
+    "ruff>=0.11.9",
+]

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -62,7 +62,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             else:
                 self.check_response_for_error(response, "_recv_task")
 
-
     async def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
     ) -> dict:


### PR DESCRIPTION
_recv_task was not handling errors.

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Raise an error from _recv_task when the response from the db was an error. In these cases the response does not contain the keys `id` or `result`.

## What is your testing strategy?

Debugger, and unit tests are passing.

## Is this related to any issues?

n/a

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
