### PR TITLE
Build: Fix discord notification

### DIFF
--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -80,8 +80,7 @@ jobs:
           RELEASE_URL="${{ github.event.release.html_url }}"
           RELEASE_NAME="${{ github.event.release.name }}"
           if [ ${#RELEASE_BODY_JSON} -gt 1800 ]; then
-            BODY=$(echo $RELEASE_BODY_JSON | head -c 1797 | sed 's/[^"]*$//')
-            BODY="${BODY%\"}...\""
+            BODY="\"$(echo $RELEASE_BODY_JSON | head -c 1796 | cut -c2-)...\""
           else
             BODY=$RELEASE_BODY_JSON
           fi

--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -74,11 +74,17 @@ jobs:
       - name: Send Discord notification
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_BODY_JSON: ${{ toJSON(github.event.release.body) }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
           RELEASE_URL="${{ github.event.release.html_url }}"
           RELEASE_NAME="${{ github.event.release.name }}"
-          BODY=$(echo '${{ toJson(github.event.release.body) }}' | head -c 1800)
+          if [ ${#RELEASE_BODY_JSON} -gt 1800 ]; then
+            BODY=$(echo $RELEASE_BODY_JSON | head -c 1797 | sed 's/[^"]*$//')
+            BODY="${BODY%\"}...\""
+          else
+            BODY=$RELEASE_BODY_JSON
+          fi
 
           curl -s -X POST "$DISCORD_WEBHOOK_URL" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## What is the motivation?

The github action breaks if there are special characters (like `'`) in the release notes.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

This PR makes sure the notification body is a valid string.

## What is your testing strategy?

Will test in the next release. The notification is still going to a private test discord channel.

## Is this related to any issues?

n/a

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
