### PR TITLE
Use `query_raw` internally within `query` function

### DIFF
--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -159,17 +159,8 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.database = database
 
     async def query(self, query: str, vars: Optional[dict[str, Value]] = None) -> Value:
-        if vars is None:
-            vars = {}
-        for key, value in self.vars.items():
-            vars[key] = value
-        message = RequestMessage(
-            RequestMethod.QUERY,
-            query=query,
-            params=vars,
-        )
-        self.id = message.id
-        response = await self._send(message, "query")
+        response = await self.query_raw(query, vars)
+        self.check_response_for_error(response, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
 

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -181,14 +181,8 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         await self._send(message, "use")
 
     async def query(self, query: str, vars: Optional[dict[str, Value]] = None) -> Value:
-        if vars is None:
-            vars = {}
-        message = RequestMessage(
-            RequestMethod.QUERY,
-            query=query,
-            params=vars,
-        )
-        response = await self._send(message, "query")
+        response = await self.query_raw(query, vars)
+        self.check_response_for_error(response, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
 

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -135,17 +135,8 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.database = database
 
     def query(self, query: str, vars: Optional[dict[str, Value]] = None) -> Value:
-        if vars is None:
-            vars = {}
-        for key, value in self.vars.items():
-            vars[key] = value
-        message = RequestMessage(
-            RequestMethod.QUERY,
-            query=query,
-            params=vars,
-        )
-        self.id = message.id
-        response = self._send(message, "query")
+        response = self.query_raw(query, vars)
+        self.check_response_for_error(response, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
 

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -133,15 +133,8 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self._send(message, "use")
 
     def query(self, query: str, vars: Optional[dict[str, Value]] = None) -> Value:
-        if vars is None:
-            vars = {}
-        message = RequestMessage(
-            RequestMethod.QUERY,
-            query=query,
-            params=vars,
-        )
-        self.id = message.id
-        response = self._send(message, "query")
+        response = self.query_raw(query, vars)
+        self.check_response_for_error(response, "query")
         self.check_response_for_result(response, "query")
         return response["result"][0]["result"]
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

It switches to use `query_raw` internally within the `query` function.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #222.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
