### PR TITLE
Fix PyPI publish: pin v1.14.0, enable manual dispatch, drop Discord

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,9 @@ jobs:
   release-python:
     name: Release surrealdb to PyPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: >-
+      (github.event_name == 'release' && github.event.action == 'published') ||
+      github.event_name == 'workflow_dispatch'
     needs: [build-python]
     environment:
       name: pypi
@@ -217,7 +219,9 @@ jobs:
   release-embedded:
     name: Release surrealdb-embedded to PyPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: >-
+      (github.event_name == 'release' && github.event.action == 'published') ||
+      github.event_name == 'workflow_dispatch'
     needs: [linux, linux-aarch64, macos, windows, sdist]
     environment:
       name: pypi-embedded

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
 
@@ -240,6 +240,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true

--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -67,31 +67,3 @@ jobs:
                 body: `🚀 This PR is included in [${tag}](${releaseUrl})`
               });
             }
-
-  notify-discord:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Discord notification
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          RELEASE_BODY_JSON: ${{ toJSON(github.event.release.body) }}
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          RELEASE_URL="${{ github.event.release.html_url }}"
-          RELEASE_NAME="${{ github.event.release.name }}"
-          if [ ${#RELEASE_BODY_JSON} -gt 1800 ]; then
-            BODY="\"$(echo $RELEASE_BODY_JSON | head -c 1796 | cut -c2-)...\""
-          else
-            BODY=$RELEASE_BODY_JSON
-          fi
-
-          curl -s -X POST "$DISCORD_WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"embeds\": [{
-                \"title\": \"New Release: ${RELEASE_NAME:-$TAG}\",
-                \"url\": \"$RELEASE_URL\",
-                \"description\": $BODY,
-                \"color\": 16711840
-              }]
-            }"


### PR DESCRIPTION
Gets the v3.0.0-alpha.1 (and future) PyPI publish working, and makes it re-runnable without recreating the release.

## 1. Pin gh-action-pypi-publish to v1.14.0
The release build failed at **Set up job**:
> The action `actions/setup-python@v5` is not allowed because all actions must be pinned to a full-length commit SHA.

`gh-action-pypi-publish@v1.12.4` is a composite action whose internal `uses: actions/setup-python@v5` is an unpinned tag, which the repo's SHA-pin policy rejects. From v1.13.0 the action SHA-pins that dependency (`actions/setup-python@a26af69… # v5.6.0`), so **v1.14.0** (`cef221092…`) is compliant. Verified its only `uses:` refs are that pinned `setup-python` and a local generated action. Retains OIDC trusted publishing + adds PEP 740 attestations.

## 2. Enable manual publish (`workflow_dispatch`)
`release-python` / `release-embedded` now also run on `workflow_dispatch`, so publishing can be re-attempted from the Actions tab or `gh workflow run build.yml --ref main` — no need to delete/recreate the GitHub release to retry.

## 3. Remove Discord notification
Dropped the `notify-discord` job from `release-comment.yml`.

Nothing has been published to PyPI yet, so `3.0.0a1` is still available.