### PR TITLE
HTTP connections: implement close() and use pooled session

### DIFF
--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -23,10 +23,13 @@ from surrealdb.types import Tokens, Value, parse_auth_result
 
 class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     """
-    A single async connection to a SurrealDB instance using HTTP. To be used once and discarded.
+    An async connection to a SurrealDB instance using HTTP.
 
     # Notes
-    A new HTTP session is created for each query to send a request to the SurrealDB server.
+    When used as an async context manager (``async with``) a single pooled
+    ``aiohttp.ClientSession`` is created and reused across every request, then
+    closed on exit. Outside a context manager a fresh session is created per
+    request.
 
     Attributes:
         url: The URL of the database to process queries for.
@@ -71,20 +74,37 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         if self.database:
             headers["Surreal-DB"] = self.database
 
+        # Reuse the pooled session when running inside a context manager,
+        # otherwise fall back to a fresh per-request session.
+        if self._session is not None and not self._session.closed:
+            return await self._request(
+                self._session, url, headers, data, operation, bypass
+            )
         async with aiohttp.ClientSession() as session:
-            async with session.request(
-                method="POST",
-                url=url,
-                headers=headers,
-                data=data,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as response:
-                response.raise_for_status()
-                raw_cbor = await response.read()
-                data = decode(raw_cbor)
-                if bypass is False:
-                    self.check_response_for_error(data, operation)
-                return data
+            return await self._request(session, url, headers, data, operation, bypass)
+
+    async def _request(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        headers: dict[str, str],
+        data: bytes,
+        operation: str,
+        bypass: bool,
+    ) -> dict[str, Any]:
+        async with session.request(
+            method="POST",
+            url=url,
+            headers=headers,
+            data=data,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as response:
+            response.raise_for_status()
+            raw_cbor = await response.read()
+            result = decode(raw_cbor)
+            if bypass is False:
+                self.check_response_for_error(result, operation)
+            return result
 
     def set_token(self, token: str) -> None:
         """
@@ -316,6 +336,16 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.check_response_for_result(response, "getting database version")
         return response["result"]
 
+    async def close(self) -> None:
+        """Close the pooled HTTP session if one is open.
+
+        Idempotent: a no-op when no session has been opened (for example
+        outside an ``async with`` block) and safe to call more than once.
+        """
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
     async def __aenter__(self) -> "AsyncHttpSurrealConnection":
         """
         Asynchronous context manager entry.
@@ -334,8 +364,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         Asynchronous context manager exit.
         Closes the aiohttp session upon exiting the context.
         """
