### PR TITLE
Trim public surface: remove dead metaclasses & TAG_* exports, move Spectron off top-level, add connection type aliases

### DIFF
--- a/examples/django/database.py
+++ b/examples/django/database.py
@@ -1,11 +1,11 @@
 """Database connection helpers."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
 
-async def get_connection() -> AsyncSurreal:
+async def get_connection() -> AsyncSurrealConnection:
     """Get a connected SurrealDB instance.
 
     Returns:
@@ -23,7 +23,7 @@ async def get_connection() -> AsyncSurreal:
     return db
 
 
-async def close_connection(db: AsyncSurreal) -> None:
+async def close_connection(db: AsyncSurrealConnection) -> None:
     """Close database connection.
 
     Args:

--- a/examples/fastapi/database.py
+++ b/examples/fastapi/database.py
@@ -3,7 +3,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
@@ -12,7 +12,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -32,7 +32,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")
@@ -53,6 +53,6 @@ async def lifespan(app):
     await db_manager.disconnect()
 
 
-async def get_db() -> AsyncGenerator[AsyncSurreal, None]:
+async def get_db() -> AsyncGenerator[AsyncSurrealConnection, None]:
     """Dependency to get database connection."""
     yield db_manager.get_db()

--- a/examples/fastapi/routes/auth.py
+++ b/examples/fastapi/routes/auth.py
@@ -1,7 +1,7 @@
 """Authentication endpoints."""
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 from database import get_db
 from models import AuthResponse, MessageResponse, SigninRequest, SignupRequest
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/auth", tags=["authentication"])
 @router.post("/signup", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
 async def signup(
     request: SignupRequest,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> AuthResponse:
     """Register a new user account."""
     try:
@@ -40,7 +40,7 @@ async def signup(
 @router.post("/signin", response_model=AuthResponse)
 async def signin(
     request: SigninRequest,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> AuthResponse:
     """Sign in to an account."""
     try:
@@ -64,7 +64,7 @@ async def signin(
 
 @router.post("/invalidate", response_model=MessageResponse)
 async def invalidate(
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> MessageResponse:
     """Sign out and invalidate the session."""
     try:

--- a/examples/fastapi/routes/users.py
+++ b/examples/fastapi/routes/users.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 from database import get_db
 from models import UserCreate, UserResponse, UserUpdate
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 @router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def create_user(
     user: UserCreate,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> UserResponse:
     """Create a new user."""
     try:
@@ -51,7 +51,7 @@ async def create_user(
 
 @router.get("", response_model=List[UserResponse])
 async def list_users(
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> List[UserResponse]:
     """Get all users."""
     try:
@@ -82,7 +82,7 @@ async def list_users(
 @router.get("/{user_id}", response_model=UserResponse)
 async def get_user(
     user_id: str,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> UserResponse:
     """Get a user by ID."""
     try:
@@ -116,7 +116,7 @@ async def get_user(
 async def update_user(
     user_id: str,
     user: UserUpdate,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> UserResponse:
     """Update a user."""
     try:
@@ -164,7 +164,7 @@ async def update_user(
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_user(
     user_id: str,
-    db: AsyncSurreal = Depends(get_db),
+    db: AsyncSurrealConnection = Depends(get_db),
 ) -> None:
     """Delete a user."""
     try:

--- a/examples/fastmcp/database.py
+++ b/examples/fastmcp/database.py
@@ -1,6 +1,6 @@
 """Database connection management."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
@@ -9,7 +9,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -29,7 +29,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")

--- a/examples/flask/database.py
+++ b/examples/flask/database.py
@@ -1,10 +1,10 @@
 """Database connection management."""
 
 from flask import current_app, g
-from surrealdb import Surreal
+from surrealdb import BlockingSurrealConnection, Surreal
 
 
-def get_db() -> Surreal:
+def get_db() -> BlockingSurrealConnection:
     """Get database connection for current request.
 
     Creates a new connection if one doesn't exist in the request context.

--- a/examples/graphql/database.py
+++ b/examples/graphql/database.py
@@ -1,6 +1,6 @@
 """Database connection management."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
