### PR TITLE
Data type fixes: hashability, Datetime dunders, RecordID.parse

### DIFF
--- a/src/surrealdb/data/models.py
+++ b/src/surrealdb/data/models.py
@@ -54,7 +54,7 @@ class GraphQLOptions:
 
 def table_or_record_id(resource_str: str) -> Table | RecordID:
     if ":" in resource_str:
-        table, record_id = resource_str.split(":")
+        table, record_id = resource_str.split(":", 1)
         if len(table) == 0 or len(record_id) == 0:
             raise InvalidTableError("invalid table or record id string")
         return RecordID(table, record_id)

--- a/src/surrealdb/data/types/datetime.py
+++ b/src/surrealdb/data/types/datetime.py
@@ -15,3 +15,14 @@ class Datetime:
             The SurrealQL string representation of the datetime.
         """
         return f"d{json.dumps(self.dt)}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.dt!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Datetime):
+            return self.dt == other.dt
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.dt)

--- a/src/surrealdb/data/types/duration.py
+++ b/src/surrealdb/data/types/duration.py
@@ -54,6 +54,9 @@ class Duration:
             return self.elapsed == other.elapsed
         return False
 
+    def __hash__(self) -> int:
+        return hash(self.elapsed)
+
     @property
     def nanoseconds(self) -> int:
         return self.elapsed

--- a/src/surrealdb/data/types/geometry.py
+++ b/src/surrealdb/data/types/geometry.py
@@ -8,6 +8,14 @@ from typing import Any
 from surrealdb.errors import InvalidGeometryError
 
 
+def _hashable(value: Any) -> Any:
+    """Recursively convert nested lists (as returned by ``get_coordinates``)
+    into tuples so a geometry's coordinates can be hashed."""
+    if isinstance(value, list):
+        return tuple(_hashable(item) for item in value)
+    return value
+
+
 def _coord_pair(point: "GeometryPoint") -> str:
     """``[longitude, latitude]`` — a point's coordinates as they appear nested
     inside another geometry's ``coordinates`` array (as opposed to a
@@ -53,6 +61,13 @@ class Geometry:
         Parses a list of coordinates into a specific geometry type. Should be implemented by subclasses.
         """
         pass
+
+    def __hash__(self) -> int:
+        """
+        Returns a hash of the geometry based on its coordinates. Nested
+        coordinate lists are converted to tuples so they can be hashed.
+        """
+        return hash(_hashable(self.get_coordinates()))
 
 
 @dataclass
@@ -106,6 +121,9 @@ class GeometryPoint(Geometry):
         if isinstance(other, GeometryPoint):
             return self.longitude == other.longitude and self.latitude == other.latitude
         return False
+
+    def __hash__(self) -> int:
+        return hash((self.longitude, self.latitude))
 
 
 @dataclass
@@ -168,6 +186,9 @@ class GeometryLine(Geometry):
         if isinstance(other, GeometryLine):
             return self.geometry_points == other.geometry_points
         return False
+
+    def __hash__(self) -> int:
+        return hash(_hashable(self.get_coordinates()))
 
 
 @dataclass
@@ -310,6 +331,9 @@ class GeometryPolygon(Geometry):
             return self.geometry_lines == other.geometry_lines
         return False
 
+    def __hash__(self) -> int:
+        return hash(_hashable(self.get_coordinates()))
+
 
 @dataclass
 class GeometryMultiPoint(Geometry):
@@ -368,6 +392,9 @@ class GeometryMultiPoint(Geometry):
         if isinstance(other, GeometryMultiPoint):
             return self.geometry_points == other.geometry_points
         return False
+
+    def __hash__(self) -> int:
+        return hash(_hashable(self.get_coordinates()))
 
 
 @dataclass
@@ -428,6 +455,9 @@ class GeometryMultiLine(Geometry):
             return self.geometry_lines == other.geometry_lines
         return False
 
+    def __hash__(self) -> int:
+        return hash(_hashable(self.get_coordinates()))
+
 
 @dataclass
 class GeometryMultiPolygon(Geometry):
@@ -487,6 +517,9 @@ class GeometryMultiPolygon(Geometry):
             return self.geometry_polygons == other.geometry_polygons
         return False
 
+    def __hash__(self) -> int:
+        return hash(_hashable(self.get_coordinates()))
+
 
 @dataclass
 class GeometryCollection:
@@ -521,3 +554,6 @@ class GeometryCollection:
         if isinstance(other, GeometryCollection):
             return self.geometries == other.geometries
         return False
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.geometries))

