### PR TITLE
Add QueryError.is_transaction_conflict

### DIFF
--- a/src/surrealdb/errors.py
+++ b/src/surrealdb/errors.py
@@ -92,6 +92,7 @@ class QueryDetailKind:
     NOT_EXECUTED = "NotExecuted"
     TIMED_OUT = "TimedOut"
     CANCELLED = "Cancelled"
+    TRANSACTION_CONFLICT = "TransactionConflict"
 
 
 class SerializationDetailKind:
@@ -274,6 +275,10 @@ class QueryError(ServerError):
     @property
     def is_cancelled(self) -> bool:
         return _detail_kind(self.details) == "Cancelled"
+
+    @property
+    def is_transaction_conflict(self) -> bool:
+        return _detail_kind(self.details) == "TransactionConflict"
 
     @property
     def timeout(self) -> dict[str, Any] | None:

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -278,6 +278,22 @@ class TestParseRpcErrorNewFormat:
         assert isinstance(err, QueryError)
         assert err.is_cancelled is True
 
+    def test_query_transaction_conflict(self) -> None:
+        err = parse_rpc_error(
+            {
+                "code": -32003,
+                "kind": "Query",
+                "message": "Transaction conflict",
+                "details": {"kind": "TransactionConflict"},
+            }
+        )
+        assert isinstance(err, QueryError)
+        assert err.is_transaction_conflict is True
+        assert err.is_not_executed is False
+        assert err.is_timed_out is False
+        assert err.is_cancelled is False
+        assert err.timeout is None
+
     def test_configuration_live_query_not_supported(self) -> None:
         err = parse_rpc_error(
             {
@@ -688,6 +704,7 @@ class TestDetailKindConstants:
         assert QueryDetailKind.NOT_EXECUTED == "NotExecuted"
         assert QueryDetailKind.TIMED_OUT == "TimedOut"
         assert QueryDetailKind.CANCELLED == "Cancelled"
+        assert QueryDetailKind.TRANSACTION_CONFLICT == "TransactionConflict"
 
     def test_serialization_detail_kinds(self) -> None:
         assert SerializationDetailKind.SERIALIZATION == "Serialization"


### PR DESCRIPTION
## Root cause

`src/surrealdb/errors.py` defines `QueryDetailKind` with `NOT_EXECUTED`, `TIMED_OUT`, and `CANCELLED`, and `QueryError` exposes matching `is_not_executed` / `is_timed_out` / `is_cancelled` properties. There is no way to detect a query that failed because it raced with a concurrent transaction (a `TransactionConflict`), even though that failure mode is specifically retryable.

This is a parity gap versus `surrealdb.js`, which already exposes `QueryError.isTransactionConflict` (`packages/sdk/src/errors.ts`, backed by `QueryErrorDetail`'s `{ kind: "TransactionConflict" }` variant, documented there as "safe to retry").

The wire-level `kind` string was confirmed against the SurrealDB server source (`surrealdb/types/src/error.rs`):

```rust
pub enum QueryError {
    NotExecuted,
    TimedOut { duration: Duration },
    Cancelled,
    TransactionConflict,
}
```

serialized with `#[surreal(tag = "kind", content = "details")]`, i.e. the wire value is the literal variant name `"TransactionConflict"` — matching the JS SDK's `QueryErrorDetail` union.

## Fix

- Added `QueryDetailKind.TRANSACTION_CONFLICT = "TransactionConflict"`.
- Added `QueryError.is_transaction_conflict`, implemented identically in style to `is_not_executed` / `is_timed_out` / `is_cancelled` (delegates to the existing `_detail_kind(self.details) == "TransactionConflict"` helper).
- Purely additive — no existing public API changed.

## Tests

Extended `tests/unit_tests/test_errors.py`:
- `TestParseRpcErrorNewFormat::test_query_transaction_conflict` — constructs a `QueryError` via `parse_rpc_error` with `details={"kind": "TransactionConflict"}` and asserts `is_transaction_conflict is True` while `is_not_executed`, `is_timed_out`, `is_cancelled`, and `timeout` are all `False`/`None`.
- `TestDetailKindConstants::test_query_detail_kinds` — extended to assert `QueryDetailKind.TRANSACTION_CONFLICT == "TransactionConflict"`.

Verified the new test fails without the fix (`git stash` the `errors.py` change and re-run): `AttributeError: 'QueryError' object has no attribute 'is_transaction_conflict'`. Restored the fix and it passes.

## Verification commands run (all passed)

```
uv sync --group dev
uv run ruff format --check --diff src/        # 71 files already formatted
uv run ruff check src/                        # All checks passed!
uv run mypy --explicit-package-bases src/     # Success: no issues found in 72 source files
uv run pyright src/                           # 0 errors, 0 warnings, 0 informations
uv run pytest tests/unit_tests/test_errors.py -v   # 93 passed
```

Also ran the full `tests/unit_tests/` suite; the only failures/errors are pre-existing `*_db_roundtrip` tests that require a live SurrealDB server on `localhost:8000` (connection refused in this sandbox), unrelated to this change. `test_errors.py` was fully green in that run as well.

No related GitHub issue exists for this gap (parity fix identified during SDK stabilization work), so per `CONTRIBUTING.md` the branch name omits the issue-number prefix.