-        if self._session is not None:
-            await self._session.close()
+        await self.close()
 
     async def attach(self) -> None:
         raise UnsupportedFeatureError(

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -50,7 +50,12 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         if self.database:
             headers["Surreal-DB"] = self.database
 
-        response = requests.post(url, headers=headers, data=data, timeout=30)
+        # Reuse the pooled session when running inside a context manager,
+        # otherwise fall back to a fresh per-request request.
+        if self.session is not None:
+            response = self.session.post(url, headers=headers, data=data, timeout=30)
+        else:
+            response = requests.post(url, headers=headers, data=data, timeout=30)
         response.raise_for_status()
 
         raw_cbor = response.content
@@ -299,6 +304,16 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.check_response_for_result(response, "getting database version")
         return response["result"]
 
+    def close(self) -> None:
+        """Close the pooled HTTP session if one is open.
+
+        Idempotent: a no-op when no session has been opened (for example
+        outside a ``with`` block) and safe to call more than once.
+        """
+        if self.session is not None:
+            self.session.close()
+        self.session = None
+
     def __enter__(self) -> "BlockingHttpSurrealConnection":
         """
         Synchronous context manager entry.
@@ -317,8 +332,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         Synchronous context manager exit.
         Closes the HTTP session upon exiting the context.
         """
-        if self.session is not None:
-            self.session.close()
+        self.close()
 
     def attach(self) -> None:
         raise UnsupportedFeatureError(

--- a/tests/unit_tests/connections/http_lifecycle/conftest.py
+++ b/tests/unit_tests/connections/http_lifecycle/conftest.py
@@ -1,0 +1,14 @@
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_surrealdb_server() -> Generator[None, None, None]:
+    """Override the parent fixture: these tests are fully mocked.
+
+    The lifecycle tests in this package stub out the HTTP transport with
+    ``aioresponses``/``responses`` and therefore never touch a real
+    SurrealDB server, so the server-reachability skip must not apply here.
+    """
+    yield

--- a/tests/unit_tests/connections/http_lifecycle/test_async_http.py
+++ b/tests/unit_tests/connections/http_lifecycle/test_async_http.py
@@ -1,0 +1,108 @@
+"""Lifecycle tests for the async HTTP connection (issues #8 and #10).
+
+These are fully mocked with ``aioresponses`` and need no live server.
+"""
+
+from typing import Any
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.data.cbor import encode
+
+URL = "http://localhost:8000"
+RPC = f"{URL}/rpc"
+
+
+def _version_body(version: str = "surrealdb-2.0.0") -> bytes:
+    return encode({"id": "1", "result": version})
+
+
+@pytest.mark.asyncio
+async def test_pooled_session_reused_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single pooled session is created on entry and reused per request."""
+    created: list[aiohttp.ClientSession] = []
+    original = aiohttp.ClientSession
+
+    def _factory(*args: Any, **kwargs: Any) -> aiohttp.ClientSession:
+        session = original(*args, **kwargs)
+        created.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "surrealdb.connections.async_http.aiohttp.ClientSession", _factory
+    )
+
+    connection = AsyncHttpSurrealConnection(URL)
+    with aioresponses() as mocked:
+        mocked.post(RPC, body=_version_body(), status=200)
+        mocked.post(RPC, body=_version_body(), status=200)
+        async with connection:
+            pooled = connection._session
+            assert pooled is not None
+            await connection.version()
+            await connection.version()
+            # Both requests reused the same pooled session object.
+            assert connection._session is pooled
+
+    # Exactly one session was created for the whole context manager,
+    # not one per request.
+    assert len(created) == 1
+    # It was closed on exit and the reference cleared.
+    assert created[0].closed is True
+    assert connection._session is None
+
+
+@pytest.mark.asyncio
+async def test_new_session_per_request_without_context_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside a context manager each request opens its own session."""
+    created: list[aiohttp.ClientSession] = []
+    original = aiohttp.ClientSession
+
+    def _factory(*args: Any, **kwargs: Any) -> aiohttp.ClientSession:
+        session = original(*args, **kwargs)
+        created.append(session)
+        return session
+
+    monkeypatch.setattr(
+        "surrealdb.connections.async_http.aiohttp.ClientSession", _factory
+    )
+
+    connection = AsyncHttpSurrealConnection(URL)
+    with aioresponses() as mocked:
+        mocked.post(RPC, body=_version_body(), status=200)
+        mocked.post(RPC, body=_version_body(), status=200)
+        await connection.version()
+        await connection.version()
+
+    assert connection._session is None
+    assert len(created) == 2
+
+
+@pytest.mark.asyncio
+async def test_close_is_noop_on_fresh_connection() -> None:
+    """close() is a safe, idempotent no-op when no session is open."""
+    connection = AsyncHttpSurrealConnection(URL)
+    assert connection._session is None
+    await connection.close()
+    await connection.close()
+    assert connection._session is None
+
+
+@pytest.mark.asyncio
+async def test_close_closes_pooled_session() -> None:
+    """close() closes an open pooled session and clears it."""
+    connection = AsyncHttpSurrealConnection(URL)
+    connection._session = aiohttp.ClientSession()
+    session = connection._session
+    await connection.close()
+    assert session.closed is True
+    assert connection._session is None
+    # Second close is still a safe no-op.
+    await connection.close()

--- a/tests/unit_tests/connections/http_lifecycle/test_blocking_http.py
+++ b/tests/unit_tests/connections/http_lifecycle/test_blocking_http.py
@@ -1,0 +1,118 @@
+"""Lifecycle tests for the blocking HTTP connection (issues #8 and #10).
+
+These are fully mocked with ``responses`` and need no live server.
+"""
+
+from typing import Any
+
+import pytest
+import requests
+import responses
+
+import surrealdb.connections.blocking_http as blocking_http_module
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.data.cbor import encode
+
+URL = "http://localhost:8000"
+RPC = f"{URL}/rpc"
+
+
+def _version_body(version: str = "surrealdb-2.0.0") -> bytes:
+    return encode({"id": "1", "result": version})
+
+
+def _register_two_versions() -> None:
+    for _ in range(2):
+        responses.add(
+            responses.POST,
+            RPC,
+            body=_version_body(),
+            status=200,
+            content_type="application/cbor",
+        )
+
+
+@responses.activate
+def test_pooled_session_reused_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single pooled session is created on entry and reused per request."""
+    _register_two_versions()
+
+    used_sessions: list[requests.Session] = []
+    original_session_post = requests.Session.post
+
+    def _spy_session_post(
+        self: requests.Session, *args: Any, **kwargs: Any
+    ) -> requests.Response:
+        used_sessions.append(self)
+        return original_session_post(self, *args, **kwargs)
+
+    module_post_calls = {"count": 0}
+    original_module_post = blocking_http_module.requests.post
+
+    def _spy_module_post(*args: Any, **kwargs: Any) -> requests.Response:
+        module_post_calls["count"] += 1
+        return original_module_post(*args, **kwargs)
+
+    monkeypatch.setattr(requests.Session, "post", _spy_session_post)
+    monkeypatch.setattr(blocking_http_module.requests, "post", _spy_module_post)
+
+    connection = BlockingHttpSurrealConnection(URL)
+    with connection:
+        pooled = connection.session
+        assert pooled is not None
+        connection.version()
+        connection.version()
+        assert connection.session is pooled
+
+    # Both requests went through the same pooled session, and the
+    # non-pooled ``requests.post`` fallback was never used.
+    assert len(used_sessions) == 2
+    assert all(s is pooled for s in used_sessions)
+    assert module_post_calls["count"] == 0
+    # Session closed and cleared on exit.
+    assert connection.session is None
+
+
+@responses.activate
+def test_request_fallback_without_context_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside a context manager requests use the ``requests.post`` fallback."""
+    _register_two_versions()
+
+    module_post_calls = {"count": 0}
+    original_module_post = blocking_http_module.requests.post
+
+    def _spy_module_post(*args: Any, **kwargs: Any) -> requests.Response:
+        module_post_calls["count"] += 1
+        return original_module_post(*args, **kwargs)
+
+    monkeypatch.setattr(blocking_http_module.requests, "post", _spy_module_post)
+
+    connection = BlockingHttpSurrealConnection(URL)
+    connection.version()
+    connection.version()
+
+    assert connection.session is None
+    assert module_post_calls["count"] == 2
+
+
+def test_close_is_noop_on_fresh_connection() -> None:
+    """close() is a safe, idempotent no-op when no session is open."""
+    connection = BlockingHttpSurrealConnection(URL)
+    assert connection.session is None
+    connection.close()
+    connection.close()
+    assert connection.session is None
+
+
+def test_close_closes_pooled_session() -> None:
+    """close() closes an open pooled session and clears it."""
+    connection = BlockingHttpSurrealConnection(URL)
+    connection.session = requests.Session()
+    connection.close()
+    assert connection.session is None
+    # Second close is still a safe no-op.
+    connection.close()


### PR DESCRIPTION
## Summary

Fixes two HTTP-connection lifecycle bugs from the pre-3.0.0-stable cleanup, in both `AsyncHttpSurrealConnection` and `BlockingHttpSurrealConnection`.

### `close()` not implemented
Neither HTTP class overrode `close()`, so calling it hit the base-class `NotImplementedError` (`async_template.py` / `sync_template.py`). Both classes now implement `close()`:
- closes the pooled session if one is open (async: `await self._session.close()`, blocking: `self.session.close()`),
- guards `None` / already-closed,
- clears the reference,
- is an idempotent no-op when there is no open session.

### session pooling
`_send` previously opened a brand-new `aiohttp.ClientSession` per request (async) / called `requests.post` directly (blocking), ignoring the pooled session set in `__aenter__` / `__enter__`. `_send` now reuses the pooled session when it is set and falls back to a per-request session/request otherwise, so non-context-manager usage still works. `__aexit__` / `__exit__` now delegate to `close()` so the pooled session is reliably closed and cleared on exit.

The async `_send` body was factored into a small `_request` helper so the pooled and per-request paths share identical request/decoding logic.

## Tests

New fully-mocked lifecycle tests under `tests/unit_tests/connections/http_lifecycle/` (no live server needed; a local `conftest.py` overrides the server-reachability skip since these mock the transport):

- a single pooled session is created on entry and reused across multiple requests within `async with` / `with` (async uses `aioresponses` + a `ClientSession` construction counter; blocking uses `responses` and spies on `requests.Session.post` vs the module-level `requests.post`);
- outside a context manager each request uses its own session/`requests.post` fallback;
- `close()` is a safe, idempotent no-op on a fresh connection, and closes+clears an open pooled session.

Async and blocking behaviour kept in parity.

## Verification
- `uv run ruff check --fix src/` — pass
- `uv run ruff format` (edited files only) — pass
- `uv run mypy --explicit-package-bases src/` — pass
- `uv run pyright src/` — pass
- `uv run mypy --explicit-package-bases tests/` — pass
- `uv run pytest tests/unit_tests/connections --ignore=tests/unit_tests/connections/embedded -q` — 8 passed, 289 skipped (server-dependent tests self-skip; no server running)