@@ -9,7 +9,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -29,7 +29,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")

--- a/examples/graphql/dataloaders.py
+++ b/examples/graphql/dataloaders.py
@@ -3,13 +3,13 @@
 from typing import List, Optional
 
 from strawberry.dataloader import DataLoader
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 
 class UserDataLoader(DataLoader):
     """DataLoader for batching user queries."""
 
-    def __init__(self, db: AsyncSurreal):
+    def __init__(self, db: AsyncSurrealConnection):
         super().__init__(load_fn=self.load_users)
         self.db = db
 

--- a/examples/jupyter/database.py
+++ b/examples/jupyter/database.py
@@ -1,11 +1,11 @@
 """Database connection helper for notebooks."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
 
-async def get_connection() -> AsyncSurreal:
+async def get_connection() -> AsyncSurrealConnection:
     """Get a connected SurrealDB instance.
 
     Returns:
@@ -29,7 +29,7 @@ async def get_connection() -> AsyncSurreal:
     return db
 
 
-async def close_connection(db: AsyncSurreal) -> None:
+async def close_connection(db: AsyncSurrealConnection) -> None:
     """Close database connection.
 
     Args:

--- a/examples/jupyter/utils.py
+++ b/examples/jupyter/utils.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, List
 
 import pandas as pd
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 
 def pretty_print(data: Any) -> None:
@@ -51,7 +51,7 @@ def to_dataframe(data: List[dict]) -> pd.DataFrame:
     return pd.DataFrame(cleaned_data)
 
 
-async def sample_data(db: AsyncSurreal) -> None:
+async def sample_data(db: AsyncSurrealConnection) -> None:
     """Load sample data into the database.
 
     Args:
@@ -72,7 +72,7 @@ async def sample_data(db: AsyncSurreal) -> None:
     print(f"✅ Loaded {len(users)} sample users")
 
 
