### PR TITLE
fix: subscribe_live yields full live notification (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking:** WebSocket `subscribe_live()` now yields the full live-notification object (`action`, `result`, `id`, …) from the server instead of only the inner record ([#247](https://github.com/surrealdb/surrealdb.py/issues/247)).
+
+### Fixed
+- `subscribe_live` WebSocket tests perform mutations on a secondary connection so query RPC replies are not interleaved with live notifications on the same socket.
+
 ## [2.0.0] - 2026-04-23
 ### Added
 - Support `surrealkv+versioned://` URL scheme for embedded databases with versioning (#231).

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -382,8 +382,12 @@ class AsyncTemplate:
     ) -> AsyncGenerator[dict[str, Value], None]:
         """Iterate live notifications for the given live query id.
 
-        Yields the full notification dict from the server (``action``, ``result``, ``id``,
-        ``record``, …), not only the changed record document.
+        Args:
+            query_uuid (Union[str, UUID]): The query UUID to subscribe to.
+
+        Yields:
+            dict: Each live notification from the server (``action``, ``result``, ``id``,
+            ``record``, etc.), not only the changed record payload.
         """
         raise NotImplementedError(f"subscribe_live not implemented for: {self}")
 

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -380,16 +380,10 @@ class AsyncTemplate:
     async def subscribe_live(
         self, query_uuid: str | UUID
     ) -> AsyncGenerator[dict[str, Value], None]:
-        """Returns a queue that receives notification messages from a running live query.
+        """Iterate live notifications for the given live query id.
 
-        Args:
-            query_uuid: The uuid for the live query
-
-        Returns:
-            the notification queue
-
-        Example:
-            await db.subscribe_live(UUID)
+        Yields the full notification dict from the server (``action``, ``result``, ``id``,
+        ``record``, …), not only the changed record document.
         """
         raise NotImplementedError(f"subscribe_live not implemented for: {self}")
 

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -482,10 +482,6 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     async def subscribe_live(
         self, query_uuid: str | UUID
     ) -> AsyncGenerator[dict[str, Value], None]:
-        """Stream live notifications for the given live query id.
-
-        Each item matches the wire format (``action``, ``result``, ``id``, ``record``, …).
-        """
         result_queue: Queue[dict[str, Any]] = Queue()
         suid = str(query_uuid)
 

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -482,6 +482,10 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     async def subscribe_live(
         self, query_uuid: str | UUID
     ) -> AsyncGenerator[dict[str, Value], None]:
+        """Stream live notifications for the given live query id.
+
+        Each item matches the wire format (``action``, ``result``, ``id``, ``record``, …).
+        """
         result_queue: Queue[dict[str, Any]] = Queue()
         suid = str(query_uuid)
 
@@ -494,7 +498,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         async def _iter() -> AsyncGenerator[dict[str, Any], None]:
             while True:
                 ret = await result_queue.get()
-                yield ret["result"]
+                yield ret
 
         return _iter()
 

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -415,6 +415,16 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             result, unwrap=self._is_single_record_operation(record)
         )
 
+    @staticmethod
+    def _live_notification_matches(
+        query_uuid: str | UUID, notification: dict[str, Any]
+    ) -> bool:
+        """Return True if this push belongs to the given live query id."""
+        nid = notification.get("id")
+        if nid is None:
+            return False
+        return str(nid) == str(query_uuid)
+
     def subscribe_live(
         self,
         query_uuid: str | UUID,
@@ -426,7 +436,8 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             query_uuid (Union[str, UUID]): The query UUID to subscribe to.
 
         Yields:
-            dict: The results of live updates.
+            dict: Each live notification from the server (``action``, ``result``, ``id``,
+            ``record``, etc.), not only the changed record payload.
         """
         try:
             while True:
@@ -442,9 +453,11 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                         data if isinstance(data, bytes) else data.encode()
                     )
 
-                    # Check if the response matches the query UUID
-                    if response.get("result", {}).get("id") == query_uuid:
-                        yield response["result"]["result"]
+                    notif = response.get("result")
+                    if isinstance(notif, dict) and self._live_notification_matches(
+                        query_uuid, notif
+                    ):
+                        yield notif
                 except Exception as e:
                     # Handle WebSocket or decoding errors
                     print("Error in live subscription:", e)

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -415,30 +415,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             result, unwrap=self._is_single_record_operation(record)
         )
 
-    @staticmethod
-    def _live_notification_matches(
-        query_uuid: str | UUID, notification: dict[str, Any]
-    ) -> bool:
-        """Return True if this push belongs to the given live query id."""
-        nid = notification.get("id")
-        if nid is None:
-            return False
-        return str(nid) == str(query_uuid)
-
     def subscribe_live(
         self,
         query_uuid: str | UUID,
     ) -> Generator[dict[str, Value], None, None]:
-        """
-        Subscribe to live updates for a given query UUID.
-
-        Args:
-            query_uuid (Union[str, UUID]): The query UUID to subscribe to.
-
-        Yields:
-            dict: Each live notification from the server (``action``, ``result``, ``id``,
-            ``record``, etc.), not only the changed record payload.
-        """
         try:
             while True:
                 try:
@@ -454,10 +434,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                     )
 
                     notif = response.get("result")
