### PR TITLE
Fix corrupted gh-action-pypi-publish SHA in release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54f72e44af3bbc36a592153 # v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           skip-existing: true
 
@@ -240,6 +240,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54f72e44af3bbc36a592153 # v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           skip-existing: true


### PR DESCRIPTION
## Problem
The v3.0.0-alpha.1 release build ([run 29283897316](https://github.com/surrealdb/surrealdb.py/actions/runs/29283897316)) failed: both `release-python` and `release-embedded` died at **Set up job** with:

> Unable to resolve action `pypa/gh-action-pypi-publish@76f52bc884231f62b54f72e44af3bbc36a592153`, unable to find version

## Cause
The pinned SHA is a **corrupted** copy of the `v1.12.4` tag's real commit SHA:
- workflow: `76f52bc884231f62b54f72e44af3bbc36a592153` (does not exist)
- real v1.12.4: `76f52bc884231f62b9a034ebfe128415bbaabdfc`

Identical `76f52bc884231f62b` prefix, then garbled — a classic bad copy/paste. The wheels + sdist all built fine; only the two publish jobs were affected, and **nothing reached PyPI**, so `3.0.0a1` is still available.

## Fix
Repin both `release-*` jobs to the correct `v1.12.4` commit SHA.

Workflow-only change; no source/test impact.