-async def clear_table(db: AsyncSurreal, table: str) -> None:
+async def clear_table(db: AsyncSurrealConnection, table: str) -> None:
     """Clear all records from a table.
 
     Args:

--- a/examples/litestar/controllers/auth.py
+++ b/examples/litestar/controllers/auth.py
@@ -4,7 +4,7 @@ from litestar import Controller, post
 from litestar.di import Provide
 from litestar.exceptions import InternalServerException
 from litestar.status_codes import HTTP_201_CREATED
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 from database import provide_db
 from models import AuthResponse, MessageResponse, SigninRequest, SignupRequest
@@ -17,7 +17,7 @@ class AuthController(Controller):
     dependencies = {"db": Provide(provide_db)}
 
     @post("/signup", status_code=HTTP_201_CREATED)
-    async def signup(self, data: SignupRequest, db: AsyncSurreal) -> AuthResponse:
+    async def signup(self, data: SignupRequest, db: AsyncSurrealConnection) -> AuthResponse:
         """Register a new user account."""
         try:
             token = await db.signup(
@@ -38,7 +38,7 @@ class AuthController(Controller):
             raise InternalServerException(f"Signup failed: {str(e)}")
 
     @post("/signin")
-    async def signin(self, data: SigninRequest, db: AsyncSurreal) -> AuthResponse:
+    async def signin(self, data: SigninRequest, db: AsyncSurrealConnection) -> AuthResponse:
         """Sign in to an account."""
         try:
             token = await db.signin(
@@ -56,7 +56,7 @@ class AuthController(Controller):
             raise InternalServerException(f"Authentication failed: {str(e)}")
 
     @post("/invalidate")
-    async def invalidate(self, db: AsyncSurreal) -> MessageResponse:
+    async def invalidate(self, db: AsyncSurrealConnection) -> MessageResponse:
         """Sign out and invalidate the session."""
         try:
             await db.invalidate()

--- a/examples/litestar/controllers/users.py
+++ b/examples/litestar/controllers/users.py
@@ -6,7 +6,7 @@ from litestar import Controller, delete, get, post, put
 from litestar.di import Provide
 from litestar.exceptions import InternalServerException, NotFoundException
 from litestar.status_codes import HTTP_201_CREATED, HTTP_204_NO_CONTENT
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurrealConnection
 
 from database import provide_db
 from models import (
@@ -26,7 +26,7 @@ class UserController(Controller):
     dependencies = {"db": Provide(provide_db)}
 
     @post(dto=UserCreateDTO, return_dto=UserResponseDTO, status_code=HTTP_201_CREATED)
-    async def create_user(self, data: UserCreate, db: AsyncSurreal) -> UserResponse:
+    async def create_user(self, data: UserCreate, db: AsyncSurrealConnection) -> UserResponse:
         """Create a new user."""
         try:
             result = await db.create(
@@ -54,7 +54,7 @@ class UserController(Controller):
             raise InternalServerException(f"Database error: {str(e)}")
 
     @get(return_dto=UserResponseDTO)
-    async def list_users(self, db: AsyncSurreal) -> List[UserResponse]:
+    async def list_users(self, db: AsyncSurrealConnection) -> List[UserResponse]:
         """Get all users."""
         try:
             result = await db.select("users")
@@ -78,7 +78,7 @@ class UserController(Controller):
             raise InternalServerException(f"Database error: {str(e)}")
 
     @get("/{user_id:str}", return_dto=UserResponseDTO)
-    async def get_user(self, user_id: str, db: AsyncSurreal) -> UserResponse:
+    async def get_user(self, user_id: str, db: AsyncSurrealConnection) -> UserResponse:
         """Get a user by ID."""
         try:
             result = await db.select(user_id)
@@ -105,7 +105,7 @@ class UserController(Controller):
         self,
         user_id: str,
         data: UserUpdate,
-        db: AsyncSurreal,
+        db: AsyncSurrealConnection,
     ) -> UserResponse:
         """Update a user."""
         try:
@@ -141,7 +141,7 @@ class UserController(Controller):
             raise InternalServerException(f"Database error: {str(e)}")
 
     @delete("/{user_id:str}", status_code=HTTP_204_NO_CONTENT)
-    async def delete_user(self, user_id: str, db: AsyncSurreal) -> None:
+    async def delete_user(self, user_id: str, db: AsyncSurrealConnection) -> None:
         """Delete a user."""
         try:
             result = await db.delete(user_id)

--- a/examples/litestar/database.py
+++ b/examples/litestar/database.py
@@ -2,7 +2,7 @@
 
 from typing import AsyncGenerator
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
@@ -11,7 +11,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -31,7 +31,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")
@@ -42,6 +42,6 @@ class DatabaseManager:
 db_manager = DatabaseManager()
 
 
-async def provide_db() -> AsyncGenerator[AsyncSurreal, None]:
+async def provide_db() -> AsyncGenerator[AsyncSurrealConnection, None]:
     """Dependency provider for database connection."""
     yield db_manager.get_db()

--- a/examples/logfire/database.py
+++ b/examples/logfire/database.py
@@ -3,7 +3,7 @@
 import logfire
 from config import config
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 
 def setup_logfire() -> None:
@@ -38,7 +38,7 @@ def setup_logfire() -> None:
     print("   ✅ All SurrealDB operations will now be traced\n")
 
 
-async def get_database() -> AsyncSurreal:
+async def get_database() -> AsyncSurrealConnection:
     """Create and return a configured database connection.
 
     Returns:

--- a/examples/quart/database.py
+++ b/examples/quart/database.py
@@ -1,10 +1,10 @@
 """Database connection management."""
 
 from quart import current_app, g
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 
-async def get_db() -> AsyncSurreal:
+async def get_db() -> AsyncSurrealConnection:
     """Get database connection for current request.
 
     Creates a new connection if one doesn't exist in the request context.

--- a/examples/sanic/database.py
+++ b/examples/sanic/database.py
@@ -1,6 +1,6 @@
 """Database connection management."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import config
 
