### PR TITLE
Add __str__ to Datetime, Duration, and Geometry types

### DIFF
--- a/src/surrealdb/data/types/datetime.py
+++ b/src/surrealdb/data/types/datetime.py
@@ -1,3 +1,17 @@
+import json
+
+
 class Datetime:
     def __init__(self, dt: str):
         self.dt = dt
+
+    def __str__(self) -> str:
+        """
+        Renders the datetime as a valid SurrealQL datetime literal, e.g.
+        ``d"2025-02-03T12:30:45.123456Z"``. The ISO string is JSON-encoded to
+        get proper double-quote/backslash escaping.
+
+        Returns:
+            The SurrealQL string representation of the datetime.
+        """
+        return f"d{json.dumps(self.dt)}"

--- a/src/surrealdb/data/types/duration.py
+++ b/src/surrealdb/data/types/duration.py
@@ -91,11 +91,23 @@ class Duration:
         return self.elapsed // UNITS["y"]
 
     def to_string(self) -> str:
+        result = ""
+        remaining = self.elapsed
         for unit in ["y", "w", "d", "h", "m", "s", "ms", "us", "ns"]:
-            value = self.elapsed // UNITS[unit]
-            if value > 0:
-                return f"{value}{unit}"
-        return "0ns"
+            amount, remaining = divmod(remaining, UNITS[unit])
+            if amount > 0:
+                result += f"{amount}{unit}"
+        return result or "0ns"
+
+    def __str__(self) -> str:
+        """
+        Renders the duration as valid SurrealQL compact-unit syntax, e.g.
+        ``1h30m`` or ``500ms``. Equivalent to :meth:`to_string`.
+
+        Returns:
+            The SurrealQL string representation of the duration.
+        """
+        return self.to_string()
 
     def to_compact(self) -> list[int]:
         return [self.elapsed // UNITS["s"]]

--- a/src/surrealdb/data/types/geometry.py
+++ b/src/surrealdb/data/types/geometry.py
@@ -8,6 +8,33 @@ from typing import Any
 from surrealdb.errors import InvalidGeometryError
 
 
+def _coord_pair(point: "GeometryPoint") -> str:
+    """``[longitude, latitude]`` — a point's coordinates as they appear nested
+    inside another geometry's ``coordinates`` array (as opposed to a
+    standalone point, which renders as ``(longitude, latitude)``)."""
+    return f"[{point.longitude}, {point.latitude}]"
+
+
+def _points_coords(points: "list[GeometryPoint]") -> str:
+    return "[" + ", ".join(_coord_pair(p) for p in points) + "]"
+
+
+def _line_coords(line: "GeometryLine") -> str:
+    return _points_coords(line.geometry_points)
+
+
+def _rings_coords(lines: "list[GeometryLine]") -> str:
+    return "[" + ", ".join(_line_coords(line) for line in lines) + "]"
+
+
+def _polygon_coords(polygon: "GeometryPolygon") -> str:
+    return _rings_coords(polygon.geometry_lines)
+
+
+def _polygons_coords(polygons: "list[GeometryPolygon]") -> str:
+    return "[" + ", ".join(_polygon_coords(p) for p in polygons) + "]"
+
+
 class Geometry:
     """
     Base class for all geometry types. Provides the interface for retrieving coordinates
@@ -43,6 +70,15 @@ class GeometryPoint(Geometry):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(longitude={self.longitude}, latitude={self.latitude})"
+
+    def __str__(self) -> str:
+        """
+        Renders the point as a valid SurrealQL geometry literal, e.g. ``(1.23, 4.56)``.
+
+        Returns:
+            The SurrealQL string representation of the point.
+        """
+        return f"({self.longitude}, {self.latitude})"
 
     def get_coordinates(self) -> tuple[float, float]:
         """
@@ -102,6 +138,16 @@ class GeometryLine(Geometry):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometry_points)})"
+
+    def __str__(self) -> str:
+        """
+        Renders the line as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'LineString', coordinates: [[0.0, 0.0], [1.0, 1.0]] }``.
+
+        Returns:
+            The SurrealQL string representation of the line.
+        """
+        return f"{{ type: 'LineString', coordinates: {_line_coords(self)} }}"
 
     @staticmethod
     def parse_coordinates(coordinates: list[tuple[float, float]]) -> "GeometryLine":
@@ -227,6 +273,16 @@ class GeometryPolygon(Geometry):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometry_lines)})"
 
+    def __str__(self) -> str:
+        """
+        Renders the polygon as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'Polygon', coordinates: [[[0.0, 0.0], ...]] }``.
+
+        Returns:
+            The SurrealQL string representation of the polygon.
+        """
+        return f"{{ type: 'Polygon', coordinates: {_polygon_coords(self)} }}"
+
     @staticmethod
     def parse_coordinates(
         coordinates: list[list[tuple[float, float]]],
@@ -281,6 +337,16 @@ class GeometryMultiPoint(Geometry):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometry_points)})"
 
