### PR TITLE
Release 3.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0]
+## [3.0.0-alpha.1] - 2026-07-13
 ### Added
 - New awaitable / lazy CRUD builder pattern. `create`, `update`, `upsert`, `delete`, and `insert` now return a builder that exposes chainable clause methods (`.content` / `.replace` / `.merge` / `.patch`) and is awaitable (async) or auto-executing on consumption (sync).
 - `.insert(table, data, relation=True)` (and the equivalent `.insert(table).relation().content(data)` chain) replaces the standalone `insert_relation` method.
@@ -126,8 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0...HEAD
-[3.0.0]: https://github.com/surrealdb/surrealdb.py/compare/v2.0.1...v3.0.0
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.1...HEAD
+[3.0.0-alpha.1]: https://github.com/surrealdb/surrealdb.py/compare/v2.0.1...v3.0.0-alpha.1
 [2.0.1]: https://github.com/surrealdb/surrealdb.py/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/surrealdb/surrealdb.py/compare/v2.0.0-alpha.1...v2.0.0
 [2.0.0-alpha.1]: https://github.com/surrealdb/surrealdb.py/compare/v1.0.8...v2.0.0-alpha.1

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0"
+version = "3.0.0-alpha.1"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0"
+version = "3.0.0-alpha.1"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"
 keywords = ["SurrealDB", "Database", "Embedded"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0"
+version = "3.0.0-alpha.1"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 keywords = ["SurrealDB", "Database"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
@@ -41,7 +41,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0",
+    "surrealdb-embedded==3.0.0-alpha.1",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0"
+version = "3.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1563,7 +1563,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0"
+version = "3.0.0a1"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Prepares the first pre-release on the 3.0.0 track.

## Changes
- Bump `surrealdb` and `surrealdb-embedded` to `3.0.0-alpha.1` (normalizes to `3.0.0a1` under PEP 440 on PyPI, and is automatically flagged as a pre-release).
- Keep the `surrealdb[embedded]` extra pin in lockstep (`surrealdb-embedded==3.0.0-alpha.1`) so the two packages release together.
- Bump `embedded/Cargo.toml` to match.
- Rename the `CHANGELOG` entry `[3.0.0]` → `[3.0.0-alpha.1]` (dated) and fix the compare links.
- Set the `Development Status` classifier to `3 - Alpha` on both packages.
- Refresh `uv.lock`.

## Release mechanics
Merging this does **not** publish anything. Publishing a GitHub Release tagged `v3.0.0-alpha.1` (marked as a pre-release) triggers `build.yml`, which builds both packages and pushes them to PyPI via trusted publishing. Version is read from the `pyproject.toml` files, not the tag.

## Install (once published)
Pre-releases are not selected by default:
```
pip install --pre surrealdb
# or
pip install surrealdb==3.0.0a1
```