@@ -9,7 +9,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -29,7 +29,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")

--- a/examples/starlette/database.py
+++ b/examples/starlette/database.py
@@ -1,6 +1,6 @@
 """Database connection management."""
 
-from surrealdb import AsyncSurreal
+from surrealdb import AsyncSurreal, AsyncSurrealConnection
 
 from config import settings
 
@@ -9,7 +9,7 @@ class DatabaseManager:
     """Manages SurrealDB connections."""
 
     def __init__(self):
-        self.db: AsyncSurreal | None = None
+        self.db: AsyncSurrealConnection | None = None
 
     async def connect(self) -> None:
         """Initialize database connection."""
@@ -29,7 +29,7 @@ class DatabaseManager:
             await self.db.close()
             self.db = None
 
-    def get_db(self) -> AsyncSurreal:
+    def get_db(self) -> AsyncSurrealConnection:
         """Get the database connection."""
         if not self.db:
             raise RuntimeError("Database not connected")

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Union
 
 _EMBEDDED_AVAILABLE = False
 try:
@@ -36,42 +36,12 @@ from surrealdb.connections.builders import (
     SyncQueryBuilder,
 )
 from surrealdb.connections.url import Url, UrlScheme
-from surrealdb.data.types.constants import (
-    TAG_BOUND_EXCLUDED,
-    TAG_BOUND_INCLUDED,
-    TAG_DATETIME,
-    TAG_DATETIME_COMPACT,
-    TAG_DECIMAL_STRING,
-    TAG_DURATION,
-    TAG_DURATION_COMPACT,
-    TAG_GEOMETRY_COLLECTION,
-    TAG_GEOMETRY_LINE,
-    TAG_GEOMETRY_MULTI_LINE,
-    TAG_GEOMETRY_MULTI_POINT,
-    TAG_GEOMETRY_MULTI_POLYGON,
-    TAG_GEOMETRY_POINT,
-    TAG_GEOMETRY_POLYGON,
-    TAG_NONE,
-    TAG_RANGE,
-    TAG_RECORD_ID,
-    TAG_TABLE_NAME,
-    TAG_UUID_STRING,
-)
 from surrealdb.data.types.datetime import Datetime
 from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.range import Range
 from surrealdb.data.types.record_id import RecordID, escape_identifier
 from surrealdb.data.types.table import Table
