### PR TITLE
Fix: Escape string identifiers in RecordID to match SurrealDB behaviour

### DIFF
--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -29,7 +29,46 @@ class RecordID:
         self.table_name = table_name
         self.id = identifier
 
+    @staticmethod
+    def _escape_identifier(identifier: str) -> str:
+        """
+        Escapes a string identifier if needed, following SurrealDB's EscapeRid logic.
+
+        Identifiers need escaping if:
+        - Empty string
+        - Contains non-alphanumeric characters (except underscore)
+        - Contains only digits and underscores (no alphabetic characters)
+
+        Args:
+            identifier: The string identifier to potentially escape
+
+        Returns:
+            The escaped identifier with angle brackets if needed, or the original if not
+        """
+        # Empty string needs escaping
+        if not identifier:
+            return f"⟨{identifier}⟩"
+
+        # Check if contains any non-alphanumeric character (excluding underscore)
+        has_special_chars = any(not c.isalnum() and c != "_" for c in identifier)
+
+        # Check if all characters are digits or underscores (no alphabetic characters)
+        # This means it needs escaping to distinguish from numeric IDs
+        has_no_alpha = not any(c.isalpha() for c in identifier)
+
+        # Apply escaping if any condition is met
+        if has_special_chars or has_no_alpha:
+            # Escape any angle brackets in the identifier itself
+            escaped = identifier.replace("⟩", "\\⟩")
+            return f"⟨{escaped}⟩"
+
+        return identifier
+
     def __str__(self) -> str:
+        # Only escape if the identifier is a string
+        if isinstance(self.id, str):
+            escaped_id = self._escape_identifier(self.id)
+            return f"{self.table_name}:{escaped_id}"
         return f"{self.table_name}:{self.id}"
 
     def __repr__(self) -> str:

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -55,6 +55,72 @@ def test_record_id_str() -> None:
     assert str(record_id) == "users:john"
 
 
+def test_record_id_str_with_numeric_string() -> None:
+    """Test RecordID string representation with long numeric string (issue #171)."""
+    record_id = RecordID("foo", "125813199042576601589342522460260755")
+    assert str(record_id) == "foo:⟨125813199042576601589342522460260755⟩"
+
+
+def test_record_id_str_with_short_numeric_string() -> None:
+    """Test RecordID string representation with short numeric string."""
+    record_id = RecordID("users", "123")
+    assert str(record_id) == "users:⟨123⟩"
+
+
+def test_record_id_str_with_underscore_only() -> None:
+    """Test RecordID string representation with only underscores."""
+    record_id = RecordID("test", "_")
+    assert str(record_id) == "test:⟨_⟩"
+
+
+def test_record_id_str_with_digits_and_underscores() -> None:
+    """Test RecordID string representation with digits and underscores."""
+    record_id = RecordID("test", "123_456")
+    assert str(record_id) == "test:⟨123_456⟩"
+
+
+def test_record_id_str_with_special_chars() -> None:
+    """Test RecordID string representation with special characters."""
+    record_id = RecordID("users", "john-doe")
+    assert str(record_id) == "users:⟨john-doe⟩"
+
+
+def test_record_id_str_with_spaces() -> None:
+    """Test RecordID string representation with spaces."""
+    record_id = RecordID("users", "john doe")
+    assert str(record_id) == "users:⟨john doe⟩"
+
+
+def test_record_id_str_with_empty_string() -> None:
+    """Test RecordID string representation with empty string."""
+    record_id = RecordID("users", "")
+    assert str(record_id) == "users:⟨⟩"
+
+
+def test_record_id_str_alphanumeric_no_escape() -> None:
+    """Test RecordID string representation with alphanumeric (no escape needed)."""
+    record_id = RecordID("users", "john123")
+    assert str(record_id) == "users:john123"
+
+
+def test_record_id_str_alphanumeric_with_underscore_no_escape() -> None:
+    """Test RecordID string representation with alphanumeric and underscore (no escape needed)."""
+    record_id = RecordID("users", "john_doe_123")
+    assert str(record_id) == "users:john_doe_123"
+
+
+def test_record_id_str_with_integer_id() -> None:
+    """Test RecordID string representation with integer identifier (no escape)."""
+    record_id = RecordID("users", 123)
+    assert str(record_id) == "users:123"
+
+
+def test_record_id_str_with_angle_bracket_escape() -> None:
+    """Test RecordID string representation with angle bracket in identifier."""
+    record_id = RecordID("test", "foo⟩bar")
+    assert str(record_id) == "test:⟨foo\\⟩bar⟩"
+
+
 def test_record_id_equality() -> None:
     """Test RecordID equality."""
     record_id1 = RecordID("users", "john")


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Previously, string identifiers like `"125813199042576601589342522460260755"` were rendered as `foo:125813199042576601589342522460260755`, which is indistinguishable from a numeric identifier. This is inconsistent with SurrealDB's behavior, which escapes such identifiers with angle brackets: `foo:⟨125813199042576601589342522460260755⟩`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Fixes a bug where `RecordID` with numeric string identifiers were not being properly escaped when converted to strings, causing ambiguity between string and numeric identifiers.

Previously, string identifiers like `"125813199042576601589342522460260755"` were rendered as `foo:125813199042576601589342522460260755`, which is indistinguishable from a numeric identifier. This is inconsistent with SurrealDB's behavior, which escapes such identifiers with angle brackets: `foo:⟨125813199042576601589342522460260755⟩`.

**Changes**
- Added `_escape_identifier()` static method to `RecordID` class that follows SurrealDB's `EscapeRid` logic
- String identifiers are now escaped with angle brackets (`⟨⟩`) when:
  - The identifier is empty
  - Contains non-alphanumeric characters (except underscore)
  - Contains only digits and underscores (no alphabetic characters)
- Updated `__str__()` method to use the new escaping logic for string identifiers
- Non-string identifiers (int, array, dict) remain unchanged

**Examples**
```python
RecordID("foo", "125813199042576601589342522460260755")  # foo:⟨125813199042576601589342522460260755⟩
RecordID("users", "john")                                # users:john
RecordID("users", "john_doe_123")                        # users:john_doe_123
RecordID("users", "john-doe")                            # users:⟨john-doe⟩
RecordID("users", "123")                                 # users:⟨123⟩
RecordID("users", 123)                                   # users:123 (no escape for numeric types)
```

## What is your testing strategy?

- Added 11 new unit tests covering various escaping scenarios
- All 253 existing tests continue to pass
- Verified behaviour matches SurrealDB's `EscapeRid` implementation

## Is this related to any issues?

Closes #171.
 
## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
