### PR TITLE
Fix Range.__str__ producing invalid SurrealQL

### DIFF
--- a/src/surrealdb/data/types/range.py
+++ b/src/surrealdb/data/types/range.py
@@ -129,3 +129,25 @@ class Range:
         if isinstance(other, Range):
             return self.begin == other.begin and self.end == other.end
         return False
+
+    def __str__(self) -> str:
+        """
+        Renders the range as valid SurrealQL range syntax, e.g. ``1..10``,
+        ``1..=10``, ``1>..10`` or ``1>..=10`` depending on the bound types.
+
+        Returns:
+            The SurrealQL string representation of the range.
+        """
+        begin_value = (
+            self.begin.value
+            if isinstance(self.begin, (BoundIncluded, BoundExcluded))
+            else ""
+        )
+        end_value = (
+            self.end.value
+            if isinstance(self.end, (BoundIncluded, BoundExcluded))
+            else ""
+        )
+        marker = ">" if isinstance(self.begin, BoundExcluded) else ""
+        suffix = "=" if isinstance(self.end, BoundIncluded) else ""
+        return f"{begin_value}{marker}..{suffix}{end_value}"

--- a/tests/unit_tests/data_types/test_range.py
+++ b/tests/unit_tests/data_types/test_range.py
@@ -5,6 +5,7 @@ import pytest
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 from surrealdb.data import cbor
 from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
+from surrealdb.data.types.record_id import RecordID
 
 
 # Unit tests for Bound classes
@@ -84,6 +85,52 @@ def test_range_equality() -> None:
     assert range1 == range2
     assert range1 != range3
     assert range1 != range4
+
+
+# Unit tests for __str__ (SurrealQL rendering)
+def test_range_str_inclusive_inclusive() -> None:
+    """Test rendering an inclusive/inclusive range as SurrealQL."""
+    range_obj = Range(BoundIncluded(1), BoundIncluded(10))
+    assert str(range_obj) == "1..=10"
+
+
+def test_range_str_inclusive_exclusive() -> None:
+    """Test rendering an inclusive-start/exclusive-end range as SurrealQL."""
+    range_obj = Range(BoundIncluded(1), BoundExcluded(10))
+    assert str(range_obj) == "1..10"
+
+
+def test_range_str_exclusive_exclusive() -> None:
+    """Test rendering an exclusive/exclusive range as SurrealQL."""
+    range_obj = Range(BoundExcluded(0), BoundExcluded(100))
+    assert str(range_obj) == "0>..100"
+
+
+def test_range_str_exclusive_inclusive() -> None:
+    """Test rendering an exclusive-start/inclusive-end range as SurrealQL."""
+    range_obj = Range(BoundExcluded(0), BoundIncluded(100))
+    assert str(range_obj) == "0>..=100"
+
+
+def test_range_str_string_bounds() -> None:
+    """Test rendering a range with string bounds as SurrealQL."""
+    range_obj = Range(BoundIncluded("a"), BoundIncluded("z"))
+    assert str(range_obj) == "a..=z"
+
+
+def test_record_id_with_range_str() -> None:
+    """Test that a RecordID with a Range id renders valid SurrealQL, not a
+    Python dataclass repr."""
+    record_id = RecordID("user", Range(BoundIncluded(1), BoundIncluded(10)))
+    assert str(record_id) == "user:1..=10"
+    assert "Range(" not in str(record_id)
+
+
+def test_record_id_with_range_str_exclusive_end() -> None:
+    """Test RecordID rendering for an inclusive-start/exclusive-end range."""
+    record_id = RecordID("user", Range(BoundIncluded(1), BoundExcluded(10)))
+    assert str(record_id) == "user:1..10"
+    assert "Range(" not in str(record_id)
 
 
 # Unit tests for encoding


### PR DESCRIPTION
## Root cause

`src/surrealdb/data/types/range.py` defines `Range` as a plain dataclass with no `__str__` override. When a `Range` is used as the `.id` of a `RecordID`, `RecordID.__str__`'s catch-all branch (`f"{self.table_name}:{self.id}"`) falls through to Python's default dataclass repr, e.g.:

```
user:Range(begin=BoundIncluded(value=1), end=BoundIncluded(value=10))
```

instead of valid SurrealQL like `user:1..=10`. This is a silent correctness footgun for any code that builds queries via string interpolation (f-strings, logging, manual query construction) with a range-typed record id.

This is a parity gap vs. the golden-reference `surrealdb.js` SDK (which does render `RecordIdRange`/`Range` correctly via `toString()`), found during stabilization. No GitHub issue number exists for it yet.

## Fix

Added `Range.__str__`, rendering:
- `begin..end` (inclusive start / exclusive end)
- `begin..=end` (inclusive / inclusive)
- `begin>..end` (exclusive start / exclusive end)
- `begin>..=end` (exclusive start / inclusive end)

This matches the SurrealQL range grammar and mirrors `surrealdb.js`'s logic in `packages/sqon/src/value/range.ts` / `record-id-range.ts` and `packages/sqon/src/internal/range.ts::getRangeJoin`.

`RecordID.__str__` required no change — once `Range.__str__` exists, its existing catch-all f-string branch calls `str()` on the id automatically.

## Cross-check against `_RANGE_PATTERN`

Cross-checked the output against `_RANGE_PATTERN` in `src/surrealdb/connections/builders.py` (used to parse raw `"table:1..10"`-style range strings for CRUD builder targets). The inclusive-start forms (`begin..end`, `begin..=end`, including unbounded `..end` / `begin..`) round-trip through that regex exactly.

**Finding (out of scope, documented for visibility):** `_RANGE_PATTERN` does not support the exclusive-start `>..` syntax at all — its bound charset has no `>`. So a `Range` with an excluded begin bound now produces *correct* SurrealQL via `__str__`, but that string won't re-parse through this specific raw-string CRUD-builder path. This is a pre-existing, narrower gap in that regex (not introduced by this change) and is out of scope here — it's part of the larger typed-`RecordIdRange` CRUD-builder integration work tracked separately.

## Scope

This fix is limited to string-rendering correctness (`Range.__str__`). It does not touch the CRUD builders or add typed `RecordIdRange` support to `db.select()`/`db.create()`/etc. — that's tracked as separate future work.

## Verification

Run from the repo root:
- `uv run ruff format --check --diff src/` — pass
- `uv run ruff check src/` — pass
- `uv run mypy --explicit-package-bases src/` — pass (`Success: no issues found in 72 source files`)
- `uv run pyright src/` — pass (`0 errors, 0 warnings, 0 informations`)
- `uv run pytest tests/unit_tests/data_types/test_range.py -k "not db_roundtrip"` — 26 passed
- `uv run pytest tests/unit_tests -k "not db_roundtrip"` — same pre-existing 25 failed / 25 errors (all require a live SurrealDB server or the embedded extension, unrelated to this change) both before and after; 372 → 379 passed (the 7 new tests)

New tests were confirmed to fail against the pre-fix code (producing the dataclass repr) and pass after the fix, by temporarily stashing the source change and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)