-from surrealdb.spectron import (
-    AsyncSpectron,
-    Spectron,
-    SpectronAPIError,
-    SpectronAuthError,
-    SpectronError,
-    SpectronNotFoundError,
-    SpectronScopeError,
-)
 from surrealdb.errors import (
     AlreadyExistsDetailKind,
     AlreadyExistsError,
@@ -120,6 +90,9 @@ __all__ = [
     "BlockingSurrealSession",
     "BlockingSurrealTransaction",
     "BlockingWsSurrealConnection",
+    # Connection type aliases (for annotating the objects the factories return)
+    "AsyncSurrealConnection",
+    "BlockingSurrealConnection",
     # Builders (returned by create/update/upsert/delete/insert/query)
     "AsyncCrudBuilder",
     "AsyncInsertBuilder",
@@ -173,100 +146,24 @@ __all__ = [
     "InvalidTableError",
     # Errors – backward compat
     "SurrealDBMethodError",
-    # Constants
-    "TAG_BOUND_EXCLUDED",
-    "TAG_BOUND_INCLUDED",
-    "TAG_DATETIME",
-    "TAG_DATETIME_COMPACT",
-    "TAG_DECIMAL_STRING",
-    "TAG_DURATION",
-    "TAG_DURATION_COMPACT",
-    "TAG_GEOMETRY_COLLECTION",
-    "TAG_GEOMETRY_LINE",
-    "TAG_GEOMETRY_MULTI_LINE",
-    "TAG_GEOMETRY_MULTI_POINT",
-    "TAG_GEOMETRY_MULTI_POLYGON",
-    "TAG_GEOMETRY_POINT",
-    "TAG_GEOMETRY_POLYGON",
-    "TAG_NONE",
-    "TAG_RANGE",
-    "TAG_RECORD_ID",
-    "TAG_TABLE_NAME",
-    "TAG_UUID_STRING",
-    # Spectron clients
-    "Spectron",
-    "AsyncSpectron",
-    # Spectron exceptions (prefixed to avoid clashes with surrealdb.* errors)
-    "SpectronError",
-    "SpectronAPIError",
-    "SpectronAuthError",
-    "SpectronScopeError",
-    "SpectronNotFoundError",
 ]
 
 _EMBEDDED_SCHEMES = (UrlScheme.MEM, UrlScheme.MEMORY, UrlScheme.FILE, UrlScheme.SURREALKV, UrlScheme.SURREALKV_VERSIONED)
 
-
-class AsyncSurrealDBMeta(type):
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Union["AsyncEmbeddedSurrealConnection", AsyncHttpSurrealConnection, AsyncWsSurrealConnection]:
-        if len(args) > 0:
-            url = args[0]
-        else:
-            url = kwargs.get("url")
-
-        if url is None:
-            raise ValueError("The 'url' parameter is required to initialise SurrealDB.")
-
-        constructed_url = Url(url)
-
-        if constructed_url.scheme in _EMBEDDED_SCHEMES:
-            if not _EMBEDDED_AVAILABLE:
-                raise UnsupportedEngineError(url)
-            return AsyncEmbeddedSurrealConnection(url=url)
-        elif (
-            constructed_url.scheme == UrlScheme.HTTP
-            or constructed_url.scheme == UrlScheme.HTTPS
-        ):
-            return AsyncHttpSurrealConnection(url=url)
-        elif (
-            constructed_url.scheme == UrlScheme.WS
-            or constructed_url.scheme == UrlScheme.WSS
-        ):
-            return AsyncWsSurrealConnection(url=url)
-        else:
-            raise UnsupportedEngineError(url)
-
-
-class BlockingSurrealDBMeta(type):
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Union["BlockingEmbeddedSurrealConnection", BlockingHttpSurrealConnection, BlockingWsSurrealConnection]:
-        if len(args) > 0:
-            url = args[0]
-        else:
-            url = kwargs.get("url")
-
-        if url is None:
-            raise ValueError("The 'url' parameter is required to initialise SurrealDB.")
-
-        constructed_url = Url(url)
-
-        if constructed_url.scheme in _EMBEDDED_SCHEMES:
-            if not _EMBEDDED_AVAILABLE:
-                raise UnsupportedEngineError(url)
-            return BlockingEmbeddedSurrealConnection(url=url)
-        elif (
-            constructed_url.scheme == UrlScheme.HTTP
-            or constructed_url.scheme == UrlScheme.HTTPS
-        ):
-            return BlockingHttpSurrealConnection(url=url)
-        elif (
-            constructed_url.scheme == UrlScheme.WS
-            or constructed_url.scheme == UrlScheme.WSS
-        ):
-            return BlockingWsSurrealConnection(url=url)
-        else:
-            raise UnsupportedEngineError(url)
+# Type aliases for the connection objects the factory functions return. The
+# ``Surreal``/``AsyncSurreal`` names are factory *functions*, so they cannot be
+# used to annotate a connection instance (e.g. ``db: AsyncSurreal``). Use these
+# unions instead: ``db: AsyncSurrealConnection`` / ``db: BlockingSurrealConnection``.
+AsyncSurrealConnection = Union[
+    AsyncWsSurrealConnection,
+    AsyncHttpSurrealConnection,
+    "AsyncEmbeddedSurrealConnection",
+]
+BlockingSurrealConnection = Union[
+    BlockingWsSurrealConnection,
+    BlockingHttpSurrealConnection,
+    "BlockingEmbeddedSurrealConnection",
+]
 
 
 def Surreal(

--- a/src/surrealdb/spectron/README.md
+++ b/src/surrealdb/spectron/README.md
@@ -4,7 +4,7 @@ Python client for [Spectron](https://github.com/surrealdb/spectron), bundled
 with `surrealdb`.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.spectron import Spectron
 
 with Spectron(
     context="acme-prod",
@@ -25,7 +25,7 @@ pip install surrealdb
 ## Clients
 
 ```python
-from surrealdb import Spectron, AsyncSpectron
+from surrealdb.spectron import Spectron, AsyncSpectron
 
 with Spectron(context="acme-prod", endpoint="https://api.spectron.example", api_key="sk-...") as memory:
     memory.remember("I work at Acme as CTO")
@@ -268,7 +268,7 @@ memory.lifecycle.fsck(check="duplicates")   # integrity report
 ## Errors
 
 ```python
-from surrealdb import SpectronAPIError, SpectronNotFoundError
+from surrealdb.spectron import SpectronAPIError, SpectronNotFoundError
 
 try:
     memory.recall("...")

--- a/tests/spectron/test_imports.py
+++ b/tests/spectron/test_imports.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 
-def test_top_level_clients_importable():
-    from surrealdb import AsyncSpectron, Spectron
+def test_clients_importable_from_subpackage():
+    from surrealdb.spectron import AsyncSpectron, Spectron
 
     assert Spectron.__name__ == "Spectron"
     assert AsyncSpectron.__name__ == "AsyncSpectron"
 
 
-def test_top_level_exception_aliases_importable():
-    from surrealdb import (
+def test_exception_aliases_importable_from_subpackage():
+    from surrealdb.spectron import (
         SpectronAPIError,
         SpectronAuthError,
         SpectronError,
@@ -26,6 +26,15 @@ def test_removed_aliases_no_longer_exposed():
     import surrealdb
 
     for name in (
+        # Spectron lives under ``surrealdb.spectron``; it is no longer
+        # re-exported at the top level of ``surrealdb``.
+        "Spectron",
+        "AsyncSpectron",
+        "SpectronError",
+        "SpectronAPIError",
+        "SpectronAuthError",
+        "SpectronScopeError",
+        "SpectronNotFoundError",
         "SpectronValidationError",
         "SpectronRateLimitError",
         "SpectronServerError",

--- a/tests/unit_tests/test_init_functions.py
+++ b/tests/unit_tests/test_init_functions.py
@@ -70,47 +70,13 @@ def test_async_surreal_invalid_protocol() -> None:
         AsyncSurreal("ftp://localhost:8000")
 
 
-# Test the meta classes indirectly through the factory functions
-# These tests ensure the meta classes work correctly
-
-
-def test_blocking_meta_class_positional_arg() -> None:
-    """Test BlockingSurrealDBMeta with positional argument."""
-    # This tests the meta class behavior indirectly
-    connection = Surreal("http://localhost:8000")
-    assert isinstance(connection, BlockingHttpSurrealConnection)
-
-
-def test_blocking_meta_class_keyword_arg() -> None:
-    """Test BlockingSurrealDBMeta with keyword argument."""
-    # This tests the meta class behavior indirectly
+def test_surreal_keyword_arg() -> None:
+    """Test Surreal function accepts the url as a keyword argument."""
     connection = Surreal(url="http://localhost:8000")
     assert isinstance(connection, BlockingHttpSurrealConnection)
 
 
-def test_blocking_meta_class_missing_url() -> None:
-    """Test BlockingSurrealDBMeta with missing URL raises ValueError."""
-    # This would test the meta class directly, but we can't instantiate it
-    # The factory function doesn't expose this error case
-    pass
-
-
-def test_async_meta_class_positional_arg() -> None:
-    """Test AsyncSurrealDBMeta with positional argument."""
-    # This tests the meta class behavior indirectly
-    connection = AsyncSurreal("http://localhost:8000")
-    assert isinstance(connection, AsyncHttpSurrealConnection)
-
-
-def test_async_meta_class_keyword_arg() -> None:
-    """Test AsyncSurrealDBMeta with keyword argument."""
-    # This tests the meta class behavior indirectly
+def test_async_surreal_keyword_arg() -> None:
+    """Test AsyncSurreal function accepts the url as a keyword argument."""
     connection = AsyncSurreal(url="http://localhost:8000")
     assert isinstance(connection, AsyncHttpSurrealConnection)
-
-
-def test_async_meta_class_missing_url() -> None:
-    """Test AsyncSurrealDBMeta with missing URL raises ValueError."""
-    # This would test the meta class directly, but we can't instantiate it
-    # The factory function doesn't expose this error case
-    pass


### PR DESCRIPTION
Part of the pre-3.0.0-stable cleanup of the public package surface (`surrealdb/__init__.py`).

## Changes

### Remove dead metaclasses
`AsyncSurrealDBMeta` and `BlockingSurrealDBMeta` were never used — `Surreal`/`AsyncSurreal` are plain factory functions and nothing sets `metaclass=`. Removed both classes from `src/surrealdb/__init__.py`. Dropped the indirect "meta class" tests in `tests/unit_tests/test_init_functions.py` (they only called the factory functions), keeping the factory tests and adding explicit keyword-argument tests.

### Remove `TAG_*` exports
Removed all `TAG_*` constant re-exports and their `__all__` entries from the top level. These are internal CBOR wire tags and remain available at `surrealdb.data.types.constants` for internal use (`data/cbor.py` and the tests already import them from there; there were no `from surrealdb import TAG_*` usages).

### Move Spectron off the top level
Removed the top-level re-exports of `Spectron`, `AsyncSpectron`, `SpectronError`, `SpectronAPIError`, `SpectronAuthError`, `SpectronScopeError`, `SpectronNotFoundError` from the imports and `__all__`. Spectron stays importable as `surrealdb.spectron` (the subpackage already exports them). Updated:
- `src/surrealdb/spectron/README.md` examples to use `from surrealdb.spectron import ...`.
- `tests/spectron/test_imports.py`: the positive tests now import from the subpackage, and the removal test asserts the names are no longer exposed on `surrealdb`. All other spectron tests already imported from `surrealdb.spectron`.

### Connection type aliases
`Surreal`/`AsyncSurreal` are factory *functions*, so users cannot annotate `db: AsyncSurreal`. Added exported `Union` aliases and both to `__all__`:

```python
AsyncSurrealConnection = Union[AsyncWsSurrealConnection, AsyncHttpSurrealConnection, "AsyncEmbeddedSurrealConnection"]
BlockingSurrealConnection = Union[BlockingWsSurrealConnection, BlockingHttpSurrealConnection, "BlockingEmbeddedSurrealConnection"]
```

Updated the `examples/` that annotated `db: AsyncSurreal | None` / `-> Surreal` / `AsyncGenerator[AsyncSurreal, None]` to use the new aliases, while leaving the factory call sites (`AsyncSurreal(url)`, `Surreal(url)`) unchanged. The `Surreal()`/`AsyncSurreal()` factory functions are unchanged.

## Verification
- `uv run ruff format src/ tests/` + `uv run ruff check --fix src/` — pass
- `uv run mypy --explicit-package-bases src/` — pass
- `uv run pyright src/` — pass
- `uv run mypy --explicit-package-bases tests/` — pass
- `uv run pytest tests/spectron tests/unit_tests --ignore=tests/unit_tests/connections/embedded -q` — 825 passed, 14 skipped, 1 xfailed, 3 xpassed
