### PR TITLE
test: fix flaky subscribe_live WebSocket race

### DIFF
--- a/tests/unit_tests/connections/conftest.py
+++ b/tests/unit_tests/connections/conftest.py
@@ -74,6 +74,27 @@ async def async_ws_connection(
 
 
 @pytest.fixture
+async def async_ws_connection_secondary(
+    connection_params: dict[str, Any],
+) -> AsyncGenerator[AsyncWsSurrealConnection, None]:
+    """Second independent async WebSocket (same auth/ns/db). Use when a test needs two sockets."""
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    try:
+        await connection.signin(connection_params["vars_params"])
+        await connection.use(
+            namespace=connection_params["namespace"],
+            database=connection_params["database_name"],
+        )
+        await connection.query(_DEFINE_TABLES)
+        yield connection
+    finally:
+        try:
+            await connection.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture
 def blocking_http_connection(
     connection_params: dict[str, Any],
 ) -> Generator[BlockingHttpSurrealConnection, None, None]:
@@ -93,6 +114,23 @@ def blocking_ws_connection(
     connection_params: dict[str, Any],
 ) -> Generator[BlockingWsSurrealConnection, None, None]:
     """Blocking WebSocket connection fixture"""
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    connection.signin(connection_params["vars_params"])
+    connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+    connection.query(_DEFINE_TABLES)
+    yield connection
+    if connection.socket:
+        connection.socket.close()
+
+
+@pytest.fixture
+def blocking_ws_connection_secondary(
+    connection_params: dict[str, Any],
+) -> Generator[BlockingWsSurrealConnection, None, None]:
+    """Second independent blocking WebSocket (same auth/ns/db). Use when a test needs two sockets."""
     connection = BlockingWsSurrealConnection(connection_params["ws_url"])
     connection.signin(connection_params["vars_params"])
     connection.use(

--- a/tests/unit_tests/connections/subscribe_live/test_async_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_async_ws.py
@@ -10,7 +10,7 @@ from surrealdb.data import RecordID
 
 async def test_live_subscription(
     async_ws_connection_with_user: AsyncWsSurrealConnection,
-    async_ws_connection: AsyncWsSurrealConnection,
+    async_ws_connection_secondary: AsyncWsSurrealConnection,
 ) -> None:
     # Start the live query
     query_uuid = await async_ws_connection_with_user.live("user")
@@ -19,8 +19,8 @@ async def test_live_subscription(
     # Start the live subscription
     subscription = await async_ws_connection_with_user.subscribe_live(query_uuid)
 
-    # Push an update
-    await async_ws_connection.query(
+    # Second socket avoids QUERY responses racing with live notifications on one WS.
+    await async_ws_connection_secondary.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
     )
 
@@ -31,14 +31,15 @@ async def test_live_subscription(
     except TimeoutError:
         pytest.fail("Timed out waiting for live subscription update")
 
-    await async_ws_connection.kill(query_uuid)
+    await async_ws_connection_secondary.kill(query_uuid)
 
     # Cleanup the subscription
-    await async_ws_connection.query("DELETE user;")
+    await async_ws_connection_secondary.query("DELETE user;")
 
 
 async def test_live_subscription_via_query(
-    async_ws_connection_with_user, async_ws_connection: AsyncWsSurrealConnection
+    async_ws_connection_with_user: AsyncWsSurrealConnection,
+    async_ws_connection_secondary: AsyncWsSurrealConnection,
 ) -> None:
     # Start the live query using query() method
     query_uuid = await async_ws_connection_with_user.query("LIVE SELECT * FROM user;")
@@ -47,8 +48,7 @@ async def test_live_subscription_via_query(
     # Start the live subscription
     subscription = await async_ws_connection_with_user.subscribe_live(query_uuid)
 
-    # Push an update
-    await async_ws_connection.query(
+    await async_ws_connection_secondary.query(
         "CREATE user:john SET name = 'John', email = 'john@example.com', password = 'password123', enabled = true;"
     )
 
@@ -59,7 +59,7 @@ async def test_live_subscription_via_query(
     except TimeoutError:
         pytest.fail("Timed out waiting for live subscription update")
 
-    await async_ws_connection.kill(query_uuid)
+    await async_ws_connection_secondary.kill(query_uuid)
 
     # Cleanup the subscription
-    await async_ws_connection.query("DELETE user;")
+    await async_ws_connection_secondary.query("DELETE user;")

--- a/tests/unit_tests/connections/subscribe_live/test_blocking_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_blocking_ws.py
@@ -8,7 +8,7 @@ from surrealdb.data import RecordID
 
 def test_live_subscription(
     blocking_ws_connection_with_user: BlockingWsSurrealConnection,
-    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
 ) -> None:
     # Start the live query
     query_uuid = blocking_ws_connection_with_user.live("user")
@@ -17,8 +17,9 @@ def test_live_subscription(
     # Start the live subscription
     subscription = blocking_ws_connection_with_user.subscribe_live(query_uuid)
 
-    # Push an update
-    blocking_ws_connection.query(
+    # Push an update on a second socket so the live connection is not interleaved
+    # with live notifications (same socket would race QUERY vs notification).
+    blocking_ws_connection_secondary.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
     )
 
@@ -31,4 +32,4 @@ def test_live_subscription(
     except Exception as e:
         pytest.fail(f"Error waiting for live subscription update: {e}")
 
-    blocking_ws_connection.kill(query_uuid)
+    blocking_ws_connection_secondary.kill(query_uuid)


### PR DESCRIPTION
## What is the motivation?

`subscribe_live` unit tests were flaky or failing when the `query()` response and a live notification arrived on the same WebSocket in different orders. Pytest was injecting the \*same\* connection for `blocking_ws_connection` and `blocking_ws_connection_with_user` (and the async equivalents), so writes and the live listener shared one socket.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## What does this change do?

- Adds `blocking_ws_connection_secondary` and `async_ws_connection_secondary` fixtures (second signed-in WebSocket; runs `DEFINE TABLE` setup like other fixtures).
- Updates `subscribe_live` tests to perform CREATE, kill, and cleanup DELETE on the secondary connection while LIVE/subscribe stay on the primary connection.

## What is your testing strategy?

- Run `uv run pytest tests/unit_tests/connections/subscribe_live/ -v` with SurrealDB on `ws://localhost:8000` (CI should cover this when the server is available).

## Is this related to any issues?

No related issues.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md