-                    if isinstance(notif, dict) and self._live_notification_matches(
-                        query_uuid, notif
-                    ):
-                        yield notif
+                    if isinstance(notif, dict):
+                        nid = notif.get("id")
+                        if nid is not None and str(nid) == str(query_uuid):
+                            yield notif
                 except Exception as e:
                     # Handle WebSocket or decoding errors
                     print("Error in live subscription:", e)

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -388,8 +388,12 @@ class SyncTemplate:
     ) -> Generator[dict[str, Value], None, None]:
         """Iterate live notifications for the given live query id.
 
-        Yields the full notification dict from the server (``action``, ``result``, ``id``,
-        ``record``, …), not only the changed record document.
+        Args:
+            query_uuid (Union[str, UUID]): The query UUID to subscribe to.
+
+        Yields:
+            dict: Each live notification from the server (``action``, ``result``, ``id``,
+            ``record``, etc.), not only the changed record payload.
         """
         raise NotImplementedError(f"subscribe_live not implemented for: {self}")
 

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -386,16 +386,10 @@ class SyncTemplate:
     def subscribe_live(
         self, query_uuid: str | UUID
     ) -> Generator[dict[str, Value], None, None]:
-        """Live notification returns a queue that receives notification messages from the back end.
+        """Iterate live notifications for the given live query id.
 
-        Args:
-            query_uuid: The uuid for the live query
-
-        Returns:
-            the notification queue
-
-        Example:
-            db.subscribe_live(UUID)
+        Yields the full notification dict from the server (``action``, ``result``, ``id``,
+        ``record``, …), not only the changed record document.
         """
         raise NotImplementedError(f"subscribe_live not implemented for: {self}")
 

--- a/tests/unit_tests/connections/subscribe_live/test_async_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_async_ws.py
@@ -26,8 +26,10 @@ async def test_live_subscription(
 
     try:
         update = await asyncio.wait_for(subscription.__anext__(), timeout=10)
-        assert update["name"] == "Jaime"
-        assert update["id"] == RecordID("user", "jaime")
+        assert update["action"] == "CREATE"
+        record = update["result"]
+        assert record["name"] == "Jaime"
+        assert record["id"] == RecordID("user", "jaime")
     except TimeoutError:
         pytest.fail("Timed out waiting for live subscription update")
 
@@ -54,8 +56,10 @@ async def test_live_subscription_via_query(
 
     try:
         update = await asyncio.wait_for(subscription.__anext__(), timeout=10)
-        assert update["name"] == "John"
-        assert update["id"] == RecordID("user", "john")
+        assert update["action"] == "CREATE"
+        record = update["result"]
+        assert record["name"] == "John"
+        assert record["id"] == RecordID("user", "john")
     except TimeoutError:
         pytest.fail("Timed out waiting for live subscription update")
 

--- a/tests/unit_tests/connections/subscribe_live/test_blocking_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_blocking_ws.py
@@ -26,8 +26,10 @@ def test_live_subscription(
     # Wait for the live subscription update
     try:
         for update in subscription:
-            assert update["name"] == "Jaime"
-            assert update["id"] == RecordID("user", "jaime")
+            assert update["action"] == "CREATE"
+            record = update["result"]
+            assert record["name"] == "Jaime"
+            assert record["id"] == RecordID("user", "jaime")
             break  # Exit after receiving the first update
     except Exception as e:
         pytest.fail(f"Error waiting for live subscription update: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -989,7 +989,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## What is the motivation?

Fixes https://github.com/surrealdb/surrealdb.py/issues/247 — callers expect each yielded value to include `action` and `result` (per docs). Previously only the inner record was yielded.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

Note: Restores documented behaviour but **breaks** code that assumed the old (undocumented) shape of a bare record. Changelog calls this out under [Unreleased].

## What does this change do?

- **Blocking WebSocket** (`subscribe_live`): yield the full server notification object; match the live id with `str(...)` for robustness.
- **Async WebSocket** (`subscribe_live`): yield the full object already stored on the live queue (was incorrectly narrowed to `ret["result"]`).
- Update template docstrings.
- **Tests**: assert `action` and nested record under `result`; add secondary WS fixtures so mutations do not race RPC vs live on one socket (same pattern as #249).

## What is your testing strategy?

- Unit tests updated for notification shape; CI integration tests against SurrealDB when available.

## Is this related to any issues?

Fixes #247

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md