+    def __str__(self) -> str:
+        """
+        Renders the multi-point as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'MultiPoint', coordinates: [[1.0, 2.0], [3.0, 4.0]] }``.
+
+        Returns:
+            The SurrealQL string representation of the multi-point.
+        """
+        return f"{{ type: 'MultiPoint', coordinates: {_points_coords(self.geometry_points)} }}"
+
     @staticmethod
     def parse_coordinates(
         coordinates: list[tuple[float, float]],
@@ -329,6 +395,16 @@ class GeometryMultiLine(Geometry):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometry_lines)})"
+
+    def __str__(self) -> str:
+        """
+        Renders the multi-line as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'MultiLineString', coordinates: [[[0.0, 0.0], ...]] }``.
+
+        Returns:
+            The SurrealQL string representation of the multi-line.
+        """
+        return f"{{ type: 'MultiLineString', coordinates: {_rings_coords(self.geometry_lines)} }}"
 
     @staticmethod
     def parse_coordinates(
@@ -379,6 +455,16 @@ class GeometryMultiPolygon(Geometry):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometry_polygons)})"
 
+    def __str__(self) -> str:
+        """
+        Renders the multi-polygon as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'MultiPolygon', coordinates: [[[[0.0, 0.0], ...]]] }``.
+
+        Returns:
+            The SurrealQL string representation of the multi-polygon.
+        """
+        return f"{{ type: 'MultiPolygon', coordinates: {_polygons_coords(self.geometry_polygons)} }}"
+
     @staticmethod
     def parse_coordinates(
         coordinates: list[list[list[tuple[float, float]]]],
@@ -418,6 +504,18 @@ class GeometryCollection:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(repr(geo) for geo in self.geometries)})"
+
+    def __str__(self) -> str:
+        """
+        Renders the collection as a valid SurrealQL geometry literal, e.g.
+        ``{ type: 'GeometryCollection', geometries: [(1.0, 2.0), ...] }``.
+        Nested geometries render recursively via their own ``__str__``.
+
+        Returns:
+            The SurrealQL string representation of the collection.
+        """
+        geometries = ", ".join(str(geo) for geo in self.geometries)
+        return f"{{ type: 'GeometryCollection', geometries: [{geometries}] }}"
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, GeometryCollection):

--- a/tests/unit_tests/data_types/test_datetimes.py
+++ b/tests/unit_tests/data_types/test_datetimes.py
@@ -18,6 +18,18 @@ def test_datetime_encode() -> None:
     assert len(encoded) > 0
 
 
+def test_datetime_str() -> None:
+    """Test Datetime.__str__ produces a valid SurrealQL datetime literal (d"...")."""
+    dt = Datetime("2025-02-03T12:30:45.123456Z")
+    assert str(dt) == 'd"2025-02-03T12:30:45.123456Z"'
+
+
+def test_datetime_str_escapes_double_quotes() -> None:
+    """Test Datetime.__str__ escapes an embedded double quote in the ISO string."""
+    dt = Datetime('2025-02-03T12:30:45"Z')
+    assert str(dt) == 'd"2025-02-03T12:30:45\\"Z"'
+
+
 def test_datetime_custom_encode() -> None:
     """Test encoding Datetime wrapper to CBOR bytes."""
     iso_datetime = "2025-02-03T12:30:45.123456Z"

--- a/tests/unit_tests/data_types/test_duration.py
+++ b/tests/unit_tests/data_types/test_duration.py
@@ -164,9 +164,35 @@ def test_duration_to_string() -> None:
     assert Duration(604800 * 1_000_000_000).to_string() == "1w"
     assert Duration(365 * 86400 * 1_000_000_000).to_string() == "1y"
 
-    # Test compound duration (should use largest unit)
+    # Test compound duration (should combine all non-zero units, largest first)
     compound = Duration(3600 * 1_000_000_000 + 30 * 60 * 1_000_000_000)  # 1h30m
-    assert compound.to_string() == "1h"
+    assert compound.to_string() == "1h30m"
+
+
+def test_duration_to_string_compound_all_units() -> None:
+    """Test Duration.to_string with every unit non-zero, matching the parser's
+    own compound format (see test_duration_parse_str_compound) and the
+    server/JS/PHP SDKs' Display implementations."""
+    elapsed = (
+        (1 * 365 * 86400 * 1_000_000_000)
+        + (2 * 604800 * 1_000_000_000)
+        + (3 * 86400 * 1_000_000_000)
+        + (4 * 3600 * 1_000_000_000)
+        + (5 * 60 * 1_000_000_000)
+        + (6 * 1_000_000_000)
+        + (7 * 1_000_000)
+        + (8 * 1_000)
+        + 9
+    )
+    assert Duration(elapsed).to_string() == "1y2w3d4h5m6s7ms8us9ns"
+
+
+def test_duration_str() -> None:
+    """Test Duration.__str__ produces the same SurrealQL literal as to_string()."""
+    assert str(Duration(0)) == "0ns"
+    assert str(Duration(1000)) == "1us"
+    compound = Duration(3600 * 1_000_000_000 + 30 * 60 * 1_000_000_000)  # 1h30m
+    assert str(compound) == compound.to_string() == "1h30m"
 
 
 def test_duration_to_compact() -> None:

