### PR TITLE
feat: Support compound duration parsing in Duration.parse()

### DIFF
--- a/src/surrealdb/data/types/duration.py
+++ b/src/surrealdb/data/types/duration.py
@@ -37,6 +37,7 @@ class Duration:
             for num_str, unit in matches:
                 num = int(num_str)
                 if unit not in UNITS:
+                    # this will never happen because the regex only matches valid units
                     raise ValueError(f"Unknown duration unit: {unit}")
                 total_ns += num * UNITS[unit]
 

--- a/tests/unit_tests/data_types/test_duration.py
+++ b/tests/unit_tests/data_types/test_duration.py
@@ -66,11 +66,11 @@ def test_duration_parse_str_microseconds() -> None:
     """Test Duration.parse with string input in microseconds (both us and µs variants)."""
     duration_us = Duration.parse("100us")
     duration_mu = Duration.parse("100µs")
-    
+
     # Both should equal 100 microseconds in nanoseconds
     assert duration_us.elapsed == 100 * 1_000
     assert duration_mu.elapsed == 100 * 1_000
-    
+
     # Both variants should produce identical results
     assert duration_us.elapsed == duration_mu.elapsed
 
@@ -78,15 +78,18 @@ def test_duration_parse_str_microseconds() -> None:
 def test_duration_parse_str_compound() -> None:
     """Test Duration.parse with comprehensive compound duration including all units."""
     duration = Duration.parse("1y2w3d4h5m6s7ms8us9ns")
-    assert duration.elapsed == (1 * 365 * 86400 * 1_000_000_000) \
-        + (2 * 604800 * 1_000_000_000) \
-        + (3 * 86400 * 1_000_000_000) \
-        + (4 * 3600 * 1_000_000_000) \
-        + (5 * 60 * 1_000_000_000) \
-        + (6 * 1_000_000_000) \
-        + (7 * 1_000_000) \
-        + (8 * 1_000) \
+    assert (
+        duration.elapsed
+        == (1 * 365 * 86400 * 1_000_000_000)
+        + (2 * 604800 * 1_000_000_000)
+        + (3 * 86400 * 1_000_000_000)
+        + (4 * 3600 * 1_000_000_000)
+        + (5 * 60 * 1_000_000_000)
+        + (6 * 1_000_000_000)
+        + (7 * 1_000_000)
+        + (8 * 1_000)
         + 9
+    )
 
 
 def test_duration_parse_str_nanoseconds() -> None:
@@ -97,7 +100,9 @@ def test_duration_parse_str_nanoseconds() -> None:
 
 def test_duration_parse_invalid_unit() -> None:
     """Test Duration.parse with invalid unit raises ValueError."""
-    with pytest.raises(ValueError, match="Unknown duration unit: x"):
+    # it fails when checking the format, before checking if the unit is valid,
+    # which is ok.
+    with pytest.raises(ValueError, match="Invalid duration format: 10x"):
         Duration.parse("10x")
 
 


### PR DESCRIPTION
## Description
Enhances `Duration.parse()` to support compound duration strings like "1h30m", "2d3h15m", etc.

## Motivation
Currently, `Duration.parse()` only supports single-unit durations ("2h", "30m"). 
This limitation requires users to convert compound durations manually. For example,
"1 hour and 30 minutes" cannot be expressed as "1h30m" and must be converted to "90m".

## Changes
- Modified `Duration.parse()` to use regex pattern matching for flexible parsing
- Supports multiple units in a single string: "1h30m", "2d3h15m30s", etc.
- Maintains full backward compatibility with existing single-unit durations
- Added comprehensive test coverage for new functionality

## Testing
- All existing tests pass
- Added new tests covering compound duration parsing
- Verified backward compatibility with single-unit durations

## Examples
```python
# New functionality
Duration.parse("1h30m")      # 90 minutes
Duration.parse("2d3h15m")    # 2 days, 3 hours, 15 minutes
Duration.parse("1h30m45s")   # 1 hour, 30 minutes, 45 seconds

# Existing functionality (still works)
Duration.parse("2h")         # 2 hours
Duration.parse("45m")        # 45 minutes