### PR TITLE
Tooling: tighten tests mypy config, assert py.typed ships, verify v3 CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,39 @@ jobs:
       - name: Run pyright checks
         run: uv run pyright src/
 
+  package:
+    name: Check packaging (py.typed)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: 3.13
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Assert py.typed ships in the wheel (PEP 561)
+        run: |
+          wheel=$(ls dist/*.whl)
+          echo "Inspecting $wheel"
+          if unzip -l "$wheel" | grep -q 'surrealdb/py.typed'; then
+            echo "OK: surrealdb/py.typed is present in the wheel"
+          else
+            echo "ERROR: surrealdb/py.typed is missing from the wheel; PEP 561 type information would not ship to users"
+            unzip -l "$wheel"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.surrealdb-version == 'nightly' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,12 +164,18 @@ disallow_any_generics = false
 warn_return_any = false
 # Don't warn about type narrowing issues
 strict_optional = false
-# Disable specific error codes that are problematic with Value union type and pytest fixtures
+# Error codes the test suite still needs suppressed. The bulk (index,
+# union-attr, call-overload, arg-type) come from the public `Value` union that
+# query()/CRUD builders return and that tests index into pervasively (~2.1k
+# occurrences across ~100 files) - enabling them would require rewriting test
+# result handling, not a config change. "operator" was dropped from this list
+# because it no longer fires anywhere. Re-enabling the data-flow codes to catch
+# public-API regressions is tracked as a dedicated test-typing follow-up.
 disable_error_code = [
     "index", "call-overload", "arg-type", "assignment", "return-value",
-    "operator", "union-attr", "func-returns-value", "name-defined",
-    "misc", "var-annotated", "comparison-overlap", "str-bytes-safe",
-    "unused-ignore", "no-untyped-def"
+    "union-attr", "func-returns-value", "name-defined", "misc",
+    "comparison-overlap", "str-bytes-safe", "unused-ignore",
+    "var-annotated", "no-untyped-def"
 ]
 
 # --------------------------------------------------


### PR DESCRIPTION
Pre-3.0.0 tooling cleanup. Scope is limited to `pyproject.toml` and `.github/workflows/ci.yml`; no `src/` changes.

## Trim `[[tool.mypy.overrides]]` `module = "tests.*"` suppressions

The `tests.*` override disabled ~14 mypy error codes, so the CI `mypy tests/` step could not catch public-API type regressions.

I attempted the aggressive trim (keep only `no-untyped-def` + `var-annotated`, drop every data-flow code). `uv run mypy --explicit-package-bases tests/` then reports **2280 errors across 102 test files**, overwhelmingly from the public `Value` union that `query()`/CRUD builders return and that tests index into pervasively:

| code | count | code | count |
|---|---|---|---|
| `index` | 868 | `func-returns-value` | 19 |
| `union-attr` | 653 | `misc` | 15 |
| `call-overload` | 584 | `return-value` | 13 |
| `arg-type` | 86 | `unused-ignore` | 13 |
| `assignment` | 22 | `name-defined` | 4 |
| | | `str-bytes-safe` | 2 |
| | | `comparison-overlap` | 1 |

`index` + `union-attr` + `call-overload` alone are ~92% and are inherent to how tests consume the `Value` union - clearing them is a broad test rewrite, not a config change, and out of scope for a tooling PR (touches ~100 files, risks conflicts with agents owning those test areas).

Per the finding's fallback ("re-add only the specific codes still needed to pass"), I re-add exactly the codes still needed and drop the one code that is now **dead**: `operator` (0 occurrences). A comment documents why the rest are kept. `mypy tests/` remains green.

## Assert `py.typed` ships in the wheel

Added a `package` CI job that runs `uv build --wheel` and fails unless `surrealdb/py.typed` is present in the built wheel (`unzip -l`), so PEP 561 type information cannot silently regress. Verified locally: the wheel contains `surrealdb/py.typed` and the assertion passes.

## v3 coverage check (investigation, no change needed)

The `surrealdb_v3`-marked tests **do execute on the v3 leg**; the marker is never used for deselection (there is no `-m "not surrealdb_v3"` in `addopts`), so it is only a label. The v3 matrix leg starts a real server and passes `SURREALDB_VERSION`; `version()` returns `surrealdb-3.x.x`, which the conftest version gates accept. Verified against a local v3 server: `bearer_v3` (4) and `structured_errors` (9) tests run and pass. The `session_txn` suite self-skips at runtime via its own probe (`"Session-scoped create/query returned empty"`) even on a v3 server - a functional/test-logic matter, not CI config, so it is left for the session/transaction owners (see follow-ups).

## Verification
- `uv run ruff format --check src/` - pass; `uv run ruff check src/` - pass
- `uv run mypy --explicit-package-bases src/` - pass
- `uv run pyright src/` - pass
- `uv run mypy --explicit-package-bases tests/` - pass
- ci.yml validated as YAML (jobs: format, mypy, pyright, package, test, test-embedded); representative test slice (359 tests) passes against a local v3 server