--- a/tests/unit_tests/data_types/test_geometry.py
+++ b/tests/unit_tests/data_types/test_geometry.py
@@ -304,6 +304,107 @@ def test_geometry_collection_roundtrip() -> None:
     assert isinstance(decoded, GeometryCollection)
 
 
+# Unit tests for __str__ (SurrealQL rendering)
+#
+# Point renders as a bare `(x, y)` literal; every other geometry renders as a
+# GeoJSON-shaped object literal with single-quoted `type` and recursively
+# formatted `coordinates`/`geometries` — matching the server's own
+# `Display`/`ToSql` for `Geometry` (surrealdb/types/src/value/geometry.rs).
+def test_geometry_point_str() -> None:
+    assert str(GeometryPoint(1.23, 4.56)) == "(1.23, 4.56)"
+    assert str(GeometryPoint(0.0, 0.0)) == "(0.0, 0.0)"
+
+
+def test_geometry_line_str() -> None:
+    line = GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+    assert str(line) == "{ type: 'LineString', coordinates: [[0.0, 0.0], [1.0, 1.0]] }"
+
+
+def test_geometry_polygon_str() -> None:
+    exterior = GeometryLine(
+        GeometryPoint(0.0, 0.0),
+        GeometryPoint(1.0, 0.0),
+        GeometryPoint(1.0, 1.0),
+        GeometryPoint(0.0, 0.0),  # Close the ring
+    )
+    polygon = GeometryPolygon(exterior)
+    assert str(polygon) == (
+        "{ type: 'Polygon', coordinates: "
+        "[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]] }"
+    )
+
+
+def test_geometry_polygon_with_hole_str() -> None:
+    exterior = GeometryLine(
+        GeometryPoint(0.0, 0.0),
+        GeometryPoint(10.0, 0.0),
+        GeometryPoint(10.0, 10.0),
+        GeometryPoint(0.0, 10.0),
+        GeometryPoint(0.0, 0.0),  # Close the ring
+    )
+    hole = GeometryLine(
+        GeometryPoint(2.0, 2.0),
+        GeometryPoint(4.0, 2.0),
+        GeometryPoint(4.0, 4.0),
+        GeometryPoint(2.0, 4.0),
+        GeometryPoint(2.0, 2.0),  # Close the ring
+    )
+    polygon = GeometryPolygon(exterior, hole)
+    assert str(polygon) == (
+        "{ type: 'Polygon', coordinates: "
+        "[[[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0], [0.0, 0.0]], "
+        "[[2.0, 2.0], [4.0, 2.0], [4.0, 4.0], [2.0, 4.0], [2.0, 2.0]]] }"
+    )
+
+
+def test_geometry_multipoint_str() -> None:
+    mp = GeometryMultiPoint(GeometryPoint(1.0, 2.0), GeometryPoint(3.0, 4.0))
+    assert str(mp) == "{ type: 'MultiPoint', coordinates: [[1.0, 2.0], [3.0, 4.0]] }"
+
+
+def test_geometry_multiline_str() -> None:
+    ml = GeometryMultiLine(
+        GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0)),
+        GeometryLine(GeometryPoint(2.0, 2.0), GeometryPoint(3.0, 3.0)),
+    )
+    assert str(ml) == (
+        "{ type: 'MultiLineString', coordinates: "
+        "[[[0.0, 0.0], [1.0, 1.0]], [[2.0, 2.0], [3.0, 3.0]]] }"
+    )
+
+
+def test_geometry_multipolygon_str() -> None:
+    exterior1 = GeometryLine(
+        GeometryPoint(0.0, 0.0),
+        GeometryPoint(1.0, 0.0),
+        GeometryPoint(1.0, 1.0),
+        GeometryPoint(0.0, 0.0),  # Close the ring
+    )
+    exterior2 = GeometryLine(
+        GeometryPoint(5.0, 5.0),
+        GeometryPoint(6.0, 5.0),
+        GeometryPoint(6.0, 6.0),
+        GeometryPoint(5.0, 5.0),  # Close the ring
+    )
+    mp = GeometryMultiPolygon(GeometryPolygon(exterior1), GeometryPolygon(exterior2))
+    assert str(mp) == (
+        "{ type: 'MultiPolygon', coordinates: "
+        "[[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]], "
+        "[[[5.0, 5.0], [6.0, 5.0], [6.0, 6.0], [5.0, 5.0]]]] }"
+    )
+
+
+def test_geometry_collection_str() -> None:
+    gc = GeometryCollection(
+        GeometryPoint(1.1, 2.2),
+        GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0)),
+    )
+    assert str(gc) == (
+        "{ type: 'GeometryCollection', geometries: "
+        "[(1.1, 2.2), { type: 'LineString', coordinates: [[0.0, 0.0], [1.0, 1.0]] }] }"
+    )
+
+
 @pytest.fixture
 async def surrealdb_connection():  # type: ignore[misc]
     url = "ws://localhost:8000/rpc"


