### PR TITLE
Do not pin aiohttp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohappyeyeballs==2.4.4",
-    "aiohttp==3.11.11",
+    "aiohttp>=3.11.11",
     "aiosignal==1.3.2",
     "async-timeout>=4.0.3",
     "attrs==25.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.4.4
-aiohttp==3.11.11
+aiohttp>=3.11.11
 aiosignal==1.3.2
 async-timeout==5.0.1
 attrs==25.1.0


### PR DESCRIPTION
## What is the motivation?

I plan to use surreal.py with another library: https://github.com/lastmile-ai/mcp-agent, and it requires `aiohttp>=3.11.13`.

The dependency here in surreal.py is quite strict as noted by: https://github.com/surrealdb/surrealdb.py/issues/179

This PR only fixes the dependency of the offending library.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

This relaxes the aiohttp constraint so we can use versions later than the pinned one (3.11.11)

## What is your testing strategy?

I ran `pip install -r requirements.txt` and it installed the library without a problem.

I peeked at the [usage of aiohttp](https://github.com/surrealdb/surrealdb.py/blob/f12b8818b5808054002579877c8b0f4b408106e5/src/surrealdb/connections/async_http.py#L76), and based on the simple usage, I don't expect this to break the client request.

## Is this related to any issues?

Partially resolves: https://github.com/surrealdb/surrealdb.py/issues/179

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