--- a/src/surrealdb/data/types/range.py
+++ b/src/surrealdb/data/types/range.py
@@ -30,6 +30,13 @@ class Bound:
         """
         return isinstance(other, Bound)
 
+    def __hash__(self) -> int:
+        """
+        Returns a hash of the bound. All plain (unbounded) ``Bound``
+        instances compare equal, so they share a constant hash.
+        """
+        return hash(type(self).__name__)
+
 
 @dataclass
 class BoundIncluded(Bound):
@@ -65,6 +72,9 @@ class BoundIncluded(Bound):
         if isinstance(other, BoundIncluded):
             return self.value == other.value
         return False
+
+    def __hash__(self) -> int:
+        return hash(("BoundIncluded", self.value))
 
 
 @dataclass
@@ -102,6 +112,9 @@ class BoundExcluded(Bound):
             return self.value == other.value
         return False
 
+    def __hash__(self) -> int:
+        return hash(("BoundExcluded", self.value))
+
 
 @dataclass
 class Range:
@@ -129,6 +142,9 @@ class Range:
         if isinstance(other, Range):
             return self.begin == other.begin and self.end == other.end
         return False
+
+    def __hash__(self) -> int:
+        return hash((self.begin, self.end))
 
     def __str__(self) -> str:
         """

--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -111,10 +111,24 @@ class RecordID:
             return self.table_name == other.table_name and self.id == other.id
         return False
 