### PR DESCRIPTION
## Root cause

Follow-up to #269 (`Range.__str__` producing invalid SurrealQL). A sweep of every value type in `src/surrealdb/data/types/` against the `Value` union in `src/surrealdb/types.py` found the same class of gap in `Datetime`, `Duration`, and all 7 `Geometry` classes: none had `__str__`, so `str(value)` (or any f-string/print/manual query-building over one) fell through to Python's default `object.__str__` (`<surrealdb.data.types.datetime.Datetime object at 0x...>`) instead of producing anything resembling SurrealQL.

`Table`, `RecordID`, and (as of #269) `Range` already do this correctly — everything else in the `Value` union (`str`, `int`, `float`, `bool`, `None`, `bytes`, `uuid.UUID`, `decimal.Decimal`) is either a plain builtin or already has a correct `__str__` from the standard library.

## Ground truth used

Cross-checked the exact literal syntax against:
- The server's own canonical rendering: `surrealdb/core/src/val/datetime.rs` (`Display`/`ToSql`), `surrealdb/core/src/val/duration.rs`, `surrealdb/types/src/value/geometry.rs`.
- The PHP SDK's equivalent types (per the task that prompted this): `surrealdb.php/src/Types/{DateTime,Duration,Geometry*}.php`.
- The JS SDK's `Duration.toString()` (`packages/sqon/src/value/duration.ts`), used to confirm a bug (see below).

## What changed

- **`Datetime.__str__`** — a `d"..."`-prefixed, JSON-escaped ISO-8601 literal (e.g. `d"2025-02-03T12:30:45.123456Z"`), matching the server's `ToSql` impl and PHP's `escape()`. The bare ISO string alone (the server's `Display`, no prefix) would not be valid SurrealQL on its own — it needs the `d` prefix to be parsed as a datetime rather than a plain string.
- **`Duration.__str__`** — delegates to the existing `to_string()`. In the process, found and fixed a real bug in `to_string()`: it returned as soon as it found the *first* non-zero unit (largest first), silently discarding the remainder — e.g. a duration of 1h30m rendered as `"1h"`, losing the 30 minutes entirely. The server's Rust `Display`, the JS SDK's `toString()`, and the PHP SDK's `__toString()` all accumulate *every* non-zero unit. Fixed to match (`1h30m`), and updated the one existing test that had locked in the old (wrong) single-unit behavior.
- **`Geometry.__str__`** (7 classes) — `GeometryPoint` renders as a bare `(x, y)` tuple literal (SurrealQL's dedicated point syntax); the other six kinds render as a GeoJSON-shaped object literal with recursively-formatted `coordinates`/`geometries` (e.g. `{ type: 'LineString', coordinates: [[0.0, 0.0], [1.0, 1.0]] }`), matching the server's `Display` exactly — including that `MultiPolygon` nests polygon → ring → point, and `GeometryCollection` recurses through each member's own `__str__` (so a nested point still renders as `(x, y)`, not a `Point` object literal).

## Deliberately not changed

- `Bound`/`BoundIncluded`/`BoundExcluded` still have no standalone `__str__`, matching the PHP SDK's design — only the composite `Range` renders bounds (via `.value` access, not `str()` on the bound itself).

## Verification

- Added failing-first unit tests for every new `__str__` (`test_datetimes.py`, `test_duration.py`, `test_geometry.py`) plus a new test asserting the fixed `Duration.to_string()` compound-unit behavior; confirmed all 13 new/updated assertions failed against the pre-fix code, then passed after.
- `uv run pytest tests/unit_tests -m "not asyncio"`: 375 passed (target files: 213 passed, 0 failed). The only failures in the full run are 12 pre-existing, unrelated `embedded` engine tests that fail identically on unmodified `main` in this sandbox (missing the optional `surrealdb[embedded]` extra) — confirmed by running them against main directly.
- `uv run ruff format --check`, `uv run ruff check`, `uv run mypy --explicit-package-bases`, `uv run pyright`: all clean on the touched files.