### PR TITLE
Allow subscribing to live queries initiated in `db.query`

### DIFF
--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -394,11 +394,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     ) -> AsyncGenerator[dict[str, Value], None]:
         result_queue: Queue[dict[str, Any]] = Queue()
         suid = str(query_uuid)
-        
+
         # Auto-register if not already registered
         if suid not in self.live_queues:
             self.live_queues[suid] = []
-        
+
         self.live_queues[suid].append(result_queue)
 
         async def _iter() -> AsyncGenerator[dict[str, Any], None]:

--- a/tests/unit_tests/connections/subscribe_live/test_async_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_async_ws.py
@@ -33,7 +33,9 @@ async def test_live_subscription(async_ws_connection_with_user, async_ws_connect
     await async_ws_connection.query("DELETE user;")
 
 
-async def test_live_subscription_via_query(async_ws_connection_with_user, async_ws_connection):
+async def test_live_subscription_via_query(
+    async_ws_connection_with_user, async_ws_connection
+):
     # Start the live query using query() method
     query_uuid = await async_ws_connection_with_user.query("LIVE SELECT * FROM user;")
     assert isinstance(query_uuid, UUID)


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Allows live queries to be written in `db.query()` function, and then subscribed to subsequently.

```py
uuid = await db.query("LIVE SELECT * FROM person;")
queue = await db.subscribe_live(uuid)
```

## Is this related to any issues?

Closes #193 

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