+    def __hash__(self) -> int:
+        # ``id`` may be an unhashable value (e.g. a dict or list) for
+        # object/array record ids, so hash its string form to stay total.
+        # This mirrors ``__eq__``: equal RecordIDs have equal ``table_name``
+        # and equal ``id``, hence equal ``str(id)``.
+        return hash((self.table_name, str(self.id)))
+
     @staticmethod
     def parse(record_str: str) -> RecordID:
         """
         Converts a string to a RecordID object.
+
+        The string is split on the *first* colon only, so ids that
+        themselves contain colons are preserved intact (e.g.
+        ``"user:complex:id:here"`` yields table ``"user"`` and id
+        ``"complex:id:here"``). ``parse`` always yields a string id — use
+        the :class:`RecordID` constructor directly for numeric, array or
+        object ids.
 
         Args:
             record_str: The string representation of the record ID
@@ -127,7 +141,7 @@ class RecordID:
                 'invalid string provided for parse. the expected string format is "table_name:record_id"'
             )
 
-        table, record_id = record_str.split(":")
+        table, record_id = record_str.split(":", 1)
         return RecordID(table, record_id)
 
     @classmethod

--- a/src/surrealdb/data/types/table.py
+++ b/src/surrealdb/data/types/table.py
@@ -55,3 +55,12 @@ class Table:
         if isinstance(other, Table):
             return self.table_name == other.table_name
         return False
+
+    def __hash__(self) -> int:
+        """
+        Returns a hash of the table, consistent with ``__eq__``.
+
+        Returns:
+            The hash of the table name.
+        """
+        return hash(self.table_name)

--- a/tests/unit_tests/data_types/test_datetimes.py
+++ b/tests/unit_tests/data_types/test_datetimes.py
@@ -30,6 +30,35 @@ def test_datetime_str_escapes_double_quotes() -> None:
     assert str(dt) == 'd"2025-02-03T12:30:45\\"Z"'
 
 
+def test_datetime_repr() -> None:
+    """Test Datetime.__repr__ shows the class name and stored value (issue #14)."""
+    dt = Datetime("2025-02-03T12:30:45.123456Z")
+    assert repr(dt) == "Datetime('2025-02-03T12:30:45.123456Z')"
+
+
+def test_datetime_equality() -> None:
+    """Test Datetime equality by stored value (issue #14)."""
+    dt1 = Datetime("2025-02-03T12:30:45.123456Z")
+    dt2 = Datetime("2025-02-03T12:30:45.123456Z")
+    dt3 = Datetime("2020-01-01T00:00:00Z")
+
+    assert dt1 == dt2
+    assert dt1 != dt3
+    assert dt1 != "2025-02-03T12:30:45.123456Z"
+    assert dt1 != object()
+
+
+def test_datetime_hashable() -> None:
+    """Datetime defines __eq__, so it must define a consistent __hash__ to
+    remain usable as a dict key / set member (issue #14)."""
+    dt1 = Datetime("2025-02-03T12:30:45.123456Z")
+    dt2 = Datetime("2025-02-03T12:30:45.123456Z")
+
+    assert hash(dt1) == hash(dt2)
+    assert dt1 in {dt2}
+    assert {dt1: "value"}[Datetime("2025-02-03T12:30:45.123456Z")] == "value"
+
+
 def test_datetime_custom_encode() -> None:
     """Test encoding Datetime wrapper to CBOR bytes."""
     iso_datetime = "2025-02-03T12:30:45.123456Z"

--- a/tests/unit_tests/data_types/test_duration.py
+++ b/tests/unit_tests/data_types/test_duration.py
@@ -132,6 +132,17 @@ def test_duration_equality() -> None:
     assert duration1 != "not a duration"
 
 
+def test_duration_hashable() -> None:
+    """Duration defines __eq__, so it must define a consistent __hash__ to
+    remain usable as a dict key / set member (issue #9)."""
+    duration1 = Duration(1000)
+    duration2 = Duration(1000)
+
+    assert hash(duration1) == hash(duration2)
+    assert duration1 in {duration2}
+    assert {duration1: "value"}[Duration(1000)] == "value"
+
+
 def test_duration_properties() -> None:
     """Test Duration property accessors."""
     # 1 hour, 30 minutes, 45 seconds, 500 milliseconds, 100 microseconds, 50 nanoseconds

--- a/tests/unit_tests/data_types/test_geometry.py
+++ b/tests/unit_tests/data_types/test_geometry.py
@@ -304,6 +304,86 @@ def test_geometry_collection_roundtrip() -> None:
     assert isinstance(decoded, GeometryCollection)
 
 
+# Unit tests for hashability (issue #9)
+#
+# Each geometry defines __eq__, so it must define a consistent __hash__ to
+# remain usable as a dict key / set member. Coordinates are nested lists, so
+# __hash__ converts them to tuples.
+def test_geometry_point_hashable() -> None:
+    point1 = GeometryPoint(1.23, 4.56)
+    point2 = GeometryPoint(1.23, 4.56)
+    assert hash(point1) == hash(point2)
+    assert point1 in {point2}
+    assert {point1: "value"}[GeometryPoint(1.23, 4.56)] == "value"
+
+
+def test_geometry_line_hashable() -> None:
+    line1 = GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+    line2 = GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+    assert hash(line1) == hash(line2)
+    assert line1 in {line2}
+
+
+def test_geometry_polygon_hashable() -> None:
+    def make_polygon() -> GeometryPolygon:
+        return GeometryPolygon(
+            GeometryLine(
+                GeometryPoint(0.0, 0.0),
+                GeometryPoint(1.0, 0.0),
+                GeometryPoint(1.0, 1.0),
+                GeometryPoint(0.0, 0.0),
+            )
+        )
+
+    assert hash(make_polygon()) == hash(make_polygon())
+    assert make_polygon() in {make_polygon()}
+
+
+def test_geometry_multipoint_hashable() -> None:
+    mp1 = GeometryMultiPoint(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+    mp2 = GeometryMultiPoint(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+    assert hash(mp1) == hash(mp2)
+    assert mp1 in {mp2}
+
+
+def test_geometry_multiline_hashable() -> None:
+    def make_multiline() -> GeometryMultiLine:
+        return GeometryMultiLine(
+            GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
+        )
+
+    assert hash(make_multiline()) == hash(make_multiline())
+    assert make_multiline() in {make_multiline()}
+
+
+def test_geometry_multipolygon_hashable() -> None:
+    def make_multipolygon() -> GeometryMultiPolygon:
+        return GeometryMultiPolygon(
+            GeometryPolygon(
+                GeometryLine(
+                    GeometryPoint(0.0, 0.0),
+                    GeometryPoint(1.0, 0.0),
+                    GeometryPoint(1.0, 1.0),
+                    GeometryPoint(0.0, 0.0),
+                )
+            )
+        )
+
+    assert hash(make_multipolygon()) == hash(make_multipolygon())
+    assert make_multipolygon() in {make_multipolygon()}
+
+
+def test_geometry_collection_hashable() -> None:
+    def make_collection() -> GeometryCollection:
+        return GeometryCollection(
+            GeometryPoint(1.0, 2.0),
+            GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0)),
+        )
+
+    assert hash(make_collection()) == hash(make_collection())
+    assert make_collection() in {make_collection()}
+
+
 # Unit tests for __str__ (SurrealQL rendering)
 #
 # Point renders as a bare `(x, y)` literal; every other geometry renders as a

--- a/tests/unit_tests/data_types/test_range.py
+++ b/tests/unit_tests/data_types/test_range.py
@@ -87,6 +87,34 @@ def test_range_equality() -> None:
     assert range1 != range4
 
 
+# Unit tests for hashability (issue #9)
+def test_bound_included_hashable() -> None:
+    """BoundIncluded defines __eq__, so it must be hashable and consistent."""
+    bound1 = BoundIncluded(5)
+    bound2 = BoundIncluded(5)
+    assert hash(bound1) == hash(bound2)
+    assert bound1 in {bound2}
+    assert {bound1: "value"}[BoundIncluded(5)] == "value"
+
+
+def test_bound_excluded_hashable() -> None:
+    """BoundExcluded defines __eq__, so it must be hashable and consistent."""
+    bound1 = BoundExcluded(5)
+    bound2 = BoundExcluded(5)
+    assert hash(bound1) == hash(bound2)
+    assert bound1 in {bound2}
+    assert {bound1: "value"}[BoundExcluded(5)] == "value"
+
+
+def test_range_hashable() -> None:
+    """Range defines __eq__, so it must be hashable and consistent."""
+    range1 = Range(BoundIncluded(1), BoundExcluded(10))
+    range2 = Range(BoundIncluded(1), BoundExcluded(10))
+    assert hash(range1) == hash(range2)
+    assert range1 in {range2}
+    assert {range1: "value"}[Range(BoundIncluded(1), BoundExcluded(10))] == "value"
+
+
 # Unit tests for __str__ (SurrealQL rendering)
 def test_range_str_inclusive_inclusive() -> None:
     """Test rendering an inclusive/inclusive range as SurrealQL."""

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -6,8 +6,10 @@ import pytest
 
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 from surrealdb.data import cbor
+from surrealdb.data.models import table_or_record_id
 from surrealdb.data.types.record_id import RecordID, escape_identifier
-from surrealdb.errors import InvalidRecordIdError
+from surrealdb.data.types.table import Table
+from surrealdb.errors import InvalidRecordIdError, InvalidTableError
 
 
 # Unit tests for RecordID class
@@ -101,10 +103,55 @@ def test_record_id_pydantic_model_dump_json_stringifies() -> None:
     assert dumped["id"] == "person:abc"
 
 
+def test_record_id_parse_with_colons_in_id() -> None:
+    """RecordID.parse splits on the first colon only, so an id that itself
+    contains colons is preserved intact (issue #13)."""
+    record_id = RecordID.parse("user:complex:id:here")
+    assert record_id.table_name == "user"
+    assert record_id.id == "complex:id:here"
+
+
+def test_record_id_parse_always_yields_string_id() -> None:
+    """RecordID.parse always yields a string id, even for all-digit ids."""
+    record_id = RecordID.parse("user:123")
+    assert record_id.table_name == "user"
+    assert record_id.id == "123"
+    assert isinstance(record_id.id, str)
+
+
 def test_record_id_parse_invalid() -> None:
     """Test RecordID.parse with invalid string."""
     with pytest.raises(InvalidRecordIdError, match="invalid string provided for parse"):
         RecordID.parse("invalid_string")
+
+
+def test_record_id_hashable() -> None:
+    """RecordID defines __eq__, so it must define a consistent __hash__ to
+    remain usable as a dict key / set member (issue #9)."""
+    record_id1 = RecordID("users", "john")
+    record_id2 = RecordID("users", "john")
+
+    # Equal objects hash equally.
+    assert record_id1 == record_id2
+    assert hash(record_id1) == hash(record_id2)
+
+    # Usable as a set member and dict key.
+    assert record_id1 in {record_id2}
+    mapping = {record_id1: "value"}
+    assert mapping[RecordID("users", "john")] == "value"
+
+
+def test_record_id_hashable_with_unhashable_id() -> None:
+    """RecordID stays hashable even when its id is an unhashable value such
+    as a dict or list (hashed via its string form)."""
+    dict_id = RecordID("person", {"name": "Tobie", "location": "London"})
+    list_id = RecordID("events", [1, 2, 3])
+
+    assert dict_id in {RecordID("person", {"name": "Tobie", "location": "London"})}
+    assert list_id in {RecordID("events", [1, 2, 3])}
+    assert hash(dict_id) == hash(
+        RecordID("person", {"name": "Tobie", "location": "London"})
+    )
 
 
 def test_record_id_str() -> None:
@@ -214,6 +261,39 @@ def test_record_id_equality() -> None:
     assert record_id1 != record_id3
     assert record_id1 != record_id4
     assert record_id1 != "not a record id"
+
+
+# Unit tests for table_or_record_id (surrealdb.data.models)
+def test_table_or_record_id_plain_table() -> None:
+    """A string without a colon resolves to a Table."""
+    resource = table_or_record_id("users")
+    assert isinstance(resource, Table)
+    assert resource.table_name == "users"
+
+
+def test_table_or_record_id_simple() -> None:
+    """A ``table:id`` string resolves to a RecordID."""
+    resource = table_or_record_id("users:john")
+    assert isinstance(resource, RecordID)
+    assert resource.table_name == "users"
+    assert resource.id == "john"
+
+
+def test_table_or_record_id_with_colons_in_id() -> None:
+    """table_or_record_id splits on the first colon only, preserving an id
+    that itself contains colons (issue #13)."""
+    resource = table_or_record_id("user:complex:id:here")
+    assert isinstance(resource, RecordID)
+    assert resource.table_name == "user"
+    assert resource.id == "complex:id:here"
+
+
+def test_table_or_record_id_empty_parts_invalid() -> None:
+    """An empty table or id part is rejected."""
+    with pytest.raises(InvalidTableError):
+        table_or_record_id("users:")
+    with pytest.raises(InvalidTableError):
+        table_or_record_id(":john")
 
 
 # Unit tests for encoding

--- a/tests/unit_tests/data_types/test_table.py
+++ b/tests/unit_tests/data_types/test_table.py
@@ -31,6 +31,17 @@ def test_table_equality() -> None:
     assert table1 != "users"
 
 
+def test_table_hashable() -> None:
+    """Table defines __eq__, so it must define a consistent __hash__ to
+    remain usable as a dict key / set member (issue #9)."""
+    table1 = Table("users")
+    table2 = Table("users")
+
+    assert hash(table1) == hash(table2)
+    assert table1 in {table2}
+    assert {table1: "value"}[Table("users")] == "value"
+
+
 # Unit tests for encoding
 def test_table_encode() -> None:
     """Test encoding Table to CBOR bytes."""


### PR DESCRIPTION
## Summary

Fixes three groups of data-type issues flagged in the pre-3.0.0 cleanup, scoped to `src/surrealdb/data/types/*.py` and `src/surrealdb/data/models.py` (plus their unit tests).

### Hashability
These value types define `__eq__` but no `__hash__`, which makes them unhashable (they cannot be used as dict keys or set members). Added a `__hash__` to each, hashing exactly the fields used in `__eq__`:

- **RecordID** — `hash((table_name, str(id)))`. Using `str(id)` keeps the hash total even when `id` is an unhashable `dict`/`list` (object/array record ids), and stays consistent with `__eq__` (equal RecordIDs have equal `table_name` and `id`, hence equal `str(id)`).
- **Table** — `hash(table_name)`.
- **Duration** — `hash(elapsed)` (its normalized nanosecond value).
- **Bound / BoundIncluded / BoundExcluded / Range** — over their fields. Base `Bound` gets a constant hash (all plain unbounded bounds compare equal), so unbounded `Range`s hash too.
- **Geometry** — `GeometryPoint`, `GeometryLine`, `GeometryPolygon`, `GeometryMultiPoint`, `GeometryMultiLine`, `GeometryMultiPolygon`, `GeometryCollection`, and the base `Geometry`. Coordinates are nested lists, so a small `_hashable` helper recursively converts them to tuples before hashing.

### Datetime dunders
`Datetime` previously defined only `__str__`. Added `__eq__` (equality by the stored value), `__repr__`, and a consistent `__hash__`, making it a proper value type.

### Colon-containing record ids
`RecordID.parse` and `data.models.table_or_record_id` both did `record_str.split(":")` with no maxsplit, which crashes / corrupts ids containing `:`. Changed both to `split(":", 1)`, so e.g. `RecordID.parse("user:complex:id:here")` yields table `"user"` and id `"complex:id:here"`. Documented that `RecordID.parse` always yields a string id.

## Tests
Added focused unit tests for all three groups (hashability across every affected type, `Datetime` `__eq__`/`__repr__`/`__hash__`, and colon-containing parse for both `RecordID.parse` and `table_or_record_id`).

## Verification
- `uv run ruff format` / `ruff check --fix src/` — clean
- `uv run mypy --explicit-package-bases src/` and `tests/` — clean
- `uv run pyright src/` — clean
- `uv run pytest tests/unit_tests/data_types/ -q` — 320 passed, 3 xpassed (pre-existing xfail Table DB roundtrips)
