### PR TITLE
Export escape_identifier and document RecordID.id's escaping contract

### DIFF
--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -61,7 +61,7 @@ from surrealdb.data.types.datetime import Datetime
 from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.range import Range
-from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.record_id import RecordID, escape_identifier
 from surrealdb.data.types.table import Table
 from surrealdb.spectron import (
     AsyncSpectron,
@@ -137,6 +137,7 @@ __all__ = [
     "Datetime",
     "Tokens",
     "Value",
+    "escape_identifier",
     # Errors – base
     "SurrealError",
     # Errors – server

--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -53,6 +53,18 @@ class RecordID:
     """
     An identifier of the record. This class houses the ID of the row, and the table name.
 
+    To reference a record in a query, prefer binding the whole ``RecordID``
+    as a query variable — it is transmitted as a typed CBOR value, never
+    concatenated into query text, so no escaping (or injection) is possible
+    by construction::
+
+        db.query("RELATE $a->owns->$b;", vars={"a": alice, "b": record_id})
+        db.query("SELECT * FROM $rid;", vars={"rid": record_id})
+
+    Note that only the *whole* record id can be bound: SurrealQL does not
+    accept a variable as just the id part of a record-id literal
+    (``company:$id`` is a parse error).
+
     Attributes:
         table_name: The table name associated with the record ID. This is
             the raw, unescaped table name.
@@ -61,12 +73,13 @@ class RecordID:
             SurrealQL needs to tell it apart from a numeric id of the same
             digits (e.g. the string id ``"231"`` vs. the numeric id
             ``231``). Interpolating ``.id`` directly into a hand-built
-            query string is unsafe for exactly this reason; use
-            ``str(record_id)`` for the full ``table:id`` target, or
-            ``surrealdb.escape_identifier(str(record_id.id))`` if you only
-            need the escaped id fragment (e.g. combined with a table name
-            you already have on hand, as when building a ``RELATE``
-            target).
+            query string is unsafe for exactly this reason. When you cannot
+            bind (composing query *text*, e.g. for logs, migration files,
+            or an ``INSERT`` target — the one spot where the server rejects
+            parameter binding), use ``str(record_id)`` for the full
+            ``table:id`` target, or
+            ``surrealdb.escape_identifier(str(record_id.id))`` for just the
+            escaped id fragment.
     """
 
     def __init__(self, table_name: str, identifier: Any) -> None:

--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -54,8 +54,19 @@ class RecordID:
     An identifier of the record. This class houses the ID of the row, and the table name.
 
     Attributes:
-        table_name: The table name associated with the record ID
-        identifier: The ID of the row
+        table_name: The table name associated with the record ID. This is
+            the raw, unescaped table name.
+        id: The ID of the row. This is the raw, unescaped value — for a
+            string id, it does **not** carry the quoting information
+            SurrealQL needs to tell it apart from a numeric id of the same
+            digits (e.g. the string id ``"231"`` vs. the numeric id
+            ``231``). Interpolating ``.id`` directly into a hand-built
+            query string is unsafe for exactly this reason; use
+            ``str(record_id)`` for the full ``table:id`` target, or
+            ``surrealdb.escape_identifier(str(record_id.id))`` if you only
+            need the escaped id fragment (e.g. combined with a table name
+            you already have on hand, as when building a ``RELATE``
+            target).
     """
 
     def __init__(self, table_name: str, identifier: Any) -> None:

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -184,11 +184,13 @@ def test_record_id_direct_id_interpolation_is_unsafe() -> None:
     unescaped identifier — interpolating it directly into a hand-built query
     string silently changes its meaning for id values that need quoting
     (e.g. an all-digit string id, which is otherwise indistinguishable from
-    a numeric id). ``str(record_id)`` (or ``escape_identifier`` on just the
-    id part) is the documented-safe way to embed a record id in SurrealQL
-    text; this test exists so nobody "fixes" this by silently changing
-    ``.id`` itself, which would break the documented, tested contract that
-    ``.id`` returns the identifier's plain Python value.
+    a numeric id). The recommended fix is to bind the whole ``RecordID`` as
+    a query variable (no query-text composition at all — see
+    ``test_relate_with_bound_record_id_vars``); when text must be composed,
+    ``str(record_id)`` (or ``escape_identifier`` on just the id part) is
+    the safe rendering. This test exists so nobody "fixes" this by silently
+    changing ``.id`` itself, which would break the documented, tested
+    contract that ``.id`` returns the identifier's plain Python value.
     """
     record_id = RecordID("company", "231")
 
@@ -196,7 +198,7 @@ def test_record_id_direct_id_interpolation_is_unsafe() -> None:
     unsafe = f"company:{record_id.id}"
     assert unsafe == "company:231"  # indistinguishable from the numeric id 231
 
-    # The documented-safe patterns:
+    # The safe text renderings, for when binding isn't possible:
     assert str(record_id) == "company:⟨231⟩"
     assert f"company:{escape_identifier(str(record_id.id))}" == "company:⟨231⟩"
 
@@ -471,21 +473,21 @@ async def test_create_with_object_record_id(surrealdb_connection: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_relate_with_manually_quoted_numeric_string_id(
+async def test_relate_with_bound_record_id_vars(
     surrealdb_connection: Any,
 ) -> None:
-    """Regression test for issue #265: relating to a record whose id is a
-    backtick-quoted numeric string (e.g. ``company:`231` ``, a *string* id
-    "231", distinct from the *numeric* id 231) must target that exact
-    record when the relation is built with the documented-safe pattern
-    (``escape_identifier`` on the id part, or ``str(record_id)`` for the
-    full target) — not by interpolating ``record_id.id`` directly, which
-    silently drops the quoting and targets the wrong (non-existent)
-    numeric-id record instead.
+    """Regression test for issue #265 — the recommended pattern: bind the
+    whole ``RecordID`` as a query variable. The value travels as a typed
+    CBOR record id, never as query text, so quoting/escaping cannot be
+    dropped and injection is impossible by construction. Note SurrealQL
+    only accepts a variable as the *whole* record id — a variable as just
+    the id part of a literal (``record_id_tests:$id``) is a parse error,
+    which is why the fallback text patterns below exist at all.
     """
     await surrealdb_connection.query(
         "DEFINE TABLE IF NOT EXISTS owns TYPE RELATION IN record_id_tests OUT record_id_tests;"
     )
+    await surrealdb_connection.query("DELETE owns;")
     await surrealdb_connection.query("CREATE record_id_tests:alice SET name = 'Alice';")
     await surrealdb_connection.query(
         "CREATE record_id_tests:`231` SET name = 'Quoted Company';"
@@ -497,7 +499,77 @@ async def test_relate_with_manually_quoted_numeric_string_id(
     quoted_id = quoted_res[0]["id"]
     assert quoted_id.id == "231"  # the raw id is the plain string "231"
 
-    # The documented-safe pattern: escape just the id part before
+    await surrealdb_connection.query(
+        "RELATE $a->owns->$b;",
+        vars={"a": RecordID("record_id_tests", "alice"), "b": quoted_id},
+    )
+
+    result = await surrealdb_connection.query(
+        "SELECT ->owns->record_id_tests.* AS companies FROM record_id_tests:alice;"
+    )
+    companies = result[0]["companies"]
+    assert len(companies) == 1
+    assert companies[0]["name"] == "Quoted Company"
+
+
+@pytest.mark.asyncio
+async def test_bound_record_id_var_treats_hostile_id_as_inert_data(
+    surrealdb_connection: Any,
+) -> None:
+    """A RecordID whose id contains SurrealQL syntax is inert when bound as
+    a variable — it stays a plain string id and cannot alter the statement.
+    (With interpolation this exact value would need careful escaping to not
+    change the query's meaning; with binding the question never arises.)
+    """
+    await surrealdb_connection.query(
+        "DEFINE TABLE IF NOT EXISTS owns TYPE RELATION IN record_id_tests OUT record_id_tests;"
+    )
+    await surrealdb_connection.query("DELETE owns;")
+    await surrealdb_connection.query("CREATE record_id_tests:alice SET name = 'Alice';")
+
+    hostile = RecordID("record_id_tests", "x; REMOVE TABLE record_id_tests; --")
+    res = await surrealdb_connection.query(
+        "RELATE $a->owns->$b;",
+        vars={"a": RecordID("record_id_tests", "alice"), "b": hostile},
+    )
+    assert res[0]["out"] == hostile  # edge points at the literal string id
+
+    # The table (and alice) survived: the hostile id was data, not syntax.
+    alive = await surrealdb_connection.query("SELECT * FROM record_id_tests:alice;")
+    assert alive[0]["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_relate_with_manually_quoted_numeric_string_id(
+    surrealdb_connection: Any,
+) -> None:
+    """Regression test for issue #265 — the fallback pattern, for contexts
+    where the query *text* itself must be composed and binding is not an
+    option: relating to a record whose id is a backtick-quoted numeric
+    string (e.g. ``company:`231` ``, a *string* id "231", distinct from the
+    *numeric* id 231) must target that exact record when the relation is
+    built with ``escape_identifier`` on the id part (or ``str(record_id)``
+    for the full target) — not by interpolating ``record_id.id`` directly,
+    which silently drops the quoting and targets the wrong (non-existent)
+    numeric-id record instead. Prefer binding the whole RecordID as a var
+    (see ``test_relate_with_bound_record_id_vars``) whenever possible.
+    """
+    await surrealdb_connection.query(
+        "DEFINE TABLE IF NOT EXISTS owns TYPE RELATION IN record_id_tests OUT record_id_tests;"
+    )
+    await surrealdb_connection.query("DELETE owns;")
+    await surrealdb_connection.query("CREATE record_id_tests:alice SET name = 'Alice';")
+    await surrealdb_connection.query(
+        "CREATE record_id_tests:`231` SET name = 'Quoted Company';"
+    )
+
+    quoted_res = await surrealdb_connection.query(
+        "SELECT * FROM record_id_tests:`231`;"
+    )
+    quoted_id = quoted_res[0]["id"]
+    assert quoted_id.id == "231"  # the raw id is the plain string "231"
+
+    # The fallback text pattern: escape just the id part before
     # interpolating it next to a literal table name.
     safe_query = f"RELATE record_id_tests:alice->owns->record_id_tests:{escape_identifier(str(quoted_id.id))};"
     await surrealdb_connection.query(safe_query)
@@ -512,12 +584,14 @@ async def test_relate_with_manually_quoted_numeric_string_id(
 
 class TestEscapeIdentifierTopLevelExport:
     """escape_identifier is exported from the top-level ``surrealdb``
-    package (not just ``surrealdb.data.types.record_id``) so callers who
-    need to safely interpolate just an id/table fragment into hand-built
-    SurrealQL — e.g. when combining a known table name with an existing
-    RecordID's ``.id`` — have a supported, discoverable way to do it,
-    instead of reaching into an internal module path or (as in #265)
-    interpolating the raw, unescaped value directly.
+    package (not just ``surrealdb.data.types.record_id``) for the cases
+    where query *text* must be composed and parameter binding is not
+    available — most notably ``INSERT`` targets, which the server refuses
+    to accept as a bound parameter (the SDK's own insert builder uses this
+    same helper for exactly that), plus logs/codegen/migration files.
+    For live queries, prefer binding the whole ``RecordID`` as a variable
+    instead of interpolating anything (see
+    ``test_relate_with_bound_record_id_vars``).
     """
 
     def test_importable_from_top_level_package(self) -> None:

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -179,6 +179,28 @@ def test_record_id_str_with_angle_bracket_escape() -> None:
     assert str(record_id) == "test:⟨foo\\⟩bar⟩"
 
 
+def test_record_id_direct_id_interpolation_is_unsafe() -> None:
+    """Pin the exact footgun reported in issue #265: ``.id`` is the raw,
+    unescaped identifier — interpolating it directly into a hand-built query
+    string silently changes its meaning for id values that need quoting
+    (e.g. an all-digit string id, which is otherwise indistinguishable from
+    a numeric id). ``str(record_id)`` (or ``escape_identifier`` on just the
+    id part) is the documented-safe way to embed a record id in SurrealQL
+    text; this test exists so nobody "fixes" this by silently changing
+    ``.id`` itself, which would break the documented, tested contract that
+    ``.id`` returns the identifier's plain Python value.
+    """
+    record_id = RecordID("company", "231")
+
+    # The unsafe pattern from #265: f"...company:{record_id.id}..."
+    unsafe = f"company:{record_id.id}"
+    assert unsafe == "company:231"  # indistinguishable from the numeric id 231
+
+    # The documented-safe patterns:
+    assert str(record_id) == "company:⟨231⟩"
+    assert f"company:{escape_identifier(str(record_id.id))}" == "company:⟨231⟩"
+
+
 def test_record_id_equality() -> None:
     """Test RecordID equality."""
     record_id1 = RecordID("users", "john")
@@ -446,6 +468,63 @@ async def test_create_with_object_record_id(surrealdb_connection: Any) -> None:
     assert result["id"] == record_id
     assert result["settings"]["active"] is True
     assert result["settings"]["marketing"] is True
+
+
+@pytest.mark.asyncio
+async def test_relate_with_manually_quoted_numeric_string_id(
+    surrealdb_connection: Any,
+) -> None:
+    """Regression test for issue #265: relating to a record whose id is a
+    backtick-quoted numeric string (e.g. ``company:`231` ``, a *string* id
+    "231", distinct from the *numeric* id 231) must target that exact
+    record when the relation is built with the documented-safe pattern
+    (``escape_identifier`` on the id part, or ``str(record_id)`` for the
+    full target) — not by interpolating ``record_id.id`` directly, which
+    silently drops the quoting and targets the wrong (non-existent)
+    numeric-id record instead.
+    """
+    await surrealdb_connection.query(
+        "DEFINE TABLE IF NOT EXISTS owns TYPE RELATION IN record_id_tests OUT record_id_tests;"
+    )
+    await surrealdb_connection.query("CREATE record_id_tests:alice SET name = 'Alice';")
+    await surrealdb_connection.query(
+        "CREATE record_id_tests:`231` SET name = 'Quoted Company';"
+    )
+
+    quoted_res = await surrealdb_connection.query(
+        "SELECT * FROM record_id_tests:`231`;"
+    )
+    quoted_id = quoted_res[0]["id"]
+    assert quoted_id.id == "231"  # the raw id is the plain string "231"
+
+    # The documented-safe pattern: escape just the id part before
+    # interpolating it next to a literal table name.
+    safe_query = f"RELATE record_id_tests:alice->owns->record_id_tests:{escape_identifier(str(quoted_id.id))};"
+    await surrealdb_connection.query(safe_query)
+
+    result = await surrealdb_connection.query(
+        "SELECT ->owns->record_id_tests.* AS companies FROM record_id_tests:alice;"
+    )
+    companies = result[0]["companies"]
+    assert len(companies) == 1
+    assert companies[0]["name"] == "Quoted Company"
+
+
+class TestEscapeIdentifierTopLevelExport:
+    """escape_identifier is exported from the top-level ``surrealdb``
+    package (not just ``surrealdb.data.types.record_id``) so callers who
+    need to safely interpolate just an id/table fragment into hand-built
+    SurrealQL — e.g. when combining a known table name with an existing
+    RecordID's ``.id`` — have a supported, discoverable way to do it,
+    instead of reaching into an internal module path or (as in #265)
+    interpolating the raw, unescaped value directly.
+    """
+
+    def test_importable_from_top_level_package(self) -> None:
+        import surrealdb
+
+        assert surrealdb.escape_identifier is escape_identifier
+        assert surrealdb.escape_identifier("231") == "⟨231⟩"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #265 (partially — see "What this does and doesn't fix" below; this is not a behavior-changing bug fix, it's closing the discoverability/documentation gap that caused the reported footgun).

## Reproduction

Ran the reporter's exact script against a local SurrealDB 3.2.0 instance (`surreal start memory`). Confirmed the bug: creating `company:`231`` (a **string** id `"231"`), then building a `RELATE` target by interpolating `RecordID.id` directly (`f"...company:{quoted_id.id};"`) produces `company:231` — parsed as the **numeric** id `231`, a different (non-existent) record. The relation silently resolves to `None`:

```
QUOTED COMPANY
repr: RecordID(table_name=company, record_id='231')
str : company:⟨231⟩
type of id: <class 'str'>

EDGE QUERY QUOTED
        RELATE person:alice->owns->company:231;

CONNECTED COMPANIES
[{'companies': [{'id': ..., 'name': 'Auto Company'}, None]}]
```

## Root cause

`RecordID.id` is deliberately the raw, unescaped Python value — this matches the golden-reference JS SDK exactly (`RecordId.id` getter in `packages/sqon/src/value/record-id.ts` is equally raw; `escapeIdPart`/`escapeIdent` in `utils/escape.ts` are internal-only, not exported from the package). So this isn't a design bug to fix by changing `.id`'s behavior — that would break the documented, already-tested contract that `.id` returns the plain value (needed for comparisons, dict keys, etc.), and would diverge from the JS reference.

The SDK's escaping logic is already correct and already tested: `str(record_id)` renders `company:⟨231⟩` correctly (see `test_record_id_str_with_short_numeric_string`, which pins exactly this case). The bug is entirely in the reporter's code using `.id` directly instead of `str(record_id)`.

## What this does and doesn't fix

**Doesn't fix**: no behavior changed. `RecordID.id` still returns the raw value; `str(record_id)` still renders the escaped `table:id` form. Both already worked correctly before this PR.

**Does fix**: the actual usability gap that caused the reporter to hit this in the first place —
1. `escape_identifier` (the function `RecordID.__str__` already uses internally) was only importable via `surrealdb.data.types.record_id`, an internal module path — not discoverable, not part of the supported public API. Exported it from the top-level `surrealdb` package, so callers who need to combine a known table name with an existing record's id (e.g. building a `RELATE` target, since there's no `relate()` builder in this SDK yet) have a supported, safe tool instead of reaching into internals or interpolating the raw value.
2. `RecordID`'s docstring said nothing about `.id` being unsafe to interpolate directly. Documented it, pointing at `str(record_id)` (full target) and `escape_identifier(str(record_id.id))` (id-only fragment) as the safe patterns.

## Verification

- Reproduced the bug against a live local server, then re-ran the exact same scenario using `escape_identifier()` on the id part — both companies now correctly link. See the new integration test below for the automated version of this.
- New tests in `test_record_id.py`:
  - `test_record_id_direct_id_interpolation_is_unsafe` — unit-level, pins the exact footgun and the two safe alternatives.
  - `test_relate_with_manually_quoted_numeric_string_id` — live-DB integration test replicating the reported `RELATE` scenario end to end.
  - `TestEscapeIdentifierTopLevelExport::test_importable_from_top_level_package` — confirms the new export.
- `uv run pytest tests/unit_tests` (unit + integration against local `surreal start memory`): all pass except 12 pre-existing, unrelated `embedded`-extra failures that fail identically on unmodified `main` (missing the optional `surrealdb[embedded]` package in this sandbox).
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/ tests/` (matching `scripts/checks.sh`, i.e. how CI actually invokes them — `src/surrealdb/__init__.py` is deliberately `ruff`-excluded in `pyproject.toml`), `uv run mypy --explicit-package-bases src/ tests/`, `uv run pyright`: all clean.