### PR TITLE
Fix None encoding and decoding for SurrealDB v2.2.x and later

### DIFF
--- a/src/surrealdb/cbor2/_decoder.py
+++ b/src/surrealdb/cbor2/_decoder.py
@@ -604,6 +604,14 @@ class CBORDecoder:
 
         return self.set_shareable(Decimal(sig) * (2 ** Decimal(exp)))
 
+    def decode_none(self) -> None:
+        # Semantic tag 6
+        value = self._decode()
+        if not isinstance(value, type(None)):
+            raise CBORDecodeValueError("invalid None value " + str(value))
+
+        return self.set_shareable(None)
+
     def decode_stringref(self) -> str | bytes:
         # Semantic tag 25
         if self._stringref_namespace is None:
@@ -786,7 +794,7 @@ semantic_decoders: dict[int, Callable[[CBORDecoder], Any]] = {
     3: CBORDecoder.decode_negative_bignum,
     4: CBORDecoder.decode_fraction,
     5: CBORDecoder.decode_bigfloat,
-    6: lambda self: None,
+    6: CBORDecoder.decode_none,
     25: CBORDecoder.decode_stringref,
     28: CBORDecoder.decode_shareable,
     29: CBORDecoder.decode_sharedref,

--- a/src/surrealdb/cbor2/_encoder.py
+++ b/src/surrealdb/cbor2/_encoder.py
@@ -658,8 +658,14 @@ class CBOREncoder:
 
     def encode_none(self, value: None) -> None:
         # tag(6, None)
-        self._fp_write(b"\xd9\x00\x06\xf6")
-        # self._fp_write(b"\xf6")
+
+        # Note that although just \xf6 (major type 6, 22) is already null in CBOR,
+        # which this cbor2 implementation decodes it as Python None,
+        # SurrealDB's variant of CBOR wraps it with \xc6 (major type 6, tag 6)
+        # which results in \xc6\xf6.
+        # We try to be compliant as much as SurrealDB's variant of CBOR
+        # and therefore encode it as \xc6\xf6.
+        self._fp_write(b"\xc6\xf6")
 
     def encode_undefined(self, value: UndefinedType) -> None:
         self._fp_write(b"\xf7")

--- a/tests/unit_tests/data_types/test_none.py
+++ b/tests/unit_tests/data_types/test_none.py
@@ -30,7 +30,7 @@ class TestAsyncWsSurrealConnectionNone(IsolatedAsyncioTestCase):
         await self.connection.use(namespace=self.namespace, database=self.database_name)
 
         # Cleanup
-        await self.connection.query("DELETE person;")
+        await self.connection.query("REMOVE TABLE person;")
 
     async def test_none(self):
         schema = """
@@ -56,6 +56,39 @@ class TestAsyncWsSurrealConnectionNone(IsolatedAsyncioTestCase):
         self.assertEqual(record_check, outcome["id"])
         self.assertEqual("Dave", outcome["name"])
         self.assertEqual(34, outcome["age"])
+
+        outcome = await self.connection.query("SELECT * FROM person")
+        self.assertEqual(2, len(outcome))
+
+        await self.connection.query("REMOVE TABLE person;")
+        await self.connection.close()
+
+    async def test_none_with_query(self):
+        schema = """
+            DEFINE TABLE person SCHEMAFULL TYPE NORMAL;
+            DEFINE FIELD name ON person TYPE string;
+            DEFINE FIELD nums ON person TYPE array<option<int>>;
+        """
+        await self.connection.query(schema)
+        outcome = await self.connection.query(
+            "UPSERT person MERGE {id: $id, name: $name, nums: $nums}",
+            {"id": [1,2], "name": "John", "nums": [None]}
+        )
+        record_check = RecordID(table_name="person", identifier=[1, 2])
+        self.assertEqual(1, len(outcome))
+        self.assertEqual(record_check, outcome[0]["id"])
+        self.assertEqual("John", outcome[0]["name"])
+        self.assertEqual([None], outcome[0].get("nums"))
+
+        outcome = await self.connection.query(
+            "UPSERT person MERGE {id: $id, name: $name, nums: $nums}",
+            {"id": [3,4], "name": "Dave", "nums": [None]}
+        )
+        record_check = RecordID(table_name="person", identifier=[3, 4])
+        self.assertEqual(1, len(outcome))
+        self.assertEqual(record_check, outcome[0]["id"])
+        self.assertEqual("Dave", outcome[0]["name"])
+        self.assertEqual([None], outcome[0].get("nums"))
 
         outcome = await self.connection.query("SELECT * FROM person")
         self.assertEqual(2, len(outcome))


### PR DESCRIPTION
## What is the motivation?

Hey 👋 This fixes a complex bug that I encountered while building something with surrealdb.py and SurrealDB v2.3.2.

This seems to affect SureralDB v2.2.x, v.2.3.x, and probably later, but not v2.1.x which is the only test target today.

### The issue I encountered

While building my [project](https://github.com/surrealdb/airbyte-connector), I encountered a strange issue where you get `unhashable type: 'RecordID'` error when sending a query like this:

```python
outcome = await self.connection.query(
    "UPSERT mytable MERGE {id: $id, name: $name, nums: $nums}",
    {"id": [1,2], "name": "John", "nums": [None]}
)
```

At a glance, it didn't make sense- but investigating further, it turned out that the issue disappears if you update the query to either (1) make the id non-array or (2) make the `nums` field not contain `None`.

I read some code, especially your implementation of CBOR, and found that there seem to be two issues in surrealdb.py's CBOR:

1. It encodes Python `None` with an encoding that does not comply with [the SurrealDB's CBOR encoding of None](https://surrealdb.com/docs/surrealdb/integration/cbor#tag-6). surrealdb.py encodes it with its first byte being `110_11001` (major type 6, tag 25). This is already incorrect because it must be `110_00110` (major type 6, tag 6). The tag 25 is not defined in SurrealDB's CBOR, either.
2. It decodes anything that starts with `110_00110` (major type 6, tag 6) as "something tagged 6" (correct). HOWEVER, it skips reading the tagged value. I believe this results in the tagged value being misintepret as a "next" value. In other words, you must consume it although the tagged value is always Python `None` which encodes as [`111_10110` (major type 7, value 22)](https://datatracker.ietf.org/doc/html/rfc7049#section-2.3). Otherwise the unconsumed bytes are misinterpret later.

This change adds the initially failing test, and the code fixes that makes my project and the test passing.

<!-- Provide information on the motivation for why you have made this change. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

<!-- Provide a description of what this pull request does. -->

This fixes the custom CBOR encoding/decoding for Python `None` to comply with https://surrealdb.com/docs/surrealdb/integration/cbor#tag-6 and prevents edge-cases like `None` in a value position overflows, resulting in errors while parsing subsequent tokens.

## What is your testing strategy?

I've pointed my [project](https://github.com/surrealdb/airbyte-connector) to the fork, and the issue got resolved.

I also added a failing test (first commit) to reproduce the issue, and confirmed that the second commit fixes the issue.

## Is this related to any issues?

<!-- If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here. -->

I've read all the open issues, and I believe this one has not been reported yet.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
