### PR TITLE
Fix `Duration` encoding and decoding

### DIFF
--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -126,10 +126,20 @@ def tag_decoder(
         return Range(tag.value[0], tag.value[1])
 
     elif tag.tag == constants.TAG_DURATION_COMPACT:
-        return Duration.parse(tag.value[0], tag.value[1])  # Two numbers (s, ns)
+        if len(tag.value) == 1:
+            return Duration.parse(tag.value[0], 0)  # seconds only
+        else:
+            return Duration.parse(tag.value[0], tag.value[1])  # seconds and nanoseconds
 
     elif tag.tag == constants.TAG_DURATION:
-        return Duration.parse(tag.value)  # String (e.g., "1d3m5ms")
+        # TAG_DURATION is encoded as [seconds, nanoseconds] tuple
+        if isinstance(tag.value, (list, tuple)) and len(tag.value) == 2:
+            return Duration.parse(tag.value[0], tag.value[1])
+        # Fallback for string format (if server sends it)
+        elif isinstance(tag.value, str):
+            return Duration.parse(tag.value)
+        else:
+            raise ValueError(f"Unexpected TAG_DURATION value format: {tag.value}")
 
     elif tag.tag == constants.TAG_DATETIME_COMPACT:
         # TODO => convert [seconds, nanoseconds] => return datetime

--- a/tests/unit_tests/data_types/test_duration.py
+++ b/tests/unit_tests/data_types/test_duration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from surrealdb.cbor import CBORTag
+from surrealdb.data import cbor
+from surrealdb.data.types import constants
 from surrealdb.data.types.duration import Duration
 
 
@@ -143,3 +146,50 @@ def test_duration_to_compact():
     duration = Duration(5 * 1_000_000_000)  # 5 seconds
     compact = duration.to_compact()
     assert compact == [5]
+
+
+def test_duration_cbor_decode_compact_single_element():
+    """Test CBOR decoding of TAG_DURATION_COMPACT with single element array."""
+    # Simulate server sending [seconds] only (no nanoseconds)
+    tag = CBORTag(constants.TAG_DURATION_COMPACT, [3600])  # 1 hour in seconds
+    
+    # tag_decoder doesn't actually use the decoder parameter for durations
+    result = cbor.tag_decoder(None, tag)
+    
+    assert isinstance(result, Duration)
+    assert result.elapsed == 3600 * 1_000_000_000  # 1 hour in nanoseconds
+
+
+def test_duration_cbor_decode_compact_dual_element():
+    """Test CBOR decoding of TAG_DURATION_COMPACT with dual element array."""
+    # Simulate server sending [seconds, nanoseconds]
+    tag = CBORTag(constants.TAG_DURATION_COMPACT, [2, 500_000_000])  # 2.5 seconds
+    
+    # tag_decoder doesn't actually use the decoder parameter for durations
+    result = cbor.tag_decoder(None, tag)
+    
+    assert isinstance(result, Duration)
+    assert result.elapsed == 2_500_000_000  # 2.5 seconds in nanoseconds
+
+
+def test_duration_cbor_encode_decode_roundtrip():
+    """Test encoding and decoding Duration through CBOR."""
+    # Create duration with both seconds and nanoseconds
+    original = Duration(2_500_000_000)  # 2.5 seconds in nanoseconds
+    
+    # Encode
+    encoded = cbor.encode(original)
+    
+    # Decode
+    decoded = cbor.decode(encoded)
+    
+    assert isinstance(decoded, Duration)
+    assert decoded == original
+    
+    # Test with whole seconds (no fractional nanoseconds)
+    original_whole = Duration(5_000_000_000)  # 5 seconds
+    encoded_whole = cbor.encode(original_whole)
+    decoded_whole = cbor.decode(encoded_whole)
+    
+    assert isinstance(decoded_whole, Duration)
+    assert decoded_whole == original_whole


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Ensures that `Duration` types work correctly with SurrealDB

## Is this related to any issues?

Closes #173 

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
