### PR TITLE
v3 return semantics: eager sync builders, query() sequence + .first(), select() unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Breaking:** Sync `select`, `create`, `update`, `upsert`, `delete`, and `insert` are now **eager**. `select(...)` and `delete(...)` run immediately and return the result. `create/update/upsert(record, data)` and `insert(table, data)` run immediately and return the result; the no-data form (`create(record)`, `insert(table)`) returns a builder whose clause methods (`.content` / `.replace` / `.merge` / `.patch` / `.relation`) and `.execute()` run the operation and return the result. Fixes the magic-consumption footguns (`bool()`, `==`, indexing, `__getattr__`) reported in findings #1/#4.
+- **Breaking:** Sync builders no longer implement any auto-executing magic methods (`__bool__`, `__eq__`, `__getitem__`, `__iter__`, `__len__`, `__contains__`, `__getattr__`, and the pending-`repr`/`str`). Inspecting a builder never triggers a query or mutation.
+- **Breaking:** `query()` now **always** returns a `list[Value]` (one entry per statement) — even for a single statement — for both async (`await db.query(...)` / `.execute()`) and sync (`.execute()`). This supersedes the earlier "single `Value` for one statement, `tuple` for many" behaviour (finding #2). Added `.first()` (async coroutine / sync method) returning the first statement's result, or `None` when there are no statements.
+- **Breaking:** `select(RecordID)` (or a single `"table:id"` string) now returns `dict[str, Value] | None` (the record, or `None` when it is absent) instead of a single-element list; `select(Table)` (or a bare table name) still returns `list[Value]`. `select()` is now typed via `@overload` on the templates, all four connections, and the session/transaction classes (findings #3/#15).
 
 ## [3.0.0-alpha.1] - 2026-07-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,17 +119,17 @@ with Surreal("ws://localhost:8000/rpc") as db:
     # In SurrealQL you can do a direct insert 
     # and the table will be created if it doesn't exist
     
-    # Create
+    # Create (sync query() returns a builder - call .execute() to run it)
     db.query("""
     insert into person {
         user: 'me',
         password: 'very_safe',
         tags: ['python', 'documentation']
     };
-    """)
+    """).execute()
 
-    # Read
-    print(db.query("select * from person"))
+    # Read - .first() returns the first statement's result (the rows)
+    print(db.query("select * from person").first())
     
     # Update
     print(db.query("""
@@ -138,10 +138,10 @@ with Surreal("ws://localhost:8000/rpc") as db:
         password: 'more_safe',
         tags: ['awesome']
     };
-    """))
+    """).execute())
 
     # Delete
-    print(db.query("delete person"))
+    print(db.query("delete person").execute())
 ```
 
 ## CRUD builder pattern (v3.0)
@@ -180,8 +180,23 @@ The builder is **typed** via `@overload`:
 - `str` target     -> `Value` (a record-id string returns a dict; a table-name
   string returns a list - the type checker can't tell them apart, so falls back to `Value`)
 
-Sync usage is similar, but the clause methods are **terminal** (there is
-no `await` to defer to, so they run immediately and return the result):
+`select()` (async and sync) always runs eagerly and unwraps single records:
+
+- `select(RecordID(...))` (or a `"table:id"` string) -> `dict[str, Value] | None`
+  (`None` when the record does not exist)
+- `select(Table(...))` (or a bare table-name string) -> `list[Value]`
+
+```python
+row = await db.select(RecordID("person", "tobie"))  # dict | None
+rows = await db.select(Table("person"))             # list
+```
+
+Sync usage is **eager** - there is no `await` to defer to, so the
+connection methods run single-shot operations immediately and return the
+plain result. A builder is only handed back for the deferred no-data form
+so you can pick a clause; there are **no** magic methods, so a builder
+never auto-executes on `bool()`, `==`, indexing, iteration, or attribute
+access.
 
 ```python
 from surrealdb import Surreal
@@ -190,43 +205,36 @@ with Surreal("ws://localhost:8000/rpc") as db:
     db.signin({"username": "root", "password": "root"})
     db.use("ns", "db")
 
-    # Terminal: .merge runs the UPDATE and returns the result dict.
-    out = db.create(RecordID("person", "tobie")).merge({"name": "Tobie"})
+    # Passing data runs immediately and returns the created record dict.
+    tobie = db.create(RecordID("person", "tobie"), {"name": "Tobie"})
 
-    # No-clause form: lazy builder; auto-executes the first time you
-    # consume it (indexing, iteration, ==, attribute access, ...).
-    builder = db.create(RecordID("person", "alice"))
-    print(builder["id"])  # <- triggers execution, returns the dict's "id"
+    # No-data form returns a builder; a terminal clause method runs it.
+    out = db.create(RecordID("person", "alice")).merge({"name": "Alice"})
 
-    # Fire-and-forget: call .execute() because no consumption happens.
+    # Clause-less run: call .execute() explicitly.
+    empty = db.create(RecordID("person", "bob")).execute()
+
+    # select() and delete() always run eagerly and return the result.
+    row = db.select(RecordID("person", "tobie"))  # dict | None
+    db.delete(RecordID("person", "bob"))
+
+    # query() returns a builder; call .execute()/.first()/.into().
     db.query("DELETE temp_data;").execute()
 ```
 
-> Note: `__repr__` and `__str__` on a pending sync builder return a
-> `"<...pending>"` placeholder rather than executing the operation, so
-> debuggers, loggers, and `print()` cannot accidentally fire pending
-> queries or mutations.
->
-> ⚠ **Truthiness and comparison** auto-execute though.
-> `if db.query("DELETE foo;")`, `bool(db.create(...))`, and
-> `db.create(...) == something` will all run the operation. If you want
-> fire-and-forget, call `.execute()` explicitly. The full list of
-> auto-executing magic methods is `__getitem__`, `__iter__`, `__len__`,
-> `__contains__`, `__eq__`, `__ne__`, `__bool__`, and `__getattr__`.
-
 ### Thread safety
 
-Sync builders guard their cache with a per-builder lock so consuming the
-same builder from multiple threads issues exactly one RPC. They are
+The no-data sync builder guards its cache with a per-builder lock so
+calling `.execute()` from multiple threads issues exactly one RPC. It is
 **not** safe for concurrent *reconfiguration* though — calling `.merge()`
-on one thread while another consumes the result is a race on the
-builder's clause/data state that the lock does not cover. Treat builders
-as single-shot, single-owner values; pass the realised result between
+on one thread while another calls `.execute()` is a race on the builder's
+clause/data state that the lock does not cover. Treat builders as
+single-shot, single-owner values; pass the realised result between
 threads, not the builder itself.
 
 The underlying `BlockingWsSurrealConnection` is itself thread-safe (it
 serialises send/recv with an internal lock), so sharing a connection
-across threads and creating per-thread builders against it is fine.
+across threads and issuing per-thread operations against it is fine.
 
 ### Async cancellation and server truth
 
@@ -244,17 +252,22 @@ need atomic rollback semantics.
 
 ## Multi-statement queries and transactions (issue #232 fix)
 
-`query()` now surfaces every statement result. When the server returns a
-single result, `query()` returns a single Value. When it returns multiple
-(multi-statement queries or `BEGIN ... COMMIT` blocks), `query()` returns
-a `tuple[Value, ...]`.
+`query()` always returns a `list[Value]` - one entry per statement, even
+for a single statement - so multi-statement queries and `BEGIN ... COMMIT`
+blocks never silently drop results. Use `.first()` for the first
+statement's result (or `None` when there are no statements).
 
 ```python
-single = await db.query("SELECT * FROM person")
+rows = await db.query("SELECT * FROM person")       # [people_list]
+first = await db.query("SELECT * FROM person").first()  # people_list
 many = await db.query(
     "SELECT * FROM person; SELECT count() FROM person GROUP ALL"
 )
-# many is (people_list, count_list)
+# many is [people_list, count_list]
+
+# Sync: query() returns a builder - run it explicitly.
+rows = db.query("SELECT * FROM person").execute()   # [people_list]
+first = db.query("SELECT * FROM person").first()    # people_list
 ```
 
 You can also map the N statement results onto a dataclass via `.into()`:
@@ -324,10 +337,13 @@ v3.0 is a breaking change. Highlights:
 | `db.merge(record, data)`                         | `db.update(record).merge(data)`                           |
 | `db.patch(record, data)`                         | `db.update(record).patch(data)`                           |
 | `db.insert_relation(table, data)`                | `db.insert(table, data, relation=True)`                   |
-| `db.query("SELECT 1; SELECT 2")` -> first result | `db.query("SELECT 1; SELECT 2")` -> `tuple` of all results |
+| `db.query("SELECT 1")` -> single result          | `db.query("SELECT 1")` -> `[result]` (use `.first()` / `[0]`) |
+| `db.query("SELECT 1; SELECT 2")` -> first result | `db.query("SELECT 1; SELECT 2")` -> `list` of all results |
 | n/a                                              | `db.run("fn::name", [args])`                              |
 | n/a                                              | `db.query("...").into(MyDataclass)`                       |
-| Sync `db.query("DELETE foo")` runs immediately   | Sync `db.query("DELETE foo").execute()` (lazy builder)     |
+| Sync `db.query("DELETE foo")` runs immediately   | Sync `db.query("DELETE foo").execute()` (returns list)     |
+| Sync `db.create(rec)[...]` (magic auto-exec)     | Sync `db.create(rec, data)` eager, or `db.create(rec).execute()` |
+| `db.select(RecordID(...))` -> `[record]`         | `db.select(RecordID(...))` -> `record` dict or `None`     |
 | `db.delete("my-table")` (silently inlined)       | `db.delete(Table("my-table"))` (raw string rejected)      |
 
 > Bare-string resource targets are now strictly validated against the

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -148,6 +148,13 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     def query(
         self, query: str, vars: dict[str, Value] | None = None
     ) -> AsyncQueryBuilder:
+        """Run SurrealQL and return an awaitable builder.
+
+        Awaiting it (or ``.execute()``) returns ``list[Value]`` - one entry per
+        statement, always a list (the v3 fix for issue #232). Use ``.first()``
+        for the first statement's result, or ``.into(cls)`` to map the results
+        onto a dataclass / class.
+        """
         return AsyncQueryBuilder(
             executor=self._make_executor(),
             query=query,
@@ -193,6 +200,13 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     def create(
         self, record: RecordIdType, data: Value | None = None
     ) -> AsyncCrudBuilder[Any]:
+        """Create a record; returns an awaitable builder.
+
+        ``await db.create(record, data)`` is sugar for
+        ``await db.create(record).content(data)``. Clause methods
+        (``.content`` / ``.replace`` / ``.merge`` / ``.patch``) return the
+        builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
             operation="CREATE",
@@ -217,6 +231,11 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     def update(
         self, record: RecordIdType, data: Value | None = None
     ) -> AsyncCrudBuilder[Any]:
+        """Update records; returns an awaitable builder.
+
+        Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
+        ``.patch`` return the builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPDATE",
@@ -240,6 +259,11 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     def upsert(
         self, record: RecordIdType, data: Value | None = None
     ) -> AsyncCrudBuilder[Any]:
+        """Insert or update records; returns an awaitable builder.
+
+        Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
+        ``.patch`` return the builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPSERT",
@@ -255,6 +279,12 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     @overload
     def delete(self, record: str) -> AsyncCrudBuilder[Value]: ...
     def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
+        """Delete records; returns an awaitable builder.
+
+        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record; a
+        ``Table`` (or bare name) to the list of deleted records. ``DELETE`` has
+        no clause methods.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
             operation="DELETE",
@@ -269,6 +299,11 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         *,
         relation: bool = False,
     ) -> AsyncInsertBuilder:
+        """Insert record(s) or relation(s); returns an awaitable builder.
+
+        Pass ``relation=True`` (or chain ``.relation()``) for ``INSERT
+        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it.
+        """
         return AsyncInsertBuilder(
             executor=self._make_executor(),
             table=table,
@@ -306,6 +341,12 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     @overload
     async def select(self, record: str) -> Value: ...
     async def select(self, record: RecordIdType) -> Value:
+        """Select records.
+
+        A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
+        when it is absent. A ``Table`` (or bare table-name string) returns the
+        list of records.
+        """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
         query = f"SELECT * FROM {resource_ref}"

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -299,6 +299,12 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def unset(self, key: str) -> None:
         self.vars.pop(key)
 
+    @overload
+    async def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    async def select(self, record: Table) -> list[Value]: ...
+    @overload
+    async def select(self, record: str) -> Value: ...
     async def select(self, record: RecordIdType) -> Value:
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -307,7 +313,14 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         response = await self.query_raw(query, variables)
         self.check_response_for_error(response, "select")
         self._check_query_result(response["result"][0])
-        return response["result"][0]["result"]
+        result = response["result"][0]["result"]
+        # Single-record targets (RecordID / "table:id") unwrap the one-element
+        # result list to the record dict, or None when the record is absent.
+        if self._is_single_record_operation(record):
+            if isinstance(result, list):
+                return result[0] if result else None
+            return result
+        return result
 
     async def version(self) -> str:
         message = RequestMessage(RequestMethod.VERSION)

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -117,29 +117,39 @@ class AsyncTemplate:
     ) -> AsyncQueryBuilder:
         """Run one or more SurrealQL statements against the database.
 
-        Returns an awaitable builder. Awaiting the builder returns:
+        Returns an awaitable builder. Awaiting it (or calling ``.execute()``)
+        returns ``list[Value]`` - one entry per statement, always a list even
+        for a single statement (this is the v3.0 fix for issue #232 - earlier
+        versions silently dropped every result after the first).
 
-        - The result Value when the server returned exactly one statement result
-        - A ``tuple[Value, ...]`` of all statement results when N>1 statements ran
-          (this is the v3.0 fix for issue #232 - earlier versions silently
-          dropped every result after the first).
-
-        Use ``.into(MyResult)`` to map the N statement results positionally onto
-        a dataclass or any class accepting keyword arguments.
+        Use ``.first()`` for the first statement's result, or ``.into(MyResult)``
+        to map the N statement results positionally onto a dataclass or any
+        class accepting keyword arguments.
 
         Args:
             query: SurrealQL statement(s).
             vars: Variables referenced in the query.
 
         Example:
-            single = await db.query('SELECT * FROM person')
+            rows = await db.query('SELECT * FROM person')  # list of statements
+            first = await db.query('SELECT * FROM person').first()
             many = await db.query('SELECT * FROM person; SELECT count() FROM person GROUP ALL')
             mapped = await db.query('CREATE ...; SELECT ...').into(MyResult)
         """
         raise NotImplementedError(f"query not implemented for: {self}")
 
+    @overload
+    async def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    async def select(self, record: Table) -> list[Value]: ...
+    @overload
+    async def select(self, record: str) -> Value: ...
     async def select(self, record: RecordIdType) -> Value:
         """Select all records in a table or a specific record.
+
+        A ``RecordID`` (or ``"table:id"`` string) returns the record dict, or
+        ``None`` when it is absent. A ``Table`` (or bare table-name string)
+        returns the list of records.
 
         Args:
             record: The table or record ID to select.

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -215,6 +215,13 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncQueryBuilder:
+        """Run SurrealQL and return an awaitable builder.
+
+        Awaiting it (or ``.execute()``) returns ``list[Value]`` - one entry per
+        statement, always a list (the v3 fix for issue #232). Use ``.first()``
+        for the first statement's result, or ``.into(cls)`` to map the results
+        onto a dataclass / class.
+        """
         return AsyncQueryBuilder(
             executor=self._make_executor(session_id, txn_id),
             query=query,
@@ -308,6 +315,12 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value:
+        """Select records.
+
+        A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
+        when it is absent. A ``Table`` (or bare table-name string) returns the
+        list of records.
+        """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
         query = f"SELECT * FROM {resource_ref}"
@@ -377,6 +390,13 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        """Create a record; returns an awaitable builder.
+
+        ``await db.create(record, data)`` is sugar for
+        ``await db.create(record).content(data)``. Clause methods
+        (``.content`` / ``.replace`` / ``.merge`` / ``.patch``) return the
+        builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="CREATE",
@@ -421,6 +441,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        """Update records; returns an awaitable builder.
+
+        Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
+        ``.patch`` return the builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPDATE",
@@ -464,6 +489,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        """Insert or update records; returns an awaitable builder.
+
+        Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
+        ``.patch`` return the builder so it stays awaitable.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPSERT",
@@ -503,6 +533,12 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        """Delete records; returns an awaitable builder.
+
+        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record; a
+        ``Table`` (or bare name) to the list of deleted records. ``DELETE`` has
+        no clause methods.
+        """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="DELETE",
@@ -519,6 +555,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncInsertBuilder:
+        """Insert record(s) or relation(s); returns an awaitable builder.
+
+        Pass ``relation=True`` (or chain ``.relation()``) for ``INSERT
+        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it.
+        """
         return AsyncInsertBuilder(
             executor=self._make_executor(session_id, txn_id),
             table=table,
@@ -555,6 +596,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         diff: bool = False,
         session_id: UUID | None = None,
     ) -> UUID:
+        """Start a live query on *table* and return its UUID.
+
+        Pass ``diff=True`` for JSON-Patch notifications. Consume notifications
+        with :meth:`subscribe_live` and stop the query with :meth:`kill`.
+        """
         kwargs: dict[str, Any] = {"table": table}
         if session_id is not None:
             kwargs["session"] = session_id
@@ -569,6 +615,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     async def subscribe_live(
         self, query_uuid: str | UUID
     ) -> AsyncGenerator[dict[str, Value], None]:
+        """Return an async generator of notifications for a live query id."""
         result_queue: Queue[dict[str, Any]] = Queue()
         suid = str(query_uuid)
 
@@ -590,6 +637,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         query_uuid: str | UUID,
         session_id: UUID | None = None,
     ) -> None:
+        """Kill a running live query by its UUID."""
         kwargs: dict[str, Any] = {"uuid": query_uuid}
         if session_id is not None:
             kwargs["session"] = session_id

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -277,9 +277,34 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         message = RequestMessage(RequestMethod.UNSET, **kwargs)
         await self._send(message, "unsetting")
 
+    @overload
+    async def select(
+        self,
+        record: RecordID,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> dict[str, Value] | None: ...
+    @overload
+    async def select(
+        self,
+        record: Table,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[Value]: ...
+    @overload
+    async def select(
+        self,
+        record: str,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> Value: ...
     async def select(
         self,
         record: RecordIdType,
+        *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value:
@@ -292,7 +317,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         )
         self.check_response_for_error(response, "select")
         self._check_query_result(response["result"][0])
-        return response["result"][0]["result"]
+        result = response["result"][0]["result"]
+        # Single-record targets (RecordID / "table:id") unwrap the one-element
+        # result list to the record dict, or None when the record is absent.
+        if self._is_single_record_operation(record):
+            if isinstance(result, list):
+                return result[0] if result else None
+            return result
+        return result
 
     def _make_executor(
         self,
@@ -698,6 +730,12 @@ class AsyncSurrealSession:
     async def unset(self, key: str) -> None:
         await self._connection.unset(key, session_id=self._session_id)
 
+    @overload
+    async def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    async def select(self, record: Table) -> list[Value]: ...
+    @overload
+    async def select(self, record: str) -> Value: ...
     async def select(self, record: RecordIdType) -> Value:
         return await self._connection.select(record, session_id=self._session_id)
 
@@ -787,6 +825,12 @@ class AsyncSurrealTransaction:
             txn_id=self._txn_id,
         )
 
+    @overload
+    async def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    async def select(self, record: Table) -> list[Value]: ...
+    @overload
+    async def select(self, record: str) -> Value: ...
     async def select(self, record: RecordIdType) -> Value:
         return await self._connection.select(
             record,

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -108,7 +108,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
                 and error.get("code") == -32000
                 and "No result found" in error.get("message", "")
             ):
-                auth_response = self.query("SELECT * FROM $auth").execute()
+                auth_response = self.query("SELECT * FROM $auth").first()
                 if isinstance(auth_response, list) and len(auth_response) > 0:
                     return auth_response[0]
             if error is not None:
@@ -159,24 +159,19 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
 
         return _executor
 
-    # CRUD overloads --------------------------------------------------------
+    # CRUD (eager) ----------------------------------------------------------
+    #
+    # Passing ``data`` runs the operation immediately and returns the result;
+    # the no-data form returns a builder so the caller can pick a clause.
 
     @overload
-    def create(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def create(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
-    @overload
-    def create(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="CREATE",
             record=record,
@@ -184,80 +179,101 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
             data=data,
             always_unwrap=True,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
-    def update(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def update(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[list[Value]]: ...
+    def update(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
     @overload
-    def update(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[Value]: ...
+    def update(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def update(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def update(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def update(self, record: str, data: Value) -> Value: ...
     def update(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[Any] | Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPDATE",
             record=record,
             op_name="update",
             data=data,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
-    def upsert(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def upsert(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[list[Value]]: ...
+    def upsert(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
     @overload
-    def upsert(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[Value]: ...
+    def upsert(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def upsert(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[Any] | Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPSERT",
             record=record,
             op_name="upsert",
             data=data,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
-    def delete(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> dict[str, Value]: ...
     @overload
-    def delete(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    def delete(self, record: Table) -> list[Value]: ...
     @overload
-    def delete(self, record: str) -> SyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    def delete(self, record: str) -> Value: ...
+    def delete(self, record: RecordIdType) -> Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="DELETE",
             record=record,
             op_name="delete",
         )
+        return cast(Value, builder.execute())
 
+    @overload
+    def insert(
+        self, table: str | Table, *, relation: bool = False
+    ) -> SyncInsertBuilder: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, relation: bool = False
+    ) -> list[Value]: ...
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
         relation: bool = False,
-    ) -> SyncInsertBuilder:
-        return SyncInsertBuilder(
+    ) -> SyncInsertBuilder | list[Value]:
+        builder = SyncInsertBuilder(
             executor=self._make_executor(),
             table=table,
             data=data,
             relation=relation,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     def run(
         self,
@@ -282,6 +298,12 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def unset(self, key: str) -> None:
         self.vars.pop(key)
 
+    @overload
+    def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    def select(self, record: Table) -> list[Value]: ...
+    @overload
+    def select(self, record: str) -> Value: ...
     def select(self, record: RecordIdType) -> Value:
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -290,7 +312,14 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         response = self.query_raw(query, variables)
         self.check_response_for_error(response, "select")
         self._check_query_result(response["result"][0])
-        return response["result"][0]["result"]
+        result = response["result"][0]["result"]
+        # Single-record targets (RecordID / "table:id") unwrap the one-element
+        # result list to the record dict, or None when the record is absent.
+        if self._is_single_record_operation(record):
+            if isinstance(result, list):
+                return result[0] if result else None
+            return result
+        return result
 
     def version(self) -> str:
         message = RequestMessage(RequestMethod.VERSION)

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -5,6 +5,7 @@ from typing import Any, cast, overload
 import requests
 
 from surrealdb.connections.builders import (
+    _UNSET,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
@@ -131,6 +132,13 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def query(
         self, query: str, vars: dict[str, Value] | None = None
     ) -> SyncQueryBuilder:
+        """Run SurrealQL and return a builder; trigger it explicitly.
+
+        ``.execute()`` returns ``list[Value]`` (one entry per statement, always
+        a list - the v3 fix for issue #232), ``.first()`` returns the first
+        statement's result (or ``None``), and ``.into(cls)`` maps the statement
+        results onto a dataclass / class.
+        """
         return SyncQueryBuilder(
             executor=self._make_executor(),
             query=query,
@@ -169,19 +177,26 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        """Create a record (eager).
+
+        ``db.create(record, data)`` runs ``CREATE ... CONTENT $data``
+        immediately and returns the created record (``data=None`` runs
+        ``CONTENT NULL``). ``db.create(record)`` (no data) returns a
+        :class:`SyncCrudBuilder` so the caller can pick a terminal clause
+        (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` / ``.execute``).
+        """
         builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="CREATE",
             record=record,
             op_name="create",
-            data=data,
             always_unwrap=True,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
@@ -196,18 +211,23 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def update(self, record: str, data: Value) -> Value: ...
     def update(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[Any] | Value:
+        """Update records, replacing existing content by default (eager).
+
+        ``db.update(record, data)`` runs eagerly and returns the result
+        (``data=None`` runs ``CONTENT NULL``); the no-data form returns a
+        :class:`SyncCrudBuilder` with terminal clause methods.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPDATE",
             record=record,
             op_name="update",
-            data=data,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
@@ -222,18 +242,23 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[Any] | Value:
+        """Insert or update records (eager).
+
+        ``db.upsert(record, data)`` runs eagerly and returns the result
+        (``data=None`` runs ``CONTENT NULL``); the no-data form returns a
+        :class:`SyncCrudBuilder` with terminal clause methods.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPSERT",
             record=record,
             op_name="upsert",
-            data=data,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def delete(self, record: RecordID) -> dict[str, Value]: ...
@@ -242,6 +267,11 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def delete(self, record: str) -> Value: ...
     def delete(self, record: RecordIdType) -> Value:
+        """Delete records eagerly and return the deleted record(s).
+
+        A ``RecordID`` (or ``"table:id"``) returns the single deleted record; a
+        ``Table`` (or bare name) returns the list of deleted records.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="DELETE",
@@ -261,19 +291,26 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def insert(
         self,
         table: str | Table,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         relation: bool = False,
     ) -> SyncInsertBuilder | list[Value]:
+        """Insert record(s) or relation(s) into a table (eager).
+
+        ``db.insert(table, data)`` runs immediately and returns the inserted
+        records. ``db.insert(table)`` (no data) returns a
+        :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
+        ``.relation()``) for ``INSERT RELATION INTO`` and run it with
+        ``.content(data)`` / ``.execute()``.
+        """
         builder = SyncInsertBuilder(
             executor=self._make_executor(),
             table=table,
-            data=data,
             relation=relation,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     def run(
         self,
@@ -305,6 +342,12 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def select(self, record: str) -> Value: ...
     def select(self, record: RecordIdType) -> Value:
+        """Select records eagerly.
+
+        A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
+        when it is absent. A ``Table`` (or bare table-name string) returns the
+        list of records.
+        """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
         query = f"SELECT * FROM {resource_ref}"

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -6,7 +6,7 @@ import threading
 import uuid
 from collections.abc import Generator
 from types import TracebackType
-from typing import Any, overload
+from typing import Any, cast, overload
 from uuid import UUID
 
 import websockets
@@ -231,9 +231,34 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self.id = message.id
         self._send(message, "unsetting")
 
+    @overload
+    def select(
+        self,
+        record: RecordID,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> dict[str, Value] | None: ...
+    @overload
+    def select(
+        self,
+        record: Table,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[Value]: ...
+    @overload
+    def select(
+        self,
+        record: str,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> Value: ...
     def select(
         self,
         record: RecordIdType,
+        *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value:
@@ -246,7 +271,14 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         )
         self.check_response_for_error(response, "select")
         self._check_query_result(response["result"][0])
-        return response["result"][0]["result"]
+        result = response["result"][0]["result"]
+        # Single-record targets (RecordID / "table:id") unwrap the one-element
+        # result list to the record dict, or None when the record is absent.
+        if self._is_single_record_operation(record):
+            if isinstance(result, list):
+                return result[0] if result else None
+            return result
+        return result
 
     def _make_executor(
         self,
@@ -260,13 +292,17 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
 
         return _executor
 
-    # CRUD overloads --------------------------------------------------------
+    # CRUD (eager) ----------------------------------------------------------
+    #
+    # Sync CRUD runs single-shot operations immediately: passing ``data``
+    # executes and returns the result, while the no-data form returns a
+    # ``SyncCrudBuilder`` so the caller can pick a clause. ``select`` and
+    # ``delete`` always run eagerly.
 
     @overload
     def create(
         self,
-        record: RecordID,
-        data: Value | None = None,
+        record: RecordIdType,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -274,21 +310,12 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def create(
         self,
-        record: Table,
-        data: Value | None = None,
+        record: RecordIdType,
+        data: Value,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
-    @overload
-    def create(
-        self,
-        record: str,
-        data: Value | None = None,
-        *,
-        session_id: UUID | None = None,
-        txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    ) -> dict[str, Value]: ...
     def create(
         self,
         record: RecordIdType,
@@ -296,8 +323,8 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="CREATE",
             record=record,
@@ -305,12 +332,14 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             data=data,
             always_unwrap=True,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
     def update(
         self,
         record: RecordID,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -319,7 +348,6 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def update(
         self,
         record: Table,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -328,11 +356,37 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def update(
         self,
         record: str,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def update(
+        self,
+        record: RecordID,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> dict[str, Value]: ...
+    @overload
+    def update(
+        self,
+        record: Table,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[Value]: ...
+    @overload
+    def update(
+        self,
+        record: str,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> Value: ...
     def update(
         self,
         record: RecordIdType,
@@ -340,20 +394,22 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[Any] | Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPDATE",
             record=record,
             op_name="update",
             data=data,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
     def upsert(
         self,
         record: RecordID,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -362,7 +418,6 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def upsert(
         self,
         record: Table,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -371,11 +426,37 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def upsert(
         self,
         record: str,
-        data: Value | None = None,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def upsert(
+        self,
+        record: RecordID,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> dict[str, Value]: ...
+    @overload
+    def upsert(
+        self,
+        record: Table,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[Value]: ...
+    @overload
+    def upsert(
+        self,
+        record: str,
+        data: Value,
+        *,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> Value: ...
     def upsert(
         self,
         record: RecordIdType,
@@ -383,14 +464,17 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> SyncCrudBuilder[Any] | Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPSERT",
             record=record,
             op_name="upsert",
             data=data,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     @overload
     def delete(
@@ -399,7 +483,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    ) -> dict[str, Value]: ...
     @overload
     def delete(
         self,
@@ -407,7 +491,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[list[Value]]: ...
+    ) -> list[Value]: ...
     @overload
     def delete(
         self,
@@ -415,21 +499,41 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Value]: ...
+    ) -> Value: ...
     def delete(
         self,
         record: RecordIdType,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any]:
-        return SyncCrudBuilder(
+    ) -> Value:
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="DELETE",
             record=record,
             op_name="delete",
         )
+        return cast(Value, builder.execute())
 
+    @overload
+    def insert(
+        self,
+        table: str | Table,
+        *,
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncInsertBuilder: ...
+    @overload
+    def insert(
+        self,
+        table: str | Table,
+        data: Value,
+        *,
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[Value]: ...
     def insert(
         self,
         table: str | Table,
@@ -438,13 +542,16 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         relation: bool = False,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncInsertBuilder:
-        return SyncInsertBuilder(
+    ) -> SyncInsertBuilder | list[Value]:
+        builder = SyncInsertBuilder(
             executor=self._make_executor(session_id, txn_id),
             table=table,
             data=data,
             relation=relation,
         )
+        if data is not None:
+            return builder.execute()
+        return builder
 
     def run(
         self,
@@ -650,40 +757,88 @@ class BlockingSurrealSession:
     def unset(self, key: str) -> None:
         self._connection.unset(key, session_id=self._session_id)
 
+    @overload
+    def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    def select(self, record: Table) -> list[Value]: ...
+    @overload
+    def select(self, record: str) -> Value: ...
     def select(self, record: RecordIdType) -> Value:
         return self._connection.select(record, session_id=self._session_id)
 
+    @overload
+    def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         return self._connection.create(record, data, session_id=self._session_id)
 
+    @overload
+    def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def update(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    @overload
+    def update(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def update(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def update(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def update(self, record: str, data: Value) -> Value: ...
     def update(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.update(record, data, session_id=self._session_id)
 
+    @overload
+    def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def upsert(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    @overload
+    def upsert(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def upsert(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.upsert(record, data, session_id=self._session_id)
 
-    def delete(self, record: RecordIdType) -> SyncCrudBuilder[Any]:
+    @overload
+    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    @overload
+    def delete(self, record: Table) -> list[Value]: ...
+    @overload
+    def delete(self, record: str) -> Value: ...
+    def delete(self, record: RecordIdType) -> Value:
         return self._connection.delete(record, session_id=self._session_id)
 
+    @overload
+    def insert(
+        self, table: str | Table, *, relation: bool = False
+    ) -> SyncInsertBuilder: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, relation: bool = False
+    ) -> list[Value]: ...
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
         relation: bool = False,
-    ) -> SyncInsertBuilder:
+    ) -> SyncInsertBuilder | list[Value]:
         return self._connection.insert(
             table, data, relation=relation, session_id=self._session_id
         )
@@ -737,6 +892,12 @@ class BlockingSurrealTransaction:
             txn_id=self._txn_id,
         )
 
+    @overload
+    def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    def select(self, record: Table) -> list[Value]: ...
+    @overload
+    def select(self, record: str) -> Value: ...
     def select(self, record: RecordIdType) -> Value:
         return self._connection.select(
             record,
@@ -744,11 +905,15 @@ class BlockingSurrealTransaction:
             txn_id=self._txn_id,
         )
 
+    @overload
+    def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         return self._connection.create(
             record,
             data,
@@ -756,11 +921,23 @@ class BlockingSurrealTransaction:
             txn_id=self._txn_id,
         )
 
+    @overload
+    def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def update(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    @overload
+    def update(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def update(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def update(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def update(self, record: str, data: Value) -> Value: ...
     def update(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.update(
             record,
             data,
@@ -768,11 +945,23 @@ class BlockingSurrealTransaction:
             txn_id=self._txn_id,
         )
 
+    @overload
+    def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    @overload
+    def upsert(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    @overload
+    def upsert(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def upsert(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
         self,
         record: RecordIdType,
         data: Value | None = None,
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.upsert(
             record,
             data,
@@ -780,20 +969,34 @@ class BlockingSurrealTransaction:
             txn_id=self._txn_id,
         )
 
-    def delete(self, record: RecordIdType) -> SyncCrudBuilder[Any]:
+    @overload
+    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    @overload
+    def delete(self, record: Table) -> list[Value]: ...
+    @overload
+    def delete(self, record: str) -> Value: ...
+    def delete(self, record: RecordIdType) -> Value:
         return self._connection.delete(
             record,
             session_id=self._session_id,
             txn_id=self._txn_id,
         )
 
+    @overload
+    def insert(
+        self, table: str | Table, *, relation: bool = False
+    ) -> SyncInsertBuilder: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, relation: bool = False
+    ) -> list[Value]: ...
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
         relation: bool = False,
-    ) -> SyncInsertBuilder:
+    ) -> SyncInsertBuilder | list[Value]:
         return self._connection.insert(
             table,
             data,

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -14,6 +14,7 @@ import websockets.sync.client as ws_sync
 from websockets.sync.client import ClientConnection
 
 from surrealdb.connections.builders import (
+    _UNSET,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
@@ -165,6 +166,13 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncQueryBuilder:
+        """Run SurrealQL and return a builder; trigger it explicitly.
+
+        ``.execute()`` returns ``list[Value]`` (one entry per statement, always
+        a list - the v3 fix for issue #232), ``.first()`` returns the first
+        statement's result (or ``None``), and ``.into(cls)`` maps the statement
+        results onto a dataclass / class.
+        """
         return SyncQueryBuilder(
             executor=self._make_executor(session_id, txn_id),
             query=query,
@@ -262,6 +270,12 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value:
+        """Select records eagerly.
+
+        A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
+        when it is absent. A ``Table`` (or bare table-name string) returns the
+        list of records.
+        """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
         query = f"SELECT * FROM {resource_ref}"
@@ -319,22 +333,29 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def create(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        """Create a record (eager).
+
+        ``db.create(record, data)`` runs ``CREATE ... CONTENT $data``
+        immediately and returns the created record (``data=None`` runs
+        ``CONTENT NULL``). ``db.create(record)`` (no data) returns a
+        :class:`SyncCrudBuilder` so the caller can pick a terminal clause
+        (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` / ``.execute``).
+        """
         builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="CREATE",
             record=record,
             op_name="create",
-            data=data,
             always_unwrap=True,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def update(
@@ -390,21 +411,27 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def update(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[Any] | Value:
+        """Update records, replacing existing content by default (eager).
+
+        ``db.update(record, data)`` runs ``UPDATE ... CONTENT $data``
+        immediately and returns the result (``data=None`` runs ``CONTENT
+        NULL``). ``db.update(record)`` (no data) returns a
+        :class:`SyncCrudBuilder` with terminal clause methods.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPDATE",
             record=record,
             op_name="update",
-            data=data,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def upsert(
@@ -460,21 +487,27 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def upsert(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[Any] | Value:
+        """Insert or update records (eager).
+
+        ``db.upsert(record, data)`` runs ``UPSERT ... CONTENT $data``
+        immediately and returns the result (``data=None`` runs ``CONTENT
+        NULL``). ``db.upsert(record)`` (no data) returns a
+        :class:`SyncCrudBuilder` with terminal clause methods.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPSERT",
             record=record,
             op_name="upsert",
-            data=data,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     @overload
     def delete(
@@ -507,6 +540,11 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value:
+        """Delete records eagerly and return the deleted record(s).
+
+        A ``RecordID`` (or ``"table:id"``) returns the single deleted record; a
+        ``Table`` (or bare name) returns the list of deleted records.
+        """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="DELETE",
@@ -537,21 +575,28 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     def insert(
         self,
         table: str | Table,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         relation: bool = False,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncInsertBuilder | list[Value]:
+        """Insert record(s) or relation(s) into a table (eager).
+
+        ``db.insert(table, data)`` runs immediately and returns the inserted
+        records. ``db.insert(table)`` (no data) returns a
+        :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
+        ``.relation()``) for ``INSERT RELATION INTO`` and run it with
+        ``.content(data)`` / ``.execute()``.
+        """
         builder = SyncInsertBuilder(
             executor=self._make_executor(session_id, txn_id),
             table=table,
-            data=data,
             relation=relation,
         )
-        if data is not None:
-            return builder.execute()
-        return builder
+        if data is _UNSET:
+            return builder
+        return builder.content(data)
 
     def run(
         self,
@@ -583,6 +628,11 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         diff: bool = False,
         session_id: UUID | None = None,
     ) -> UUID:
+        """Start a live query on *table* and return its UUID.
+
+        Pass ``diff=True`` for JSON-Patch notifications. Consume notifications
+        with :meth:`subscribe_live` and stop the query with :meth:`kill`.
+        """
         kwargs: dict[str, Any] = {"table": table}
         if session_id is not None:
             kwargs["session"] = session_id
@@ -597,6 +647,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         query_uuid: str | UUID,
         session_id: UUID | None = None,
     ) -> None:
+        """Kill a running live query by its UUID."""
         kwargs: dict[str, Any] = {"uuid": query_uuid}
         if session_id is not None:
             kwargs["session"] = session_id
@@ -608,6 +659,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         query_uuid: str | UUID,
     ) -> Generator[dict[str, Value], None, None]:
+        """Yield live-query notifications for the given live query id."""
         try:
             while True:
                 try:
@@ -773,7 +825,7 @@ class BlockingSurrealSession:
     def create(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         return self._connection.create(record, data, session_id=self._session_id)
 
@@ -792,7 +844,7 @@ class BlockingSurrealSession:
     def update(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.update(record, data, session_id=self._session_id)
 
@@ -811,7 +863,7 @@ class BlockingSurrealSession:
     def upsert(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.upsert(record, data, session_id=self._session_id)
 
@@ -835,7 +887,7 @@ class BlockingSurrealSession:
     def insert(
         self,
         table: str | Table,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         relation: bool = False,
     ) -> SyncInsertBuilder | list[Value]:
@@ -912,7 +964,7 @@ class BlockingSurrealTransaction:
     def create(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         return self._connection.create(
             record,
@@ -936,7 +988,7 @@ class BlockingSurrealTransaction:
     def update(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.update(
             record,
@@ -960,7 +1012,7 @@ class BlockingSurrealTransaction:
     def upsert(
         self,
         record: RecordIdType,
-        data: Value | None = None,
+        data: Value = _UNSET,
     ) -> SyncCrudBuilder[Any] | Value:
         return self._connection.upsert(
             record,
@@ -993,7 +1045,7 @@ class BlockingSurrealTransaction:
     def insert(
         self,
         table: str | Table,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         relation: bool = False,
     ) -> SyncInsertBuilder | list[Value]:

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -76,6 +76,14 @@ U = TypeVar("U")
 AsyncExecutor = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
 SyncExecutor = Callable[[str, dict[str, Any]], dict[str, Any]]
 
+# Sentinel marking "no data argument was supplied". The eager sync CRUD
+# methods must distinguish ``db.create(rec)`` (defer - return a builder) from
+# ``db.create(rec, None)`` (execute eagerly with ``CONTENT NULL``). ``None`` is
+# a valid ``Value`` so it cannot double as the "absent" marker. Typed as
+# ``Any`` so it is accepted as the default of a ``data: Value`` parameter
+# without widening the public signature to ``Value | None``.
+_UNSET: Any = object()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -891,4 +899,5 @@ __all__ = [
     "SyncCrudBuilder",
     "SyncInsertBuilder",
     "SyncQueryBuilder",
+    "_UNSET",
 ]

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -1,5 +1,5 @@
 """
-Awaitable / lazy CRUD and query builders shared across all connection types.
+Awaitable / eager CRUD and query builders shared across all connection types.
 
 The builders capture the operation state (target resource, optional clause,
 data payload) and execute it through an injected ``executor`` callback.
@@ -7,31 +7,43 @@ This keeps wire-level concerns (session/transaction routing, websocket vs
 http transport) in the connection classes while the SQL construction and
 result extraction live in one place.
 
-Async builders are awaitable - ``await db.create(...)`` runs the operation.
-Sync builders implement magic methods so the returned object behaves like
-the result it produces; clause methods on sync builders are *terminal* and
-execute immediately, returning the underlying result. An explicit
-``execute()`` method is also available for callers that want to be explicit.
+Async vs sync
+-------------
+- **Async** builders are awaitable - ``await db.create(...)`` runs the
+  operation. Their clause methods (``.content`` / ``.replace`` / ``.merge``
+  / ``.patch``) return ``self`` so the builder stays awaitable, and the RPC
+  only fires on ``await`` / ``.execute()``.
+- **Sync** builders are *eager*: there is no ``await`` to defer execution to,
+  so the sync connection methods run single-shot operations immediately and
+  hand back the plain result. A sync builder is only returned for the
+  deferred forms - ``db.create(record)`` with no data, or ``db.insert(table)``
+  with no data - and every terminal method on it (``.content`` / ``.replace``
+  / ``.merge`` / ``.patch`` / ``.relation().content(...)`` / ``.execute()``)
+  runs the operation and returns the underlying result. Sync builders carry
+  **no** magic dunders: they never auto-execute on ``bool()``, ``==``,
+  indexing, iteration, or attribute access.
 
-Idempotency
------------
-Builders cache their result. Awaiting (or consuming) the same instance
-twice runs the operation **once**:
+Idempotency (async only)
+------------------------
+Async builders cache their result: awaiting the same instance twice (or from
+concurrent tasks) runs the operation **once** via an ``asyncio.Future`` so
+concurrent awaits all wait on the same in-flight operation rather than firing
+duplicate RPC calls. ``query().into(MyResult)`` shares the cached fetch with
+the parent ``query()`` builder, so ``await q.into(T)`` followed by ``await q``
+issues only one server round-trip. Sync builders keep a simple ``_executed``
+flag + lock so an explicit ``.execute()`` after a terminal clause returns the
+cached result rather than re-issuing the RPC.
 
-- Async builders use an ``asyncio.Future`` so concurrent awaits all wait on
-  the same in-flight operation rather than firing duplicate RPC calls.
-- Sync builders use a simple ``_executed`` flag plus cached result.
-
-In both cases ``query().into(MyResult)`` shares the cached fetch with the
-parent ``query()`` builder, so ``await q.into(T)`` followed by ``await q``
-issues only one server round-trip.
+query() always returns a sequence
+---------------------------------
+Both :class:`AsyncQueryBuilder` and :class:`SyncQueryBuilder` return
+``list[Value]`` - one entry per statement - even for a single statement
+(fixes the historic silent-discard behaviour, GH issue #232). Use
+``.first()`` to pull the first statement's result, or ``.into(cls)`` to map
+the N statement results positionally onto a dataclass / class.
 
 Safety
 ------
-- ``__repr__`` and ``__str__`` on sync builders return a ``"<...pending>"``
-  placeholder when the operation has not yet been triggered, so debuggers,
-  loggers, or pytest introspection cannot accidentally execute a pending
-  query / mutation.
 - Plain ``str`` resource targets are bound through ``type::thing()`` /
   ``type::table()`` (parameterised) rather than concatenated into the SQL,
   guarding against the classic injection footgun where untrusted input
@@ -44,7 +56,7 @@ import asyncio
 import inspect
 import re
 import threading
-from collections.abc import Awaitable, Callable, Generator, Iterator
+from collections.abc import Awaitable, Callable, Generator
 from dataclasses import fields, is_dataclass
 from typing import Any, Generic, TypeVar, cast
 
@@ -611,9 +623,9 @@ class AsyncInsertBuilder(_InsertState):
 class AsyncQueryBuilder(_QueryState):
     """Awaitable QUERY builder for async connections.
 
-    Returns a single Value when the server returned exactly one statement
-    result, otherwise a tuple of all statement results (fixes the historic
-    silent-discard behaviour - GH issue #232).
+    Always returns ``list[Value]`` - one entry per statement - even for a
+    single statement (fixes the historic silent-discard behaviour, GH issue
+    #232). Use ``.first()`` for the first statement's result.
 
     Idempotent: the underlying RPC fires once, and ``.into(cls)`` shares
     the same cached fetch.
@@ -642,13 +654,17 @@ class AsyncQueryBuilder(_QueryState):
         # issuing a second RPC.
         return AsyncQueryIntoBuilder(self, cls)
 
-    async def execute(self) -> Value | tuple[Value, ...]:
-        values = await self._fetch_values()
-        if len(values) == 1:
-            return values[0]
-        return tuple(values)
+    async def execute(self) -> list[Value]:
+        return cast("list[Value]", await self._fetch_values())
 
-    def __await__(self) -> Generator[Any, None, Value | tuple[Value, ...]]:
+    async def first(self) -> Value:
+        """Return the first statement's result (``None`` if no statements)."""
+        values = await self._fetch_values()
+        if not values:
+            return None
+        return cast(Value, values[0])
+
+    def __await__(self) -> Generator[Any, None, list[Value]]:
         return self.execute().__await__()
 
 
@@ -677,135 +693,31 @@ class AsyncQueryIntoBuilder(Generic[T]):
 # ---------------------------------------------------------------------------
 
 
-class _SyncBuilderMixin:
-    """Magic methods that auto-execute the builder when used as a result.
+class SyncCrudBuilder(_CrudState, Generic[T]):
+    """Eager CRUD builder for sync connections.
 
-    Subclasses must define ``_run_once()`` returning the cached result and
-    a ``_lock: threading.Lock`` attribute. Subclasses' ``_run_once()``
-    implementations must acquire ``self._lock`` around their cache check
-    so two threads consuming the same builder don't issue duplicate RPCs
-    or corrupt cached state.
+    Sync connection methods run single-shot operations (``db.create(record,
+    data)``) immediately and return the plain result. This builder is only
+    handed back for the deferred no-data form (``db.create(record)``) so the
+    caller can pick a clause. Every terminal method here runs the operation
+    the moment it is called and returns the underlying result:
 
-    Builders are *lazy* — the operation only runs when you ask for the
-    result. The methods that auto-execute are:
+    - ``.content(data)`` / ``.replace(data)`` / ``.merge(data)`` /
+      ``.patch(data)`` run ``CREATE/UPDATE/UPSERT ... <CLAUSE> $data``.
+    - ``.execute()`` runs the clause-less form.
 
-    - ``__getitem__`` (``builder[key]``)
-    - ``__iter__`` (``for x in builder``)
-    - ``__len__`` (``len(builder)``)
-    - ``__contains__`` (``x in builder``)
-    - ``__eq__`` / ``__ne__`` (``builder == other``)
-    - ``__bool__`` (``if builder:`` or ``not builder``)
-    - ``__getattr__`` (any unknown attribute lookup)
+    There are **no** magic dunders: the builder never auto-executes on
+    ``bool()``, ``==``, indexing, iteration, or attribute access. Repeat
+    ``.execute()`` calls return the cached result; calling another clause
+    method after the builder has executed raises rather than silently
+    returning the stale result.
 
-    .. warning::
-
-        ``__bool__`` and ``__eq__`` mean that **any** truthiness check or
-        comparison fires the operation, including idioms like
-        ``if db.query("DELETE foo;"): ...`` or
-        ``assert db.create(...)``. If you don't intend to consume the
-        result, call ``.execute()`` explicitly (for fire-and-forget) or
-        bind the builder to a name and only access it conditionally.
-
-    .. warning::
-
-        ``__getattr__`` forwards any non-underscore attribute access to
-        the realised result. A typo
-        (``builder.contnet({"x": 1})`` instead of ``.content``) will
-        silently fire the operation and *then* raise ``AttributeError``
-        from the result. A type checker (``mypy`` / ``pyright``) catches
-        these statically.
-
-    ``__repr__`` / ``__str__`` deliberately do **not** trigger execution -
-    they return a ``"<...pending>"`` placeholder when the builder has not
-    yet been run. This keeps loggers, debuggers, and test introspection
-    from accidentally firing pending queries.
-
-    Thread safety:
-        ``_run_once()`` is guarded by a per-builder lock so that
-        consuming the same builder from multiple threads issues exactly
-        one RPC. The builder is **not** safe for concurrent
-        *reconfiguration* across threads though - calling ``.merge()``
-        on one thread while another consumes the result is a race on
-        ``_mode`` / ``_data`` that the lock does not cover. Treat
-        builders as single-shot, single-owner values; pass the realised
-        result between threads, not the builder itself.
-    """
-
-    # The bool/None defaults are immutable and safe at class level.
-    # ``_lock`` deliberately has NO class-level default: subclasses MUST
-    # initialise a per-instance ``threading.Lock()`` in __init__.
-    # Without this guard a forgotten override would silently share one
-    # global lock across every builder instance, defeating the per-builder
-    # cache contract; with the type-only declaration, a forgotten override
-    # raises ``AttributeError`` at first ``_run_once`` call instead.
-    _executed: bool = False
-    _cached_result: Any = None
-    _lock: threading.Lock  # pyright: ignore[reportUninitializedInstanceVariable]
-
-    def _run_once(self) -> Any:  # pragma: no cover - abstract
-        raise NotImplementedError
-
-    def __getitem__(self, key: Any) -> Any:
-        return self._run_once()[key]
-
-    def __iter__(self) -> Iterator[Any]:
-        return iter(self._run_once())
-
-    def __len__(self) -> int:
-        return len(self._run_once())
-
-    def __contains__(self, item: Any) -> bool:
-        return item in self._run_once()
-
-    def __eq__(self, other: object) -> bool:
-        return bool(self._run_once() == other)
-
-    def __ne__(self, other: object) -> bool:
-        return bool(self._run_once() != other)
-
-    def __bool__(self) -> bool:
-        return bool(self._run_once())
-
-    def __repr__(self) -> str:
-        if self._executed:
-            return repr(self._cached_result)
-        return (
-            f"<{self.__class__.__name__} pending - call .execute() or consume to run>"
-        )
-
-    def __str__(self) -> str:
-        if self._executed:
-            return str(self._cached_result)
-        return self.__repr__()
-
-    def __getattr__(self, name: str) -> Any:
-        # __getattr__ is only invoked when the attribute is missing on the
-        # instance. Internal attributes start with ``_`` and are always set
-        # in __init__ so we never reach here for them.
-        if name.startswith("_"):
-            raise AttributeError(name)
-        return getattr(self._run_once(), name)
-
-
-class SyncCrudBuilder(_CrudState, _SyncBuilderMixin, Generic[T]):
-    """Lazy CRUD builder for sync connections.
-
-    Important - sync vs async difference:
-
-    - On **async** connections the clause methods (``content`` / ``replace``
-      / ``merge`` / ``patch``) return ``self`` so the builder remains
-      awaitable: ``await db.create(rec).merge({"x": 1})``.
-    - On **sync** connections the clause methods are **terminal**: they run
-      the operation immediately and return the result value. There is no
-      sync ``await`` to defer execution to, so chaining further would have
-      no effect.
-
-    For the no-clause case (plain ``db.create(record)``) the sync builder
-    is lazy and only runs once the result is consumed (indexed, iterated,
-    compared, etc.) or ``.execute()`` is called explicitly. Repeat consumes
-    return the same cached result; calling another clause method after the
-    builder has executed raises rather than silently returning the stale
-    result.
+    Thread safety: ``_run_once()`` is guarded by a per-builder lock so
+    consuming the same builder from multiple threads issues exactly one
+    RPC. The builder is **not** safe for concurrent *reconfiguration* -
+    calling ``.merge()`` on one thread while another calls ``.execute()``
+    races on ``_mode`` / ``_data``. Treat builders as single-shot,
+    single-owner values.
     """
 
     def __init__(
@@ -862,9 +774,13 @@ class SyncCrudBuilder(_CrudState, _SyncBuilderMixin, Generic[T]):
             return self._cached_result
 
 
-class SyncInsertBuilder(_InsertState, _SyncBuilderMixin):
-    """Lazy INSERT builder for sync connections (idempotent).
+class SyncInsertBuilder(_InsertState):
+    """Eager INSERT builder for sync connections.
 
+    Handed back only for the deferred no-data form (``db.insert(table)``).
+    ``.content(data)`` and ``.execute()`` run the operation and return the
+    inserted record(s); ``.relation()`` toggles ``INSERT RELATION`` and
+    returns ``self`` for chaining. There are **no** magic dunders.
     Reconfiguring the builder *after* it has executed raises rather than
     silently returning the cached result.
     """
@@ -912,13 +828,21 @@ class SyncInsertBuilder(_InsertState, _SyncBuilderMixin):
             return self._cached_result
 
 
-class SyncQueryBuilder(_QueryState, _SyncBuilderMixin):
-    """Lazy QUERY builder for sync connections.
+class SyncQueryBuilder(_QueryState):
+    """Eager QUERY builder for sync connections.
 
-    Idempotent: ``.execute()``, magic-method consumption, and
-    ``.into(cls)`` all share a single cached fetch and update
-    ``_executed`` consistently, so ``repr(builder)`` after any of them
-    no longer shows ``"pending"``.
+    ``db.query(sql)`` returns this builder; the caller triggers execution
+    explicitly:
+
+    - ``.execute()`` -> ``list[Value]`` (one entry per statement, always a
+      list - even for a single statement).
+    - ``.first()`` -> the first statement's result (``None`` if no
+      statements).
+    - ``.into(cls)`` -> the N statement results mapped positionally onto a
+      dataclass / class.
+
+    There are **no** magic dunders. Idempotent: ``.execute()``,
+    ``.first()``, and ``.into(cls)`` all share a single cached fetch.
     """
 
     def __init__(
@@ -930,35 +854,33 @@ class SyncQueryBuilder(_QueryState, _SyncBuilderMixin):
         super().__init__(query, variables)
         self._executor = executor
         self._executed = False
-        self._cached_result: Any = None
         self._cached_values: list[Any] | None = None
         self._lock = threading.Lock()
 
     def into(self, cls: type[T]) -> T:
-        # Reuse this builder's cached fetch so `await q` plus `q.into(T)`
-        # on the same instance only issues one RPC. Going through
-        # ``_run_once`` (rather than ``_fetch_values`` directly) keeps
-        # ``_executed`` and ``_cached_result`` in lockstep so subsequent
-        # ``repr(builder)`` shows the real result, not "pending".
-        self._run_once()
-        assert self._cached_values is not None  # set by _run_once
-        return _map_to_class(cls, self._cached_values)
+        # Reuse this builder's cached fetch so `.execute()` plus `.into(T)`
+        # on the same instance only issue one RPC.
+        values = self._run_once()
+        return _map_to_class(cls, values)
 
-    def execute(self) -> Value | tuple[Value, ...]:
-        return cast("Value | tuple[Value, ...]", self._run_once())
+    def execute(self) -> list[Value]:
+        return cast("list[Value]", self._run_once())
 
-    def _run_once(self) -> Any:
+    def first(self) -> Value:
+        """Return the first statement's result (``None`` if no statements)."""
+        values = self._run_once()
+        if not values:
+            return None
+        return cast(Value, values[0])
+
+    def _run_once(self) -> list[Any]:
         with self._lock:
             if not self._executed:
                 response = self._executor(self._query, self._variables)
-                values = self._statement_values(response)
-                self._cached_values = values
-                if len(values) == 1:
-                    self._cached_result = values[0]
-                else:
-                    self._cached_result = tuple(values)
+                self._cached_values = self._statement_values(response)
                 self._executed = True
-            return self._cached_result
+            assert self._cached_values is not None
+            return self._cached_values
 
 
 __all__ = [

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -50,112 +50,138 @@ class SyncTemplate:
     ) -> SyncQueryBuilder:
         """Run one or more SurrealQL statements against the database.
 
-        Returns a lazy builder. Triggering execution (e.g. by indexing,
-        iterating, or calling ``.execute()``) returns:
+        Returns a builder. Trigger execution explicitly:
 
-        - The result Value when the server returned exactly one statement result
-        - A ``tuple[Value, ...]`` of all statement results when N>1 statements
-          ran (this is the v3.0 fix for issue #232 - earlier versions silently
-          dropped every result after the first).
-
-        Use ``.into(MyResult)`` to map the N statement results positionally onto
-        a dataclass or any class accepting keyword arguments.
+        - ``.execute()`` -> ``list[Value]`` (one entry per statement, always a
+          list even for a single statement - this is the v3.0 fix for issue
+          #232, earlier versions silently dropped every result after the
+          first).
+        - ``.first()`` -> the first statement's result (``None`` if no
+          statements).
+        - ``.into(MyResult)`` maps the N statement results positionally onto a
+          dataclass or any class accepting keyword arguments.
         """
         raise NotImplementedError(f"query not implemented for: {self}")
 
+    @overload
+    def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    @overload
+    def select(self, record: Table) -> list[Value]: ...
+    @overload
+    def select(self, record: str) -> Value: ...
     def select(self, record: RecordIdType) -> Value:
-        """Select all records in a table or a specific record."""
+        """Select all records in a table or a specific record.
+
+        A ``RecordID`` (or ``"table:id"`` string) returns the record dict, or
+        ``None`` when it is absent. A ``Table`` (or bare table-name string)
+        returns the list of records.
+        """
         raise NotImplementedError(f"select not implemented for: {self}")
 
     @overload
-    def create(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def create(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
-    @overload
-    def create(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
+    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         """Create a record.
 
-        Returns a lazy builder. Optional terminal clause methods:
+        ``db.create(record, data)`` runs ``CREATE ... CONTENT $data`` eagerly
+        and returns the created record. ``db.create(record)`` (no data)
+        returns a :class:`SyncCrudBuilder`; pick a terminal clause to run it:
 
         - ``.content(data)``  -> ``CREATE ... CONTENT $data``
         - ``.replace(data)``  -> ``CREATE ... REPLACE $data``
         - ``.merge(data)``    -> ``CREATE ... MERGE $data``
         - ``.patch(data)``    -> ``CREATE ... PATCH $data``
-
-        ``db.create(record, data)`` is sugar for ``db.create(record).content(data)``.
+        - ``.execute()``      -> ``CREATE ...`` (no clause)
         """
         raise NotImplementedError(f"create not implemented for: {self}")
 
     @overload
-    def update(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def update(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[list[Value]]: ...
+    def update(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
     @overload
-    def update(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[Value]: ...
+    def update(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def update(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def update(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def update(self, record: str, data: Value) -> Value: ...
     def update(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
-        """Update records (replacing the existing data by default)."""
+    ) -> SyncCrudBuilder[Any] | Value:
+        """Update records (replacing the existing data by default).
+
+        ``db.update(record, data)`` runs eagerly and returns the result; the
+        no-data form returns a :class:`SyncCrudBuilder` with terminal clause
+        methods (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` /
+        ``.execute``).
+        """
         raise NotImplementedError(f"update not implemented for: {self}")
 
     @overload
-    def upsert(
-        self, record: RecordID, data: Value | None = None
-    ) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
-    def upsert(
-        self, record: Table, data: Value | None = None
-    ) -> SyncCrudBuilder[list[Value]]: ...
+    def upsert(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
     @overload
-    def upsert(
-        self, record: str, data: Value | None = None
-    ) -> SyncCrudBuilder[Value]: ...
+    def upsert(self, record: str) -> SyncCrudBuilder[Value]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value) -> dict[str, Value]: ...
+    @overload
+    def upsert(self, record: Table, data: Value) -> list[Value]: ...
+    @overload
+    def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
         self, record: RecordIdType, data: Value | None = None
-    ) -> SyncCrudBuilder[Any]:
-        """Insert or update records."""
+    ) -> SyncCrudBuilder[Any] | Value:
+        """Insert or update records.
+
+        ``db.upsert(record, data)`` runs eagerly and returns the result; the
+        no-data form returns a :class:`SyncCrudBuilder` with terminal clause
+        methods.
+        """
         raise NotImplementedError(f"upsert not implemented for: {self}")
 
     @overload
-    def delete(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> dict[str, Value]: ...
     @overload
-    def delete(self, record: Table) -> SyncCrudBuilder[list[Value]]: ...
+    def delete(self, record: Table) -> list[Value]: ...
     @overload
-    def delete(self, record: str) -> SyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> SyncCrudBuilder[Any]:
-        """Delete records."""
+    def delete(self, record: str) -> Value: ...
+    def delete(self, record: RecordIdType) -> Value:
+        """Delete records eagerly and return the deleted record(s)."""
         raise NotImplementedError(f"delete not implemented for: {self}")
 
     def info(self) -> Value:
         """Return the record of the authenticated record user."""
         raise NotImplementedError(f"info not implemented for: {self}")
 
+    @overload
+    def insert(
+        self, table: str | Table, *, relation: bool = False
+    ) -> SyncInsertBuilder: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, relation: bool = False
+    ) -> list[Value]: ...
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
         relation: bool = False,
-    ) -> SyncInsertBuilder:
+    ) -> SyncInsertBuilder | list[Value]:
         """Insert one or multiple records (or relations) into a table.
 
-        Pass ``relation=True`` to issue ``INSERT RELATION INTO``, or chain
-        ``.relation()`` on the returned builder.
+        ``db.insert(table, data)`` runs eagerly and returns the inserted
+        records. ``db.insert(table)`` (no data) returns a
+        :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
+        ``.relation()``) for ``INSERT RELATION INTO`` and run it with
+        ``.content(data)`` / ``.execute()``.
         """
         raise NotImplementedError(f"insert not implemented for: {self}")
 

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -3,6 +3,7 @@ from typing import Any, overload
 from uuid import UUID
 
 from surrealdb.connections.builders import (
+    _UNSET,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
@@ -83,13 +84,14 @@ class SyncTemplate:
     @overload
     def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
         """Create a record.
 
         ``db.create(record, data)`` runs ``CREATE ... CONTENT $data`` eagerly
-        and returns the created record. ``db.create(record)`` (no data)
-        returns a :class:`SyncCrudBuilder`; pick a terminal clause to run it:
+        and returns the created record (``data=None`` runs ``CONTENT NULL``).
+        ``db.create(record)`` (no data) returns a :class:`SyncCrudBuilder`;
+        pick a terminal clause to run it:
 
         - ``.content(data)``  -> ``CREATE ... CONTENT $data``
         - ``.replace(data)``  -> ``CREATE ... REPLACE $data``
@@ -112,7 +114,7 @@ class SyncTemplate:
     @overload
     def update(self, record: str, data: Value) -> Value: ...
     def update(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[Any] | Value:
         """Update records (replacing the existing data by default).
 
@@ -136,7 +138,7 @@ class SyncTemplate:
     @overload
     def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
-        self, record: RecordIdType, data: Value | None = None
+        self, record: RecordIdType, data: Value = _UNSET
     ) -> SyncCrudBuilder[Any] | Value:
         """Insert or update records.
 
@@ -171,7 +173,7 @@ class SyncTemplate:
     def insert(
         self,
         table: str | Table,
-        data: Value | None = None,
+        data: Value = _UNSET,
         *,
         relation: bool = False,
     ) -> SyncInsertBuilder | list[Value]:

--- a/tests/unit_tests/connections/bearer_v3/test_bearer_record_blocking_ws.py
+++ b/tests/unit_tests/connections/bearer_v3/test_bearer_record_blocking_ws.py
@@ -34,7 +34,7 @@ def test_bearer_access_record_user(bearer_v3_root_ws: dict) -> None:
 
     grant_result = root.query(
         "ACCESS bearer_record_api GRANT FOR RECORD users:testrecord"
-    ).execute()
+    ).first()
     assert grant_result is not None
     assert isinstance(grant_result, dict)
     grant_info = grant_result.get("grant")
@@ -59,7 +59,7 @@ def test_bearer_access_record_user(bearer_v3_root_ws: dict) -> None:
         assert tokens.access is not None
         assert tokens.access != ""
 
-        result = conn.query("RETURN 1")
+        result = conn.query("RETURN 1").first()
         assert result == 1
     finally:
         if conn.socket:
@@ -87,7 +87,7 @@ def test_bearer_record_signin_token_not_usable_with_authenticate(
     ).execute()
     grant_result = root.query(
         "ACCESS bearer_record_auth GRANT FOR RECORD auth_records:auth_test"
-    ).execute()
+    ).first()
     bearer_key = grant_result["grant"]["key"]
 
     conn = BlockingWsSurrealConnection(url)

--- a/tests/unit_tests/connections/bearer_v3/test_bearer_user_blocking_ws.py
+++ b/tests/unit_tests/connections/bearer_v3/test_bearer_user_blocking_ws.py
@@ -23,10 +23,14 @@ def test_bearer_access_system_user(bearer_v3_root_ws: dict) -> None:
     namespace = bearer_v3_root_ws["namespace"]
     database_name = bearer_v3_root_ws["database_name"]
 
-    root.query("DEFINE USER IF NOT EXISTS testuser ON DATABASE PASSWORD 'testpass' ROLES EDITOR").execute()
-    root.query("DEFINE ACCESS IF NOT EXISTS bearer_api ON DATABASE TYPE BEARER FOR USER").execute()
+    root.query(
+        "DEFINE USER IF NOT EXISTS testuser ON DATABASE PASSWORD 'testpass' ROLES EDITOR"
+    ).execute()
+    root.query(
+        "DEFINE ACCESS IF NOT EXISTS bearer_api ON DATABASE TYPE BEARER FOR USER"
+    ).execute()
 
-    grant_result = root.query("ACCESS bearer_api GRANT FOR USER testuser").execute()
+    grant_result = root.query("ACCESS bearer_api GRANT FOR USER testuser").first()
     assert grant_result is not None
     assert isinstance(grant_result, dict)
     grant_info = grant_result.get("grant")
@@ -51,7 +55,7 @@ def test_bearer_access_system_user(bearer_v3_root_ws: dict) -> None:
         assert tokens.access is not None
         assert tokens.access != ""
 
-        result = conn.query("RETURN 1")
+        result = conn.query("RETURN 1").first()
         assert result == 1
     finally:
         if conn.socket:
@@ -70,9 +74,15 @@ def test_bearer_signin_token_not_usable_with_authenticate(
     namespace = bearer_v3_root_ws["namespace"]
     database_name = bearer_v3_root_ws["database_name"]
 
-    root.query("DEFINE USER IF NOT EXISTS auth_testuser ON DATABASE PASSWORD 'testpass' ROLES EDITOR").execute()
-    root.query("DEFINE ACCESS IF NOT EXISTS bearer_auth_test ON DATABASE TYPE BEARER FOR USER").execute()
-    grant_result = root.query("ACCESS bearer_auth_test GRANT FOR USER auth_testuser").execute()
+    root.query(
+        "DEFINE USER IF NOT EXISTS auth_testuser ON DATABASE PASSWORD 'testpass' ROLES EDITOR"
+    ).execute()
+    root.query(
+        "DEFINE ACCESS IF NOT EXISTS bearer_auth_test ON DATABASE TYPE BEARER FOR USER"
+    ).execute()
+    grant_result = root.query(
+        "ACCESS bearer_auth_test GRANT FOR USER auth_testuser"
+    ).first()
     bearer_key = grant_result["grant"]["key"]
 
     conn = BlockingWsSurrealConnection(url)

--- a/tests/unit_tests/connections/create/test_async_http.py
+++ b/tests/unit_tests/connections/create/test_async_http.py
@@ -34,7 +34,7 @@ async def test_create_string(
     outcome = await async_http_connection.create("user")
     assert "user" == outcome["id"].table_name
 
-    assert len(await async_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -49,7 +49,7 @@ async def test_create_string_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -68,7 +68,7 @@ async def test_create_string_with_data_and_id(
     assert create_data["email"] == first_outcome["email"]
     assert create_data["enabled"] == first_outcome["enabled"]
 
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert "tobie" == result[0]["id"].id
@@ -86,7 +86,7 @@ async def test_create_record_id(
     assert "user" == outcome["id"].table_name
     assert 1 == outcome["id"].id
 
-    assert len(await async_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_create_record_id_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -117,7 +117,7 @@ async def test_create_table(
     outcome = await async_http_connection.create(table)
     assert "user" == outcome["id"].table_name
 
-    assert len(await async_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -133,7 +133,7 @@ async def test_create_table_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]

--- a/tests/unit_tests/connections/create/test_async_ws.py
+++ b/tests/unit_tests/connections/create/test_async_ws.py
@@ -34,7 +34,7 @@ async def test_create_string(
     outcome = await async_ws_connection.create("user")
     assert "user" == outcome["id"].table_name
 
-    assert len(await async_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -49,7 +49,7 @@ async def test_create_string_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -70,7 +70,7 @@ async def test_create_string_with_data_and_id(
     assert create_data["email"] == first_outcome["email"]
     assert create_data["enabled"] == first_outcome["enabled"]
 
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert "tobie" == result[0]["id"].id
@@ -88,7 +88,7 @@ async def test_create_record_id(
     assert "user" == outcome["id"].table_name
     assert 1 == outcome["id"].id
 
-    assert len(await async_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -105,7 +105,7 @@ async def test_create_record_id_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -121,7 +121,7 @@ async def test_create_table(
     outcome = await async_ws_connection.create(table)
     assert "user" == outcome["id"].table_name
 
-    assert len(await async_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(await async_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 @pytest.mark.asyncio
@@ -137,7 +137,7 @@ async def test_create_table_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]

--- a/tests/unit_tests/connections/create/test_blocking_http.py
+++ b/tests/unit_tests/connections/create/test_blocking_http.py
@@ -30,10 +30,10 @@ def setup_user(
 def test_create_string(
     blocking_http_connection: BlockingHttpSurrealConnection, setup_user: None
 ) -> None:
-    outcome = blocking_http_connection.create("user")
+    outcome = blocking_http_connection.create("user").execute()
     assert "user" == outcome["id"].table_name
 
-    assert len(blocking_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_string_with_data(
@@ -47,7 +47,7 @@ def test_create_string_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -65,7 +65,7 @@ def test_create_string_with_data_and_id(
     assert create_data["email"] == first_outcome["email"]
     assert create_data["enabled"] == first_outcome["enabled"]
 
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert "tobie" == result[0]["id"].id
@@ -78,11 +78,11 @@ def test_create_record_id(
     blocking_http_connection: BlockingHttpSurrealConnection, setup_user: None
 ) -> None:
     record_id = RecordID("user", 1)
-    outcome = blocking_http_connection.create(record_id)
+    outcome = blocking_http_connection.create(record_id).execute()
     assert "user" == outcome["id"].table_name
     assert 1 == outcome["id"].id
 
-    assert len(blocking_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_record_id_with_data(
@@ -98,7 +98,7 @@ def test_create_record_id_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -110,10 +110,10 @@ def test_create_table(
     blocking_http_connection: BlockingHttpSurrealConnection, setup_user: None
 ) -> None:
     table = Table("user")
-    outcome = blocking_http_connection.create(table)
+    outcome = blocking_http_connection.create(table).execute()
     assert "user" == outcome["id"].table_name
 
-    assert len(blocking_http_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_http_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_table_with_data(
@@ -128,7 +128,7 @@ def test_create_table_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]

--- a/tests/unit_tests/connections/create/test_blocking_ws.py
+++ b/tests/unit_tests/connections/create/test_blocking_ws.py
@@ -30,10 +30,10 @@ def setup_user(
 def test_create_string(
     blocking_ws_connection: BlockingWsSurrealConnection, setup_user: None
 ) -> None:
-    outcome = blocking_ws_connection.create("user")
+    outcome = blocking_ws_connection.create("user").execute()
     assert "user" == outcome["id"].table_name
 
-    assert len(blocking_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_string_with_data(
@@ -47,7 +47,7 @@ def test_create_string_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -65,7 +65,7 @@ def test_create_string_with_data_and_id(
     assert create_data["email"] == first_outcome["email"]
     assert create_data["enabled"] == first_outcome["enabled"]
 
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert "tobie" == result[0]["id"].id
@@ -78,11 +78,11 @@ def test_create_record_id(
     blocking_ws_connection: BlockingWsSurrealConnection, setup_user: None
 ) -> None:
     record_id = RecordID("user", 1)
-    outcome = blocking_ws_connection.create(record_id)
+    outcome = blocking_ws_connection.create(record_id).execute()
     assert "user" == outcome["id"].table_name
     assert 1 == outcome["id"].id
 
-    assert len(blocking_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_record_id_with_data(
@@ -98,7 +98,7 @@ def test_create_record_id_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]
@@ -110,10 +110,10 @@ def test_create_table(
     blocking_ws_connection: BlockingWsSurrealConnection, setup_user: None
 ) -> None:
     table = Table("user")
-    outcome = blocking_ws_connection.create(table)
+    outcome = blocking_ws_connection.create(table).execute()
     assert "user" == outcome["id"].table_name
 
-    assert len(blocking_ws_connection.query("SELECT * FROM user;")) == 1
+    assert len(blocking_ws_connection.query("SELECT * FROM user;").first()) == 1
 
 
 def test_create_table_with_data(
@@ -128,7 +128,7 @@ def test_create_table_with_data(
     assert create_data["email"] == outcome["email"]
     assert create_data["enabled"] == outcome["enabled"]
 
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(result) == 1
     assert "user" == result[0]["id"].table_name
     assert create_data["name"] == result[0]["name"]

--- a/tests/unit_tests/connections/delete/test_async_http.py
+++ b/tests/unit_tests/connections/delete/test_async_http.py
@@ -26,7 +26,7 @@ async def test_delete_string(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -44,7 +44,7 @@ async def test_delete_record_id(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -63,5 +63,5 @@ async def test_delete_table(async_http_connection: AsyncHttpSurrealConnection) -
     assert any(record["name"] == "Jaime" for record in outcome)
 
     # Verify all records were deleted
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []

--- a/tests/unit_tests/connections/delete/test_async_ws.py
+++ b/tests/unit_tests/connections/delete/test_async_ws.py
@@ -26,7 +26,7 @@ async def test_delete_string(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -44,7 +44,7 @@ async def test_delete_record_id(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -63,5 +63,5 @@ async def test_delete_table(async_ws_connection: AsyncWsSurrealConnection) -> No
     assert any(record["name"] == "Jaime" for record in outcome)
 
     # Verify all records were deleted
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []

--- a/tests/unit_tests/connections/delete/test_blocking_http.py
+++ b/tests/unit_tests/connections/delete/test_blocking_http.py
@@ -27,15 +27,14 @@ def test_debug_delete(blocking_http_connection: BlockingHttpSurrealConnection) -
     blocking_http_connection.query("DELETE user;").execute()
     blocking_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
 
-    # Debug: Check what delete actually returns. `.execute()` is required
-    # because lazy builders never trigger execution from `repr()`/`str()`
-    # (so debuggers and loggers don't accidentally fire pending operations).
-    outcome = blocking_http_connection.delete("user:tobie").execute()
+    # Debug: Check what delete actually returns. delete() runs eagerly and
+    # returns the deleted record directly (no builder / .execute()).
+    outcome = blocking_http_connection.delete("user:tobie")
     print(f"DEBUG: Delete outcome: {outcome}")
     print(f"DEBUG: Type: {type(outcome)}")
 
     # Verify the record was actually deleted
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -52,7 +51,7 @@ def test_delete_string(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -69,7 +68,7 @@ def test_delete_record_id(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -87,5 +86,5 @@ def test_delete_table(blocking_http_connection: BlockingHttpSurrealConnection) -
     assert any(record["name"] == "Jaime" for record in outcome)
 
     # Verify all records were deleted
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert outcome == []

--- a/tests/unit_tests/connections/delete/test_blocking_ws.py
+++ b/tests/unit_tests/connections/delete/test_blocking_ws.py
@@ -25,7 +25,7 @@ def test_delete_string(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -42,7 +42,7 @@ def test_delete_record_id(
     assert outcome["name"] == "Tobie"
 
     # Verify the record was actually deleted
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []
 
 
@@ -60,5 +60,5 @@ def test_delete_table(blocking_ws_connection: BlockingWsSurrealConnection) -> No
     assert any(record["name"] == "Jaime" for record in outcome)
 
     # Verify all records were deleted
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert outcome == []

--- a/tests/unit_tests/connections/embedded/test_blocking_embedded.py
+++ b/tests/unit_tests/connections/embedded/test_blocking_embedded.py
@@ -10,7 +10,7 @@ def test_mem_connection() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        result = db.create("person", {"name": "Alice", "age": 30}).execute()
+        result = db.create("person", {"name": "Alice", "age": 30})
         assert result is not None
 
         people = db.select("person")
@@ -22,7 +22,7 @@ def test_create_and_select() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        created = db.create("user", {"name": "Bob", "email": "bob@example.com"}).execute()
+        created = db.create("user", {"name": "Bob", "email": "bob@example.com"})
         assert created is not None
 
         users = db.select("user")
@@ -34,9 +34,9 @@ def test_update_operation() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        db.create("product", {"name": "Widget", "price": 10}).execute()
+        db.create("product", {"name": "Widget", "price": 10})
 
-        updated = db.update("product", {"name": "Widget", "price": 15}).execute()
+        updated = db.update("product", {"name": "Widget", "price": 15})
         assert updated is not None
 
 
@@ -45,9 +45,9 @@ def test_delete_operation() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        db.create("temp", {"data": "test"}).execute()
+        db.create("temp", {"data": "test"})
 
-        deleted = db.delete("temp").execute()
+        deleted = db.delete("temp")
         assert deleted is not None
 
 
@@ -81,7 +81,7 @@ def test_merge_operation() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        db.create("item", {"name": "Item1", "quantity": 5}).execute()
+        db.create("item", {"name": "Item1", "quantity": 5})
 
         merged = db.update("item").merge({"quantity": 10})
         assert merged is not None
@@ -92,10 +92,10 @@ def test_upsert_operation() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        upserted = db.upsert("record:1", {"value": "first"}).execute()
+        upserted = db.upsert("record:1", {"value": "first"})
         assert upserted is not None
 
-        upserted = db.upsert("record:1", {"value": "second"}).execute()
+        upserted = db.upsert("record:1", {"value": "second"})
         assert upserted is not None
 
 
@@ -118,7 +118,7 @@ def test_connection_lifecycle() -> None:
     db.connect("mem://")
     db.use("test", "test")
 
-    db.create("test", {"value": 1}).execute()
+    db.create("test", {"value": 1})
 
     db.close()
 

--- a/tests/unit_tests/connections/embedded/test_blocking_embedded.py
+++ b/tests/unit_tests/connections/embedded/test_blocking_embedded.py
@@ -56,11 +56,17 @@ def test_query_operation() -> None:
     with Surreal("mem://") as db:
         db.use("test", "test")
 
-        result = db.query("CREATE person SET name = 'Charlie', age = 25")
-        assert result is not None
+        # query() returns a builder under eager-sync; a terminal (.first() /
+        # .execute()) is required to actually run the statement.
+        created = db.query("CREATE person SET name = 'Charlie', age = 25").first()
+        assert isinstance(created, list)
+        assert created[0]["name"] == "Charlie"
 
-        result = db.query("SELECT * FROM person WHERE age > $min_age", {"min_age": 20})
-        assert result is not None
+        rows = db.query(
+            "SELECT * FROM person WHERE age > $min_age", {"min_age": 20}
+        ).first()
+        assert isinstance(rows, list)
+        assert any(row["name"] == "Charlie" for row in rows)
 
 
 def test_let_and_unset() -> None:

--- a/tests/unit_tests/connections/embedded/test_file_persistence.py
+++ b/tests/unit_tests/connections/embedded/test_file_persistence.py
@@ -40,7 +40,7 @@ def test_sync_file_persistence() -> None:
         with Surreal(db_url) as db:
             db.use("test", "test")
 
-            created = db.create("persistent", {"name": "Bob", "value": 100}).execute()
+            created = db.create("persistent", {"name": "Bob", "value": 100})
             assert created is not None
 
         # Second connection: verify data persisted

--- a/tests/unit_tests/connections/insert/test_async_http.py
+++ b/tests/unit_tests/connections/insert/test_async_http.py
@@ -43,7 +43,7 @@ async def test_insert_string_with_data(
     await async_http_connection.query("DELETE user;")
     outcome = await async_http_connection.insert("user", insert_bulk_data)
     assert 2 == len(outcome)
-    assert len(await async_http_connection.query("SELECT * FROM user;")) == 2
+    assert len(await async_http_connection.query("SELECT * FROM user;").first()) == 2
     await async_http_connection.query("DELETE user;")
 
 

--- a/tests/unit_tests/connections/insert/test_async_ws.py
+++ b/tests/unit_tests/connections/insert/test_async_ws.py
@@ -43,7 +43,7 @@ async def test_insert_string_with_data(
     await async_ws_connection.query("DELETE user;")
     outcome = await async_ws_connection.insert("user", insert_bulk_data)
     assert 2 == len(outcome)
-    assert len(await async_ws_connection.query("SELECT * FROM user;")) == 2
+    assert len(await async_ws_connection.query("SELECT * FROM user;").first()) == 2
     await async_ws_connection.query("DELETE user;")
 
 

--- a/tests/unit_tests/connections/insert/test_blocking_http.py
+++ b/tests/unit_tests/connections/insert/test_blocking_http.py
@@ -43,7 +43,7 @@ def test_insert_string_with_data(
     blocking_http_connection.query("DELETE user;").execute()
     outcome = blocking_http_connection.insert("user", insert_bulk_data)
     assert 2 == len(outcome)
-    assert len(blocking_http_connection.query("SELECT * FROM user;")) == 2
+    assert len(blocking_http_connection.query("SELECT * FROM user;").first()) == 2
     blocking_http_connection.query("DELETE user;").execute()
 
 

--- a/tests/unit_tests/connections/insert/test_blocking_ws.py
+++ b/tests/unit_tests/connections/insert/test_blocking_ws.py
@@ -42,7 +42,7 @@ def test_insert_string_with_data(
     blocking_ws_connection.query("DELETE user;").execute()
     outcome = blocking_ws_connection.insert("user", insert_bulk_data)
     assert 2 == len(outcome)
-    assert len(blocking_ws_connection.query("SELECT * FROM user;")) == 2
+    assert len(blocking_ws_connection.query("SELECT * FROM user;").first()) == 2
 
 
 def test_insert_record_id_result_error(

--- a/tests/unit_tests/connections/invalidate/test_async_http.py
+++ b/tests/unit_tests/connections/invalidate/test_async_http.py
@@ -42,22 +42,22 @@ async def test_invalidate_with_guest_mode_on(
     """
     This test only works if the SURREAL_CAPS_ALLOW_GUESTS=false is set in the docker container
     """
-    outcome = await secondary_connection.query("SELECT * FROM user;")
+    outcome = await secondary_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     await secondary_connection.invalidate()
 
     try:
-        outcome = await secondary_connection.query("SELECT * FROM user;")
+        outcome = await secondary_connection.query("SELECT * FROM user;").first()
         assert len(outcome) == 0
     except Exception as err:
         # Check for the actual error message from newer SurrealDB versions
         assert "Not enough permissions" in str(
             err
         ) or "Anonymous access not allowed" in str(err)
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
 
@@ -69,16 +69,16 @@ async def test_invalidate_test_for_no_guest_mode(
     This test asserts that there is an error thrown due to no guest mode being allowed
     Only run this test if SURREAL_CAPS_ALLOW_GUESTS=false is set in the docker container
     """
-    outcome = await secondary_connection.query("SELECT * FROM user;")
+    outcome = await secondary_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     await secondary_connection.invalidate()
 
     # Try to query after invalidation - behavior depends on guest mode setting
     try:
-        outcome = await secondary_connection.query("SELECT * FROM user;")
+        outcome = await secondary_connection.query("SELECT * FROM user;").first()
         # If guest mode is enabled, we get empty results instead of an exception
         assert len(outcome) == 0
     except Exception as err:
@@ -87,5 +87,5 @@ async def test_invalidate_test_for_no_guest_mode(
             err
         ) or "Anonymous access not allowed" in str(err)
 
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1

--- a/tests/unit_tests/connections/invalidate/test_async_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_async_ws.py
@@ -34,21 +34,21 @@ async def main_connection() -> None:
 async def test_invalidate_with_guest_mode_on(
     main_connection, async_ws_connection: AsyncWsSurrealConnection
 ) -> None:
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     await async_ws_connection.invalidate()
 
     try:
-        outcome = await async_ws_connection.query("SELECT * FROM user;")
+        outcome = await async_ws_connection.query("SELECT * FROM user;").first()
         assert len(outcome) == 0
     except Exception as err:
         assert "Not enough permissions" in str(
             err
         ) or "Anonymous access not allowed" in str(err)
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
 
@@ -56,16 +56,16 @@ async def test_invalidate_with_guest_mode_on(
 async def test_invalidate_test_for_no_guest_mode(
     main_connection, async_ws_connection: AsyncWsSurrealConnection
 ) -> None:
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     await async_ws_connection.invalidate()
 
     # Try to query after invalidation - behavior depends on guest mode setting
     try:
-        outcome = await async_ws_connection.query("SELECT * FROM user;")
+        outcome = await async_ws_connection.query("SELECT * FROM user;").first()
         # If guest mode is enabled, we get empty results instead of an exception
         assert len(outcome) == 0
     except Exception as err:
@@ -74,5 +74,5 @@ async def test_invalidate_test_for_no_guest_mode(
             err
         ) or "Anonymous access not allowed" in str(err)
 
-    outcome = await main_connection.query("SELECT * FROM user;")
+    outcome = await main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1

--- a/tests/unit_tests/connections/invalidate/test_blocking_http.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_http.py
@@ -32,41 +32,41 @@ def main_connection() -> None:
 def test_invalidate_test_for_no_guest_mode(
     main_connection, blocking_http_connection: BlockingHttpSurrealConnection
 ) -> None:
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     blocking_http_connection.invalidate()
 
     try:
-        outcome = blocking_http_connection.query("SELECT * FROM user;")
+        outcome = blocking_http_connection.query("SELECT * FROM user;").first()
         assert len(outcome) == 0
     except Exception as err:
         assert "Not enough permissions" in str(
             err
         ) or "Anonymous access not allowed" in str(err)
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
 
 def test_invalidate_with_guest_mode_on(
     main_connection, blocking_http_connection: BlockingHttpSurrealConnection
 ) -> None:
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     blocking_http_connection.invalidate()
 
     try:
-        outcome = blocking_http_connection.query("SELECT * FROM user;")
+        outcome = blocking_http_connection.query("SELECT * FROM user;").first()
         assert len(outcome) == 0
     except Exception as err:
         assert "Not enough permissions" in str(
             err
         ) or "Anonymous access not allowed" in str(err)
 
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1

--- a/tests/unit_tests/connections/invalidate/test_blocking_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_ws.py
@@ -33,37 +33,37 @@ def main_connection() -> None:
 def test_invalidate_with_guest_mode_on(
     main_connection, blocking_ws_connection: BlockingWsSurrealConnection
 ) -> None:
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     blocking_ws_connection.invalidate()
 
     try:
-        outcome = blocking_ws_connection.query("SELECT * FROM user;")
+        outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
         assert len(outcome) == 0
     except Exception as err:
         assert "Not enough permissions" in str(
             err
         ) or "Anonymous access not allowed" in str(err)
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
 
 def test_invalidate_test_for_no_guest_mode(
     main_connection, blocking_ws_connection: BlockingWsSurrealConnection
 ) -> None:
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1
 
     blocking_ws_connection.invalidate()
 
     # Try to query after invalidation - behavior depends on guest mode setting
     try:
-        outcome = blocking_ws_connection.query("SELECT * FROM user;")
+        outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
         # If guest mode is enabled, we get empty results instead of an exception
         assert len(outcome) == 0
     except Exception as err:
@@ -72,5 +72,5 @@ def test_invalidate_test_for_no_guest_mode(
             err
         ) or "Anonymous access not allowed" in str(err)
 
-    outcome = main_connection.query("SELECT * FROM user;")
+    outcome = main_connection.query("SELECT * FROM user;").first()
     assert len(outcome) == 1

--- a/tests/unit_tests/connections/let/test_async_http.py
+++ b/tests/unit_tests/connections/let/test_async_http.py
@@ -17,7 +17,7 @@ async def test_let(async_http_connection: AsyncHttpSurrealConnection) -> None:
     await async_http_connection.query("CREATE person SET name = $name")
     outcome = await async_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
     await async_http_connection.query("DELETE person;")

--- a/tests/unit_tests/connections/let/test_async_ws.py
+++ b/tests/unit_tests/connections/let/test_async_ws.py
@@ -17,7 +17,7 @@ async def test_let(async_ws_connection: AsyncWsSurrealConnection) -> None:
     await async_ws_connection.query("CREATE person SET name = $name")
     outcome = await async_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
     await async_ws_connection.query("DELETE person;")

--- a/tests/unit_tests/connections/let/test_blocking_http.py
+++ b/tests/unit_tests/connections/let/test_blocking_http.py
@@ -16,7 +16,7 @@ def test_let(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
     blocking_http_connection.query("CREATE person SET name = $name").execute()
     outcome = blocking_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
     blocking_http_connection.query("DELETE person;").execute()

--- a/tests/unit_tests/connections/let/test_blocking_ws.py
+++ b/tests/unit_tests/connections/let/test_blocking_ws.py
@@ -16,7 +16,7 @@ def test_let(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     blocking_ws_connection.query("CREATE person SET name = $name").execute()
     outcome = blocking_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
     blocking_ws_connection.query("DELETE person;").execute()

--- a/tests/unit_tests/connections/merge/test_async_http.py
+++ b/tests/unit_tests/connections/merge/test_async_http.py
@@ -38,7 +38,7 @@ async def test_merge_string(
     outcome = await async_http_connection.update("user:tobie").merge({})
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -55,7 +55,7 @@ async def test_merge_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -70,7 +70,7 @@ async def test_merge_record_id(
     first_outcome = await async_http_connection.update(record_id).merge({})
     assert first_outcome["id"] == record_id
     assert first_outcome["name"] == "Tobie"
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -87,7 +87,7 @@ async def test_merge_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -103,7 +103,7 @@ async def test_merge_table(
     first_outcome = await async_http_connection.update(table).merge({})
     assert first_outcome[0]["id"] == record_id
     assert first_outcome[0]["name"] == "Tobie"
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -121,7 +121,7 @@ async def test_merge_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/merge/test_async_ws.py
+++ b/tests/unit_tests/connections/merge/test_async_ws.py
@@ -38,7 +38,7 @@ async def test_merge_string(
     outcome = await async_ws_connection.update("user:tobie").merge({})
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -55,7 +55,7 @@ async def test_merge_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -70,7 +70,7 @@ async def test_merge_record_id(
     first_outcome = await async_ws_connection.update(record_id).merge({})
     assert first_outcome["id"] == record_id
     assert first_outcome["name"] == "Tobie"
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -87,7 +87,7 @@ async def test_merge_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -103,7 +103,7 @@ async def test_merge_table(
     first_outcome = await async_ws_connection.update(table).merge({})
     assert first_outcome[0]["id"] == record_id
     assert first_outcome[0]["name"] == "Tobie"
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -121,7 +121,7 @@ async def test_merge_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/merge/test_blocking_http.py
+++ b/tests/unit_tests/connections/merge/test_blocking_http.py
@@ -37,7 +37,7 @@ def test_merge_string(
     outcome = blocking_http_connection.update("user:tobie").merge({})
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -53,7 +53,7 @@ def test_merge_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -67,7 +67,7 @@ def test_merge_record_id(
     first_outcome = blocking_http_connection.update(record_id).merge({})
     assert first_outcome["id"] == record_id
     assert first_outcome["name"] == "Tobie"
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -83,7 +83,7 @@ def test_merge_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -98,7 +98,7 @@ def test_merge_table(
     first_outcome = blocking_http_connection.update(table).merge({})
     assert first_outcome[0]["id"] == record_id
     assert first_outcome[0]["name"] == "Tobie"
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -115,7 +115,7 @@ def test_merge_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/merge/test_blocking_ws.py
+++ b/tests/unit_tests/connections/merge/test_blocking_ws.py
@@ -37,7 +37,7 @@ def test_merge_string(
     outcome = blocking_ws_connection.update("user:tobie").merge({})
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -53,7 +53,7 @@ def test_merge_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -67,7 +67,7 @@ def test_merge_record_id(
     first_outcome = blocking_ws_connection.update(record_id).merge({})
     assert first_outcome["id"] == record_id
     assert first_outcome["name"] == "Tobie"
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -83,7 +83,7 @@ def test_merge_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -98,7 +98,7 @@ def test_merge_table(
     first_outcome = blocking_ws_connection.update(table).merge({})
     assert first_outcome[0]["id"] == record_id
     assert first_outcome[0]["name"] == "Tobie"
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
 
@@ -115,7 +115,7 @@ def test_merge_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/patch/test_async_http.py
+++ b/tests/unit_tests/connections/patch/test_async_http.py
@@ -41,7 +41,7 @@ async def test_patch_string_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -60,7 +60,7 @@ async def test_patch_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -80,7 +80,7 @@ async def test_patch_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is False
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/patch/test_async_ws.py
+++ b/tests/unit_tests/connections/patch/test_async_ws.py
@@ -41,7 +41,7 @@ async def test_patch_string_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -60,7 +60,7 @@ async def test_patch_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -80,7 +80,7 @@ async def test_patch_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is False
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/patch/test_blocking_http.py
+++ b/tests/unit_tests/connections/patch/test_blocking_http.py
@@ -40,7 +40,7 @@ def test_patch_string_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -58,7 +58,7 @@ def test_patch_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -77,7 +77,7 @@ def test_patch_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is False
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/patch/test_blocking_ws.py
+++ b/tests/unit_tests/connections/patch/test_blocking_ws.py
@@ -40,7 +40,7 @@ def test_patch_string_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -58,7 +58,7 @@ def test_patch_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is False
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -77,7 +77,7 @@ def test_patch_table_with_data(
     assert outcome[0]["name"] == "Jaime"
     assert outcome[0]["email"] == "jaime@example.com"
     assert outcome[0]["enabled"] is False
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/query/test_async_http.py
+++ b/tests/unit_tests/connections/query/test_async_http.py
@@ -9,7 +9,7 @@ async def test_query(async_http_connection: AsyncHttpSurrealConnection) -> None:
     await async_http_connection.query("DELETE user;")
     result = await async_http_connection.query(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', password = 'password123', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="tobie"),
@@ -22,7 +22,7 @@ async def test_query(async_http_connection: AsyncHttpSurrealConnection) -> None:
 
     result = await async_http_connection.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),
@@ -33,7 +33,7 @@ async def test_query(async_http_connection: AsyncHttpSurrealConnection) -> None:
         }
     ]
 
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),

--- a/tests/unit_tests/connections/query/test_async_ws.py
+++ b/tests/unit_tests/connections/query/test_async_ws.py
@@ -9,7 +9,7 @@ async def test_query(async_ws_connection: AsyncWsSurrealConnection) -> None:
     await async_ws_connection.query("DELETE user;")
     result = await async_ws_connection.query(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', password = 'password123', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="tobie"),
@@ -22,7 +22,7 @@ async def test_query(async_ws_connection: AsyncWsSurrealConnection) -> None:
 
     result = await async_ws_connection.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),
@@ -33,7 +33,7 @@ async def test_query(async_ws_connection: AsyncWsSurrealConnection) -> None:
         }
     ]
 
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),

--- a/tests/unit_tests/connections/query/test_blocking_http.py
+++ b/tests/unit_tests/connections/query/test_blocking_http.py
@@ -8,7 +8,7 @@ def test_query(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
     blocking_http_connection.query("DELETE user;").execute()
     result = blocking_http_connection.query(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', password = 'password123', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="tobie"),
@@ -21,7 +21,7 @@ def test_query(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
 
     result = blocking_http_connection.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),
@@ -32,7 +32,7 @@ def test_query(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
         }
     ]
 
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),

--- a/tests/unit_tests/connections/query/test_blocking_ws.py
+++ b/tests/unit_tests/connections/query/test_blocking_ws.py
@@ -8,7 +8,7 @@ def test_query(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     blocking_ws_connection.query("DELETE user;").execute()
     result = blocking_ws_connection.query(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', password = 'password123', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="tobie"),
@@ -21,7 +21,7 @@ def test_query(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
 
     result = blocking_ws_connection.query(
         "CREATE user:jaime SET name = 'Jaime', email = 'jaime@example.com', password = 'password456', enabled = true;"
-    )
+    ).first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),
@@ -32,7 +32,7 @@ def test_query(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
         }
     ]
 
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result == [
         {
             "id": RecordID(table_name="user", identifier="jaime"),

--- a/tests/unit_tests/connections/select/test_async_http.py
+++ b/tests/unit_tests/connections/select/test_async_http.py
@@ -1,6 +1,8 @@
 import pytest
 
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
 
 
 @pytest.mark.asyncio
@@ -26,3 +28,56 @@ async def test_select(async_http_connection: AsyncHttpSurrealConnection) -> None
 
     await async_http_connection.query("DELETE user;")
     await async_http_connection.query("DELETE users;")
+
+
+@pytest.mark.asyncio
+async def test_select_record_id_present(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;").execute()
+    await async_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = await async_http_connection.select(RecordID("user", "tobie"))
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    await async_http_connection.query("DELETE user;").execute()
+
+
+@pytest.mark.asyncio
+async def test_select_record_id_absent(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;").execute()
+
+    outcome = await async_http_connection.select(RecordID("user", "missing"))
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_select_string_record_id_present(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;").execute()
+    await async_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = await async_http_connection.select("user:tobie")
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    await async_http_connection.query("DELETE user;").execute()
+
+
+@pytest.mark.asyncio
+async def test_select_table_returns_list(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;").execute()
+    await async_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+    await async_http_connection.query("CREATE user:jaime SET name = 'Jaime';").execute()
+
+    outcome = await async_http_connection.select(Table("user"))
+    assert isinstance(outcome, list)
+    assert len(outcome) == 2
+
+    await async_http_connection.query("DELETE user;").execute()

--- a/tests/unit_tests/connections/select/test_async_ws.py
+++ b/tests/unit_tests/connections/select/test_async_ws.py
@@ -1,6 +1,8 @@
 import pytest
 
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
 
 
 @pytest.mark.asyncio
@@ -26,3 +28,56 @@ async def test_select(async_ws_connection: AsyncWsSurrealConnection) -> None:
 
     await async_ws_connection.query("DELETE user;")
     await async_ws_connection.query("DELETE users;")
+
+
+@pytest.mark.asyncio
+async def test_select_record_id_present(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;").execute()
+    await async_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = await async_ws_connection.select(RecordID("user", "tobie"))
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    await async_ws_connection.query("DELETE user;").execute()
+
+
+@pytest.mark.asyncio
+async def test_select_record_id_absent(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;").execute()
+
+    outcome = await async_ws_connection.select(RecordID("user", "missing"))
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_select_string_record_id_present(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;").execute()
+    await async_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = await async_ws_connection.select("user:tobie")
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    await async_ws_connection.query("DELETE user;").execute()
+
+
+@pytest.mark.asyncio
+async def test_select_table_returns_list(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;").execute()
+    await async_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+    await async_ws_connection.query("CREATE user:jaime SET name = 'Jaime';").execute()
+
+    outcome = await async_ws_connection.select(Table("user"))
+    assert isinstance(outcome, list)
+    assert len(outcome) == 2
+
+    await async_ws_connection.query("DELETE user;").execute()

--- a/tests/unit_tests/connections/select/test_blocking_http.py
+++ b/tests/unit_tests/connections/select/test_blocking_http.py
@@ -1,6 +1,6 @@
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
 
 
 def test_select(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
@@ -25,3 +25,52 @@ def test_select(blocking_http_connection: BlockingHttpSurrealConnection) -> None
 
     blocking_http_connection.query("DELETE user;").execute()
     blocking_http_connection.query("DELETE users;").execute()
+
+
+def test_select_record_id_present(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+    blocking_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = blocking_http_connection.select(RecordID("user", "tobie"))
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    blocking_http_connection.query("DELETE user;").execute()
+
+
+def test_select_record_id_absent(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+
+    outcome = blocking_http_connection.select(RecordID("user", "missing"))
+    assert outcome is None
+
+
+def test_select_string_record_id_present(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+    blocking_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = blocking_http_connection.select("user:tobie")
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    blocking_http_connection.query("DELETE user;").execute()
+
+
+def test_select_table_returns_list(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+    blocking_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+    blocking_http_connection.query("CREATE user:jaime SET name = 'Jaime';").execute()
+
+    outcome = blocking_http_connection.select(Table("user"))
+    assert isinstance(outcome, list)
+    assert len(outcome) == 2
+
+    blocking_http_connection.query("DELETE user;").execute()

--- a/tests/unit_tests/connections/select/test_blocking_ws.py
+++ b/tests/unit_tests/connections/select/test_blocking_ws.py
@@ -1,6 +1,6 @@
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
 
 
 def test_select(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
@@ -22,3 +22,52 @@ def test_select(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     assert outcome[0]["name"] == "Jaime"
     assert outcome[1]["name"] == "Tobie"
     assert 2 == len(outcome)
+
+
+def test_select_record_id_present(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+    blocking_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = blocking_ws_connection.select(RecordID("user", "tobie"))
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    blocking_ws_connection.query("DELETE user;").execute()
+
+
+def test_select_record_id_absent(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+
+    outcome = blocking_ws_connection.select(RecordID("user", "missing"))
+    assert outcome is None
+
+
+def test_select_string_record_id_present(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+    blocking_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+
+    outcome = blocking_ws_connection.select("user:tobie")
+    assert isinstance(outcome, dict)
+    assert outcome["name"] == "Tobie"
+
+    blocking_ws_connection.query("DELETE user;").execute()
+
+
+def test_select_table_returns_list(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+    blocking_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()
+    blocking_ws_connection.query("CREATE user:jaime SET name = 'Jaime';").execute()
+
+    outcome = blocking_ws_connection.select(Table("user"))
+    assert isinstance(outcome, list)
+    assert len(outcome) == 2
+
+    blocking_ws_connection.query("DELETE user;").execute()

--- a/tests/unit_tests/connections/session_txn/conftest.py
+++ b/tests/unit_tests/connections/session_txn/conftest.py
@@ -50,11 +50,15 @@ def session_txn_requires_v3(
     result = None
     probe_error: Exception | None = None
     try:
-        blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_probe;").execute()
-        blocking_ws_connection.query("DEFINE TABLE session_txn_probe SCHEMALESS;").execute()
+        blocking_ws_connection.query(
+            "REMOVE TABLE IF EXISTS session_txn_probe;"
+        ).execute()
+        blocking_ws_connection.query(
+            "DEFINE TABLE session_txn_probe SCHEMALESS;"
+        ).execute()
         try:
             # Mirror what the actual tests do - no signin on the session.
-            session.create("session_txn_probe:check", {"probe": True}).execute()
+            session.create("session_txn_probe:check", {"probe": True})
             result = session.query("SELECT * FROM session_txn_probe;").execute()
         except Exception as exc:  # noqa: BLE001 - capture for skip decision
             probe_error = exc
@@ -63,7 +67,9 @@ def session_txn_requires_v3(
             session.close_session()
         except Exception:
             pass
-        blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_probe;").execute()
+        blocking_ws_connection.query(
+            "REMOVE TABLE IF EXISTS session_txn_probe;"
+        ).execute()
     if probe_error is not None:
         pytest.skip(
             "Session-scoped create/query failed "

--- a/tests/unit_tests/connections/session_txn/test_session_async_ws.py
+++ b/tests/unit_tests/connections/session_txn/test_session_async_ws.py
@@ -36,7 +36,7 @@ async def test_new_session_use_query_create_select(
         connection_params["namespace"],
         connection_params["database_name"],
     )
-    result = await session.query("SELECT * FROM session_txn_test;")
+    result = await session.query("SELECT * FROM session_txn_test;").first()
     assert isinstance(result, list)
     assert len(result) == 0
 
@@ -84,8 +84,8 @@ async def test_two_sessions_isolated(
         456,
     )
 
-    res_a = await session_a.query("RETURN $var;")
-    res_b = await session_b.query("RETURN $var;")
+    res_a = await session_a.query("RETURN $var;").first()
+    res_b = await session_b.query("RETURN $var;").first()
     assert res_a == 123
     assert res_b == 456
 

--- a/tests/unit_tests/connections/session_txn/test_session_blocking_ws.py
+++ b/tests/unit_tests/connections/session_txn/test_session_blocking_ws.py
@@ -34,7 +34,7 @@ def test_new_session_use_query_create_select(
         connection_params["namespace"],
         connection_params["database_name"],
     )
-    result = session.query("SELECT * FROM session_txn_test;")
+    result = session.query("SELECT * FROM session_txn_test;").first()
     assert isinstance(result, list)
     assert len(result) == 0
 
@@ -90,8 +90,8 @@ def test_two_sessions_isolated(
         456,
     )
 
-    res_a = session_a.query("RETURN $var;")
-    res_b = session_b.query("RETURN $var;")
+    res_a = session_a.query("RETURN $var;").first()
+    res_b = session_b.query("RETURN $var;").first()
     assert res_a == 123
     assert res_b == 456
 

--- a/tests/unit_tests/connections/session_txn/test_transaction_async_ws.py
+++ b/tests/unit_tests/connections/session_txn/test_transaction_async_ws.py
@@ -36,7 +36,7 @@ async def test_transaction_commit(
 
     before_commit = await session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:committed;"
-    )
+    ).first()
     assert isinstance(before_commit, list)
     assert len(before_commit) == 0
 
@@ -44,7 +44,7 @@ async def test_transaction_commit(
 
     after_commit = await session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:committed;"
-    )
+    ).first()
     assert isinstance(after_commit, list)
     assert len(after_commit) == 1
     assert after_commit[0].get("name") == "txn-commit"
@@ -75,7 +75,7 @@ async def test_transaction_cancel(
 
     after_cancel = await session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:cancelled;"
-    )
+    ).first()
     assert isinstance(after_cancel, list)
     assert len(after_cancel) == 0
 
@@ -99,7 +99,7 @@ async def test_transaction_query_select(
         "session_txn_test:txn_query",
         {"name": "txn-query", "value": 1},
     )
-    result = await txn.query("SELECT * FROM session_txn_test:txn_query;")
+    result = await txn.query("SELECT * FROM session_txn_test:txn_query;").first()
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].get("name") == "txn-query"
@@ -111,11 +111,12 @@ async def test_transaction_query_select(
     await txn.commit()
     await session.close_session()
 
+
 @pytest.mark.asyncio
 async def test_transaction_begin_uuid_v3(
-        async_ws_connection: AsyncWsSurrealConnection,
-        connection_params: dict,
-        setup_table: None,
+    async_ws_connection: AsyncWsSurrealConnection,
+    connection_params: dict,
+    setup_table: None,
 ) -> None:
     session = await async_ws_connection.new_session()
     await session.use(

--- a/tests/unit_tests/connections/session_txn/test_transaction_blocking_ws.py
+++ b/tests/unit_tests/connections/session_txn/test_transaction_blocking_ws.py
@@ -35,7 +35,7 @@ def test_transaction_commit(
 
     before_commit = session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:committed;"
-    )
+    ).first()
     assert isinstance(before_commit, list)
     assert len(before_commit) == 0
 
@@ -43,7 +43,7 @@ def test_transaction_commit(
 
     after_commit = session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:committed;"
-    )
+    ).first()
     assert isinstance(after_commit, list)
     assert len(after_commit) == 1
     assert after_commit[0].get("name") == "txn-commit"
@@ -73,7 +73,7 @@ def test_transaction_cancel(
 
     after_cancel = session.query(
         "SELECT * FROM session_txn_test WHERE id = session_txn_test:cancelled;"
-    )
+    ).first()
     assert isinstance(after_cancel, list)
     assert len(after_cancel) == 0
 
@@ -96,7 +96,7 @@ def test_transaction_query_select(
         "session_txn_test:txn_query",
         {"name": "txn-query", "value": 1},
     )
-    result = txn.query("SELECT * FROM session_txn_test:txn_query;")
+    result = txn.query("SELECT * FROM session_txn_test:txn_query;").first()
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].get("name") == "txn-query"

--- a/tests/unit_tests/connections/subscribe_live/test_async_ws.py
+++ b/tests/unit_tests/connections/subscribe_live/test_async_ws.py
@@ -44,7 +44,9 @@ async def test_live_subscription_via_query(
     async_ws_connection_secondary: AsyncWsSurrealConnection,
 ) -> None:
     # Start the live query using query() method
-    query_uuid = await async_ws_connection_with_user.query("LIVE SELECT * FROM user;")
+    query_uuid = await async_ws_connection_with_user.query(
+        "LIVE SELECT * FROM user;"
+    ).first()
     assert isinstance(query_uuid, UUID)
 
     # Start the live subscription

--- a/tests/unit_tests/connections/test_concurrent_blocking_ws.py
+++ b/tests/unit_tests/connections/test_concurrent_blocking_ws.py
@@ -24,7 +24,9 @@ def setup_data(
     blocking_ws_connection.query_raw("DELETE likes;")
     blocking_ws_connection.query_raw("DELETE document;")
     blocking_ws_connection.query_raw("REMOVE TABLE user;")
-    blocking_ws_connection.query("DEFINE TABLE IF NOT EXISTS user SCHEMALESS;").execute()
+    blocking_ws_connection.query(
+        "DEFINE TABLE IF NOT EXISTS user SCHEMALESS;"
+    ).execute()
     blocking_ws_connection.query("CREATE user:1 SET name = 'User 1';").execute()
     blocking_ws_connection.query("CREATE user:2 SET name = 'User 2';").execute()
     yield
@@ -208,6 +210,6 @@ def test_sequential_operations_still_work(
     # Query to verify
     result = blocking_ws_connection.query(
         "SELECT * FROM document WHERE id = document:100;"
-    )
+    ).first()
     assert len(result) == 1
     assert result[0]["content"] == "Test"

--- a/tests/unit_tests/connections/unset/test_async_http.py
+++ b/tests/unit_tests/connections/unset/test_async_http.py
@@ -17,7 +17,7 @@ async def test_unset(async_http_connection: AsyncHttpSurrealConnection) -> None:
     await async_http_connection.query("CREATE person SET name = $name")
     outcome = await async_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert len(outcome) == 1
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
@@ -26,7 +26,7 @@ async def test_unset(async_http_connection: AsyncHttpSurrealConnection) -> None:
     # because the key was unset then $name.first is None returning []
     outcome = await async_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome == []
 
     await async_http_connection.query("DELETE person;")

--- a/tests/unit_tests/connections/unset/test_async_ws.py
+++ b/tests/unit_tests/connections/unset/test_async_ws.py
@@ -17,7 +17,7 @@ async def test_unset(async_ws_connection: AsyncWsSurrealConnection) -> None:
     await async_ws_connection.query("CREATE person SET name = $name")
     outcome = await async_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert len(outcome) == 1
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
@@ -26,7 +26,7 @@ async def test_unset(async_ws_connection: AsyncWsSurrealConnection) -> None:
     # because the key was unset then $name.first is None returning []
     outcome = await async_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome == []
 
     await async_ws_connection.query("DELETE person;")

--- a/tests/unit_tests/connections/unset/test_blocking_http.py
+++ b/tests/unit_tests/connections/unset/test_blocking_http.py
@@ -16,7 +16,7 @@ def test_unset(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
     blocking_http_connection.query("CREATE person SET name = $name").execute()
     outcome = blocking_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert len(outcome) == 1
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
@@ -25,7 +25,7 @@ def test_unset(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
     # because the key was unset then $name.first is None returning []
     outcome = blocking_http_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome == []
 
     blocking_http_connection.query("DELETE person;").execute()

--- a/tests/unit_tests/connections/unset/test_blocking_ws.py
+++ b/tests/unit_tests/connections/unset/test_blocking_ws.py
@@ -16,7 +16,7 @@ def test_unset(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     blocking_ws_connection.query("CREATE person SET name = $name").execute()
     outcome = blocking_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert len(outcome) == 1
     assert outcome[0]["name"] == {"first": "Tobie", "last": "Morgan Hitchcock"}
 
@@ -25,7 +25,7 @@ def test_unset(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     # because the key was unset then $name.first is None returning []
     outcome = blocking_ws_connection.query(
         "SELECT * FROM person WHERE name.first = $name.first"
-    )
+    ).first()
     assert outcome == []
 
     blocking_ws_connection.query("DELETE person;").execute()

--- a/tests/unit_tests/connections/update/test_async_http.py
+++ b/tests/unit_tests/connections/update/test_async_http.py
@@ -47,7 +47,7 @@ async def test_update_string(
     outcome = await async_http_connection.update("user:tobie")
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")
 
@@ -65,7 +65,7 @@ async def test_update_string_with_data(
 
     first_outcome = await async_http_connection.update("user:tobie", update_data)
     check_change(first_outcome, record_id)
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")
 
@@ -83,7 +83,7 @@ async def test_update_record_id(
 
     first_outcome = await async_http_connection.update(record_id)
     check_no_change(first_outcome, record_id)
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")
 
@@ -99,7 +99,7 @@ async def test_update_record_id_with_data(
 
     outcome = await async_http_connection.update(record_id, update_data)
     check_change(outcome, record_id)
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")
 
@@ -118,7 +118,7 @@ async def test_update_table(
     table = Table("user")
     first_outcome = await async_http_connection.update(table)
     check_no_change(first_outcome[0], record_id)
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")
 
@@ -137,6 +137,6 @@ async def test_update_table_with_data(
     table = Table("user")
     outcome = await async_http_connection.update(table, update_data)
     check_change(outcome[0], record_id)
-    outcome = await async_http_connection.query("SELECT * FROM user;")
+    outcome = await async_http_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
     await async_http_connection.query("DELETE user;")

--- a/tests/unit_tests/connections/update/test_async_ws.py
+++ b/tests/unit_tests/connections/update/test_async_ws.py
@@ -47,7 +47,7 @@ async def test_update_string(
     outcome = await async_ws_connection.update("user:tobie")
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -64,7 +64,7 @@ async def test_update_string_with_data(
 
     first_outcome = await async_ws_connection.update("user:tobie", update_data)
     check_change(first_outcome, record_id)
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
 
 
@@ -81,7 +81,7 @@ async def test_update_record_id(
 
     first_outcome = await async_ws_connection.update(record_id)
     check_no_change(first_outcome, record_id)
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -98,7 +98,7 @@ async def test_update_record_id_with_data(
 
     outcome = await async_ws_connection.update(record_id, update_data)
     check_change(outcome, record_id)
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
 
 
@@ -116,7 +116,7 @@ async def test_update_table(
     table = Table("user")
     first_outcome = await async_ws_connection.update(table)
     check_no_change(first_outcome[0], record_id)
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -134,5 +134,5 @@ async def test_update_table_with_data(
     table = Table("user")
     outcome = await async_ws_connection.update(table, update_data)
     check_change(outcome[0], record_id)
-    outcome = await async_ws_connection.query("SELECT * FROM user;")
+    outcome = await async_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)

--- a/tests/unit_tests/connections/update/test_blocking_http.py
+++ b/tests/unit_tests/connections/update/test_blocking_http.py
@@ -43,10 +43,10 @@ def test_update_string(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', enabled = true, password = 'root';"
     ).execute()
 
-    outcome = blocking_http_connection.update("user:tobie")
+    outcome = blocking_http_connection.update("user:tobie").execute()
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()
 
@@ -64,7 +64,7 @@ def test_update_string_with_data(
     first_outcome = blocking_http_connection.update("user:tobie", update_data)
     print("DEBUG update_string_with_data result:", first_outcome)
     check_change(first_outcome, record_id)
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     print("DEBUG update_string_with_data query result:", outcome)
     check_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()
@@ -80,9 +80,9 @@ def test_update_record_id(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', enabled = true, password = 'root';"
     ).execute()
 
-    first_outcome = blocking_http_connection.update(record_id)
+    first_outcome = blocking_http_connection.update(record_id).execute()
     check_no_change(first_outcome, record_id)
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()
 
@@ -100,7 +100,7 @@ def test_update_record_id_with_data(
     outcome = blocking_http_connection.update(record_id, update_data)
     print("DEBUG update_record_id_with_data result:", outcome)
     check_change(outcome, record_id)
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     print("DEBUG update_record_id_with_data query result:", outcome)
     check_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()
@@ -117,9 +117,9 @@ def test_update_table(
     ).execute()
 
     table = Table("user")
-    first_outcome = blocking_http_connection.update(table)
+    first_outcome = blocking_http_connection.update(table).execute()
     check_no_change(first_outcome[0], record_id)
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()
 
@@ -138,7 +138,7 @@ def test_update_table_with_data(
     outcome = blocking_http_connection.update(table, update_data)
     print("DEBUG update_table_with_data result:", outcome)
     check_change(outcome[0], record_id)
-    outcome = blocking_http_connection.query("SELECT * FROM user;")
+    outcome = blocking_http_connection.query("SELECT * FROM user;").first()
     print("DEBUG update_table_with_data query result:", outcome)
     check_change(outcome[0], record_id)
     blocking_http_connection.query("DELETE user;").execute()

--- a/tests/unit_tests/connections/update/test_blocking_ws.py
+++ b/tests/unit_tests/connections/update/test_blocking_ws.py
@@ -43,10 +43,10 @@ def test_update_string(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', enabled = true, password = 'root';"
     ).execute()
 
-    outcome = blocking_ws_connection.update("user:tobie")
+    outcome = blocking_ws_connection.update("user:tobie").execute()
     assert outcome["id"] == record_id
     assert outcome["name"] == "Tobie"
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -62,7 +62,7 @@ def test_update_string_with_data(
 
     first_outcome = blocking_ws_connection.update("user:tobie", update_data)
     check_change(first_outcome, record_id)
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
 
 
@@ -76,9 +76,9 @@ def test_update_record_id(
         "CREATE user:tobie SET name = 'Tobie', email = 'tobie@example.com', enabled = true, password = 'root';"
     ).execute()
 
-    first_outcome = blocking_ws_connection.update(record_id)
+    first_outcome = blocking_ws_connection.update(record_id).execute()
     check_no_change(first_outcome, record_id)
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -94,7 +94,7 @@ def test_update_record_id_with_data(
 
     outcome = blocking_ws_connection.update(record_id, update_data)
     check_change(outcome, record_id)
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)
 
 
@@ -109,9 +109,9 @@ def test_update_table(
     ).execute()
 
     table = Table("user")
-    first_outcome = blocking_ws_connection.update(table)
+    first_outcome = blocking_ws_connection.update(table).execute()
     check_no_change(first_outcome[0], record_id)
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_no_change(outcome[0], record_id)
 
 
@@ -128,5 +128,5 @@ def test_update_table_with_data(
     table = Table("user")
     outcome = blocking_ws_connection.update(table, update_data)
     check_change(outcome[0], record_id)
-    outcome = blocking_ws_connection.query("SELECT * FROM user;")
+    outcome = blocking_ws_connection.query("SELECT * FROM user;").first()
     check_change(outcome[0], record_id)

--- a/tests/unit_tests/connections/upsert/test_async_http.py
+++ b/tests/unit_tests/connections/upsert/test_async_http.py
@@ -50,7 +50,7 @@ async def test_upsert_string(
     assert outcome["name"] == "Tobie"
     assert outcome["email"] == "tobie@example.com"
     assert outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -69,7 +69,7 @@ async def test_upsert_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -86,7 +86,7 @@ async def test_upsert_record_id(
     assert first_outcome["name"] == "Tobie"
     assert first_outcome["email"] == "tobie@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -103,7 +103,7 @@ async def test_upsert_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -117,7 +117,7 @@ async def test_upsert_table(
     table = Table("user")
     record_id = RecordID("user", "tobie")
     first_outcome = await async_http_connection.upsert(table, existing_data)
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
     assert any(r["name"] == "Tobie" for r in result)
@@ -139,7 +139,7 @@ async def test_upsert_table_with_data(
         and r["enabled"] is True
         for r in outcome
     )
-    result = await async_http_connection.query("SELECT * FROM user;")
+    result = await async_http_connection.query("SELECT * FROM user;").first()
     assert any(
         r["name"] == "Jaime"
         and r["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/upsert/test_async_ws.py
+++ b/tests/unit_tests/connections/upsert/test_async_ws.py
@@ -50,7 +50,7 @@ async def test_upsert_string(
     assert outcome["name"] == "Tobie"
     assert outcome["email"] == "tobie@example.com"
     assert outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -69,7 +69,7 @@ async def test_upsert_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -86,7 +86,7 @@ async def test_upsert_record_id(
     assert first_outcome["name"] == "Tobie"
     assert first_outcome["email"] == "tobie@example.com"
     assert first_outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -105,7 +105,7 @@ async def test_upsert_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -119,7 +119,7 @@ async def test_upsert_table(
     table = Table("user")
     record_id = RecordID("user", "tobie")
     first_outcome = await async_ws_connection.upsert(table, existing_data)
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
     assert any(r["name"] == "Tobie" for r in result)
@@ -141,7 +141,7 @@ async def test_upsert_table_with_data(
         and r["enabled"] is True
         for r in outcome
     )
-    result = await async_ws_connection.query("SELECT * FROM user;")
+    result = await async_ws_connection.query("SELECT * FROM user;").first()
     assert any(
         r["name"] == "Jaime"
         and r["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/upsert/test_blocking_http.py
+++ b/tests/unit_tests/connections/upsert/test_blocking_http.py
@@ -51,7 +51,7 @@ def test_upsert_string(
     assert outcome["name"] == "Tobie"
     assert outcome["email"] == "tobie@example.com"
     assert outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -69,7 +69,7 @@ def test_upsert_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -87,7 +87,7 @@ def test_upsert_record_id(
     assert first_outcome["name"] == "Tobie"
     assert first_outcome["email"] == "tobie@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -105,7 +105,7 @@ def test_upsert_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -120,7 +120,7 @@ def test_upsert_table(
     table = Table("user")
     record_id = RecordID("user", "tobie")
     first_outcome = blocking_http_connection.upsert(table, existing_data)
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
     assert any(r["name"] == "Tobie" for r in result)
@@ -141,7 +141,7 @@ def test_upsert_table_with_data(
         and r["enabled"] is True
         for r in outcome
     )
-    result = blocking_http_connection.query("SELECT * FROM user;")
+    result = blocking_http_connection.query("SELECT * FROM user;").first()
     assert any(
         r["name"] == "Jaime"
         and r["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/upsert/test_blocking_ws.py
+++ b/tests/unit_tests/connections/upsert/test_blocking_ws.py
@@ -49,7 +49,7 @@ def test_upsert_string(
     assert outcome["name"] == "Tobie"
     assert outcome["email"] == "tobie@example.com"
     assert outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -67,7 +67,7 @@ def test_upsert_string_with_data(
     assert first_outcome["name"] == "Jaime"
     assert first_outcome["email"] == "jaime@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -83,7 +83,7 @@ def test_upsert_record_id(
     assert first_outcome["name"] == "Tobie"
     assert first_outcome["email"] == "tobie@example.com"
     assert first_outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Tobie"
     assert result[0]["email"] == "tobie@example.com"
@@ -101,7 +101,7 @@ def test_upsert_record_id_with_data(
     assert outcome["name"] == "Jaime"
     assert outcome["email"] == "jaime@example.com"
     assert outcome["enabled"] is True
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert result[0]["id"] == record_id
     assert result[0]["name"] == "Jaime"
     assert result[0]["email"] == "jaime@example.com"
@@ -114,7 +114,7 @@ def test_upsert_table(
     table = Table("user")
     record_id = RecordID("user", "tobie")
     first_outcome = blocking_ws_connection.upsert(table, existing_data)
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
     assert any(r["name"] == "Tobie" for r in result)
@@ -135,7 +135,7 @@ def test_upsert_table_with_data(
         and r["enabled"] is True
         for r in outcome
     )
-    result = blocking_ws_connection.query("SELECT * FROM user;")
+    result = blocking_ws_connection.query("SELECT * FROM user;").first()
     assert any(
         r["name"] == "Jaime"
         and r["email"] == "jaime@example.com"

--- a/tests/unit_tests/connections/v3_api/test_builder_clauses.py
+++ b/tests/unit_tests/connections/v3_api/test_builder_clauses.py
@@ -105,9 +105,7 @@ async def test_async_update_patch_record_id(
     _async_setup: None,
     _sync_setup: None,
 ) -> None:
-    await async_ws_connection.create(
-        RecordID("bld", "d"), {"name": "dora", "score": 1}
-    )
+    await async_ws_connection.create(RecordID("bld", "d"), {"name": "dora", "score": 1})
     out = await async_ws_connection.update(RecordID("bld", "d")).patch(
         [{"op": "replace", "path": "/score", "value": 99}]
     )
@@ -149,8 +147,10 @@ async def test_async_insert_relation_chained(
 ) -> None:
     await async_ws_connection.create(RecordID("bld", "u3"))
     await async_ws_connection.create(RecordID("bld", "u4"))
-    out = await async_ws_connection.insert(Table("rel_y")).relation().content(
-        {"in": RecordID("bld", "u3"), "out": RecordID("bld", "u4")}
+    out = (
+        await async_ws_connection.insert(Table("rel_y"))
+        .relation()
+        .content({"in": RecordID("bld", "u3"), "out": RecordID("bld", "u4")})
     )
     assert isinstance(out, list)
 
@@ -172,20 +172,21 @@ def test_sync_update_merge_table(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    blocking_ws_connection.create(RecordID("bld", "s2"), {"y": 1}).execute()
+    blocking_ws_connection.create(RecordID("bld", "s2"), {"y": 1})
     out = blocking_ws_connection.update(Table("bld")).merge({"flag": True})
     assert isinstance(out, list)
 
 
-def test_sync_builder_auto_execute_on_index(
+def test_sync_builder_execute_no_clause(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    """Indexing into a sync builder triggers execution."""
-    blocking_ws_connection.create(RecordID("bld", "s3"), {"name": "x"}).execute()
+    """The no-data builder runs the clause-less op via ``.execute()``."""
+    blocking_ws_connection.create(RecordID("bld", "s3"), {"name": "x"})
     builder = blocking_ws_connection.update(RecordID("bld", "s3"))
-    # accessing a key triggers __getitem__ -> _run_once()
-    assert builder["name"] == "x"
+    # No magic auto-execute anymore - callers run it explicitly.
+    out = builder.execute()
+    assert out["name"] == "x"
 
 
 def test_sync_builder_explicit_execute(
@@ -245,7 +246,7 @@ def test_sync_insert_table_with_hyphen(
     out = blocking_ws_connection.insert(
         Table("hyphen-table"),
         {"name": "bob"},
-    ).execute()
+    )
     assert isinstance(out, list)
     assert len(out) == 1
     assert out[0]["name"] == "bob"
@@ -264,4 +265,4 @@ def test_sync_insert_raw_string_with_hyphen_rejected(
     from surrealdb.errors import SurrealError
 
     with pytest.raises(SurrealError, match="raw string target"):
-        blocking_ws_connection.insert("hyphen-table", {"name": "charlie"}).execute()
+        blocking_ws_connection.insert("hyphen-table", {"name": "charlie"})

--- a/tests/unit_tests/connections/v3_api/test_query_returns.py
+++ b/tests/unit_tests/connections/v3_api/test_query_returns.py
@@ -1,13 +1,13 @@
 """
-Tests for the new v3.0 query() return shape.
+Tests for the v3.0 query() return shape.
 
 Verifies the fix for GH issue #232: previously query() always returned
 ``response["result"][0]["result"]``, silently dropping every statement
-result after the first. The new behaviour returns:
-
-- the result Value when exactly one statement was executed
-- a ``tuple[Value, ...]`` when multiple statements were executed (so
-  transactions and multi-statement queries no longer lose data).
+result after the first. The new behaviour ALWAYS returns a
+``list[Value]`` - one entry per statement, even for a single statement -
+so transactions and multi-statement queries never lose data. ``.first()``
+returns the first statement's result, and ``.into(cls)`` maps the N
+statement results positionally onto a dataclass / class.
 """
 
 from collections.abc import AsyncGenerator, Generator
@@ -48,24 +48,26 @@ def _blocking_setup(
 
 
 @pytest.mark.asyncio
-async def test_async_query_single_statement_returns_value(
+async def test_async_query_single_statement_returns_list(
     async_ws_connection: AsyncWsSurrealConnection,
     _async_setup: None,
     _blocking_setup: None,
 ) -> None:
     result = await async_ws_connection.query("RETURN 42;")
-    assert result == 42
+    assert result == [42]
+    first = await async_ws_connection.query("RETURN 42;").first()
+    assert first == 42
 
 
 @pytest.mark.asyncio
-async def test_async_query_multi_statement_returns_tuple(
+async def test_async_query_multi_statement_returns_list(
     async_ws_connection: AsyncWsSurrealConnection,
     _async_setup: None,
     _blocking_setup: None,
 ) -> None:
     result = await async_ws_connection.query("RETURN 1; RETURN 2; RETURN 3;")
-    assert isinstance(result, tuple)
-    assert result == (1, 2, 3)
+    assert isinstance(result, list)
+    assert result == [1, 2, 3]
 
 
 @pytest.mark.asyncio
@@ -77,14 +79,10 @@ async def test_async_query_transaction_block_surfaces_all_results(
     """Reproduction for issue #232.
 
     The transaction should expose the UPDATE result rather than silently
-    dropping it. SurrealDB 3.x returns one entry per statement (the
-    builder packages those into a tuple); older versions collapse the
-    block to the last statement's result. Either way, the UPDATE
-    result must be observable - it must not be silently discarded.
+    dropping it. ``query()`` returns one ``list`` entry per statement, so
+    the UPDATE result must be observable somewhere in the list.
     """
-    await async_ws_connection.query(
-        "CREATE multi_q:1 SET status = 'pending';"
-    )
+    await async_ws_connection.query("CREATE multi_q:1 SET status = 'pending';")
     result = await async_ws_connection.query(
         "BEGIN TRANSACTION;"
         " UPDATE multi_q:1 SET status = 'running';"
@@ -99,13 +97,8 @@ async def test_async_query_transaction_block_surfaces_all_results(
             and item[0].get("status") == "running"
         )
 
-    if isinstance(result, tuple):
-        # v3: tuple of (BEGIN, UPDATE, COMMIT) statement results.
-        assert any(_is_update_result(item) for item in result), result
-    else:
-        # v2: server collapses the block to the last statement's result;
-        # query() returns that single value directly.
-        assert _is_update_result(result), result
+    assert isinstance(result, list)
+    assert any(_is_update_result(item) for item in result), result
 
 
 @pytest.mark.asyncio
@@ -120,9 +113,9 @@ async def test_async_query_into_dataclass(
         second: int
         third: int
 
-    mapped = await async_ws_connection.query(
-        "RETURN 10; RETURN 20; RETURN 30;"
-    ).into(Result)
+    mapped = await async_ws_connection.query("RETURN 10; RETURN 20; RETURN 30;").into(
+        Result
+    )
     assert isinstance(mapped, Result)
     assert mapped.first == 10
     assert mapped.second == 20
@@ -151,21 +144,22 @@ async def test_async_query_into_field_count_mismatch(
 # ---------------------------------------------------------------------------
 
 
-def test_blocking_query_single_statement_returns_value(
+def test_blocking_query_single_statement_returns_list(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _blocking_setup: None,
 ) -> None:
     result = blocking_ws_connection.query("RETURN 42;").execute()
-    assert result == 42
+    assert result == [42]
+    assert blocking_ws_connection.query("RETURN 42;").first() == 42
 
 
-def test_blocking_query_multi_statement_returns_tuple(
+def test_blocking_query_multi_statement_returns_list(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _blocking_setup: None,
 ) -> None:
     result = blocking_ws_connection.query("RETURN 1; RETURN 2; RETURN 3;").execute()
-    assert isinstance(result, tuple)
-    assert result == (1, 2, 3)
+    assert isinstance(result, list)
+    assert result == [1, 2, 3]
 
 
 def test_blocking_query_into_dataclass(

--- a/tests/unit_tests/connections/v3_api/test_safety.py
+++ b/tests/unit_tests/connections/v3_api/test_safety.py
@@ -74,9 +74,7 @@ async def test_async_query_awaited_twice_runs_once(
     # Both await results are identical (same cached fetch)
     assert first == second
     # Server-side, the UPDATE only ran once - n is 2, not 3
-    after = await async_ws_connection.query(
-        "SELECT n FROM counter:trace"
-    )
+    after = await async_ws_connection.query("SELECT n FROM counter:trace").first()
     assert after[0]["n"] == 2
 
 
@@ -92,7 +90,7 @@ async def test_async_query_concurrent_awaits_run_once(
     )
     a, b, c = await asyncio.gather(builder, builder, builder)
     assert a == b == c
-    after = await async_ws_connection.query("SELECT n FROM counter:concurrent")
+    after = await async_ws_connection.query("SELECT n FROM counter:concurrent").first()
     assert after[0]["n"] == 1
 
 
@@ -128,17 +126,16 @@ async def test_async_into_shares_parent_fetch(
 
     await async_ws_connection.query("CREATE counter:share SET n = 7")
     builder = async_ws_connection.query(
-        "UPDATE counter:share SET n = n + 1 RETURN AFTER;"
-        "RETURN 99;"
+        "UPDATE counter:share SET n = n + 1 RETURN AFTER;RETURN 99;"
     )
     direct = await builder
     mapped = await builder.into(Pair)
-    # `direct` is a tuple (update_list, 99); `mapped` repacks the same
+    # `direct` is a list [update_list, 99]; `mapped` repacks the same
     # values into Pair. They reference the same cached fetch.
     assert direct[0] == mapped.a
     assert direct[1] == mapped.b
     # Server-side, the UPDATE ran only once - the n value is 8 (was 7, +1).
-    after = await async_ws_connection.query("SELECT n FROM counter:share")
+    after = await async_ws_connection.query("SELECT n FROM counter:share").first()
     assert after[0]["n"] == 8
 
 
@@ -153,19 +150,18 @@ def test_sync_into_shares_parent_fetch(
 
     blocking_ws_connection.query("CREATE counter:sync_share SET n = 5").execute()
     builder = blocking_ws_connection.query(
-        "UPDATE counter:sync_share SET n = n + 1 RETURN AFTER;"
-        "RETURN 11;"
+        "UPDATE counter:sync_share SET n = n + 1 RETURN AFTER;RETURN 11;"
     )
     direct = builder.execute()
     mapped = builder.into(Pair)
     assert direct[0] == mapped.a
     assert direct[1] == mapped.b
-    after = blocking_ws_connection.query("SELECT n FROM counter:sync_share")
+    after = blocking_ws_connection.query("SELECT n FROM counter:sync_share").first()
     assert after[0]["n"] == 6
 
 
 # ---------------------------------------------------------------------------
-# Safe __repr__ / __str__
+# No-data builders are inert until run
 # ---------------------------------------------------------------------------
 
 
@@ -173,17 +169,20 @@ def test_sync_builder_repr_does_not_execute(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    """Calling repr()/str() on a pending builder must not run the query."""
+    """A no-data builder must not run until a clause / execute() is called.
+
+    Sync builders carry no magic dunders, so ``repr()``/``str()`` (and any
+    other incidental inspection) can never fire the pending operation.
+    """
     blocking_ws_connection.query("CREATE counter:repr_safe SET n = 1").execute()
     blocking_ws_connection.update("counter:repr_safe").merge({"n": 999})
-    # Fresh pending builder - just inspecting must not execute it.
-    pending = blocking_ws_connection.update("counter:repr_safe", {"n": 555})
-    assert "pending" in repr(pending)
-    assert "pending" in str(pending)
-    after = blocking_ws_connection.query(
-        "SELECT n FROM counter:repr_safe"
-    ).execute()
-    # n is whatever the previously-terminal merge set, not 555.
+    # Fresh no-data builder - just inspecting must not execute it.
+    pending = blocking_ws_connection.update("counter:repr_safe")
+    repr(pending)
+    str(pending)
+    after = blocking_ws_connection.query("SELECT n FROM counter:repr_safe").first()
+    # n is whatever the previous terminal merge set - the pending builder
+    # above never ran, so it did not clobber the value.
     assert after[0]["n"] == 999
 
 
@@ -210,9 +209,7 @@ def test_sync_unsafe_string_record_rejected(
     _sync_setup: None,
 ) -> None:
     with pytest.raises(SurrealError):
-        blocking_ws_connection.delete(
-            "counter:1..10; REMOVE TABLE counter;"
-        ).execute()
+        blocking_ws_connection.delete("counter:1..10; REMOVE TABLE counter;")
 
 
 @pytest.mark.asyncio
@@ -221,11 +218,14 @@ async def test_string_record_id_bound_safely(
     _async_setup: None,
     _sync_setup: None,
 ) -> None:
-    """A normal `"table:id"` string is bound as a parameterised RecordID."""
+    """A normal `"table:id"` string is bound as a parameterised RecordID.
+
+    select() of a single record-id string unwraps to the record dict.
+    """
     await async_ws_connection.create("counter:abc", {"n": 42})
     out = await async_ws_connection.select("counter:abc")
-    assert isinstance(out, list)
-    assert out[0]["n"] == 42
+    assert isinstance(out, dict)
+    assert out["n"] == 42
 
 
 @pytest.mark.asyncio
@@ -283,7 +283,8 @@ def test_sync_crud_reconfigure_after_execute_raises(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    builder = blocking_ws_connection.create("counter:sync_reconfig", {"n": 1})
+    # No-data create returns a builder; run it, then reconfiguring raises.
+    builder = blocking_ws_connection.create("counter:sync_reconfig")
     builder.execute()  # explicit consumption
     with pytest.raises(SurrealError, match="Cannot reconfigure"):
         builder.merge({"n": 2})
@@ -293,43 +294,36 @@ def test_sync_insert_reconfigure_after_execute_raises(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    builder = blocking_ws_connection.insert("counter", {"n": 1})
-    builder.execute()
+    # No-data insert returns a builder; .content() runs it, then
+    # reconfiguring raises.
+    builder = blocking_ws_connection.insert("counter")
+    builder.content({"n": 1})
     with pytest.raises(SurrealError, match="Cannot reconfigure"):
         builder.relation()
 
 
 # ---------------------------------------------------------------------------
-# Sync `query().into()` keeps `_executed` / repr in lockstep
+# Sync `query().into()` and `.execute()` share one cached fetch
 # ---------------------------------------------------------------------------
 
 
-def test_sync_query_into_marks_executed(
+def test_sync_query_into_and_execute_share_fetch(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    """After `.into(cls)` the builder must report executed, not pending.
-
-    Previously `.into()` populated the values cache without flipping
-    `_executed`, so `repr(builder)` after a successful `.into()` would
-    misleadingly print "pending" even though the RPC had already run.
-    """
+    """`.into(cls)` and `.execute()` on one builder share a single fetch."""
 
     @dataclass
     class Pair:
         a: int
         b: int
 
-    blocking_ws_connection.query(
-        "CREATE counter:into_repr SET n = 1"
-    ).execute()
+    blocking_ws_connection.query("CREATE counter:into_repr SET n = 1").execute()
     builder = blocking_ws_connection.query("RETURN 10; RETURN 20;")
-    assert "pending" in repr(builder)
     mapped = builder.into(Pair)
     assert mapped == Pair(a=10, b=20)
-    assert "pending" not in repr(builder)
-    # And re-executing returns the same cached tuple without re-fetching.
-    assert builder.execute() == (10, 20)
+    # Re-executing returns the same cached list without re-fetching.
+    assert builder.execute() == [10, 20]
 
 
 # ---------------------------------------------------------------------------
@@ -347,33 +341,39 @@ def test_string_record_id_with_extra_colons_rejected(
     literal-parsing rules for compound IDs, so we refuse to guess.
     """
     with pytest.raises(SurrealError, match="Ambiguous record-id"):
-        blocking_ws_connection.delete("counter:part:rest").execute()
+        blocking_ws_connection.delete("counter:part:rest")
 
 
 # ---------------------------------------------------------------------------
-# Truthiness / equality auto-execute behaviour
+# No magic auto-execute: inspecting a builder never runs it
 # ---------------------------------------------------------------------------
 
 
-def test_sync_builder_bool_triggers_execution(
+def test_sync_builder_has_no_magic_auto_execute(
     blocking_ws_connection: BlockingWsSurrealConnection,
     _sync_setup: None,
 ) -> None:
-    """`bool(builder)` runs the operation - this is documented but tested.
+    """Sync builders carry no auto-executing dunders.
 
-    The point of the test is to *pin* the behaviour so a future refactor
-    that silently changes it will break this test and force an explicit
-    decision (and a docs update).
+    ``bool()`` on a builder is plain object truthiness (always True) and
+    must NOT run the operation; only ``.execute()`` / a clause method does.
+    Pins the eager-model contract so a future refactor that re-introduces
+    magic consumption breaks here and forces an explicit decision.
     """
     blocking_ws_connection.query("CREATE counter:bool_check SET n = 5").execute()
     builder = blocking_ws_connection.query(
         "UPDATE counter:bool_check SET n = n + 1 RETURN AFTER"
     )
-    assert "pending" in repr(builder)
-    assert bool(builder)  # auto-executes
-    assert "pending" not in repr(builder)
-    after = blocking_ws_connection.query("SELECT n FROM counter:bool_check")
-    assert after[0]["n"] == 6  # update ran exactly once
+    assert bool(builder) is True  # object truthiness - does NOT execute
+    for magic in ("__bool__", "__eq__", "__getitem__", "__iter__", "__len__"):
+        assert magic not in type(builder).__dict__
+    # The UPDATE never ran: n is still 5.
+    after = blocking_ws_connection.query("SELECT n FROM counter:bool_check").first()
+    assert after[0]["n"] == 5
+    # Explicit execution runs it exactly once.
+    builder.execute()
+    after = blocking_ws_connection.query("SELECT n FROM counter:bool_check").first()
+    assert after[0]["n"] == 6
 
 
 # ---------------------------------------------------------------------------
@@ -392,9 +392,7 @@ def test_sync_builder_thread_safe_run_once(
     operation independently - corrupting the cache and (for mutations)
     duplicating side effects.
     """
-    blocking_ws_connection.query(
-        "CREATE counter:thread_safe SET n = 0"
-    ).execute()
+    blocking_ws_connection.query("CREATE counter:thread_safe SET n = 0").execute()
     builder = blocking_ws_connection.query(
         "UPDATE counter:thread_safe SET n = n + 1 RETURN AFTER"
     )
@@ -415,9 +413,7 @@ def test_sync_builder_thread_safe_run_once(
     # Every thread sees the *same* cached result.
     assert all(r == results[0] for r in results)
     # And the UPDATE ran exactly once - n is 1, not 8.
-    after = blocking_ws_connection.query(
-        "SELECT n FROM counter:thread_safe"
-    )
+    after = blocking_ws_connection.query("SELECT n FROM counter:thread_safe").first()
     assert after[0]["n"] == 1
 
 
@@ -543,10 +539,10 @@ async def test_async_into_then_await_shares_fetch(
     )
     mapped = await builder.into(Pair)
     direct = await builder
-    assert isinstance(direct, tuple)
+    assert isinstance(direct, list)
     assert direct[0] == mapped.a
     assert direct[1] == mapped.b
-    after = await async_ws_connection.query("SELECT n FROM counter:reverse")
+    after = await async_ws_connection.query("SELECT n FROM counter:reverse").first()
     assert isinstance(after, list)
     assert after[0]["n"] == 4  # update ran exactly once
 

--- a/tests/unit_tests/data_types/test_arrays.py
+++ b/tests/unit_tests/data_types/test_arrays.py
@@ -154,7 +154,7 @@ async def test_empty_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test1 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array
 
 
@@ -166,7 +166,7 @@ async def test_simple_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test2 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array
 
 
@@ -178,7 +178,7 @@ async def test_string_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test3 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array
 
 
@@ -190,7 +190,7 @@ async def test_mixed_type_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test4 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array
 
 
@@ -202,7 +202,7 @@ async def test_nested_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test5 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array
 
 
@@ -217,5 +217,5 @@ async def test_array_of_objects_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE array_tests:test6 SET value = $val;",
         vars={"val": test_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM array_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM array_tests;").first()
     assert result[0]["value"] == test_array

--- a/tests/unit_tests/data_types/test_booleans.py
+++ b/tests/unit_tests/data_types/test_booleans.py
@@ -95,7 +95,7 @@ async def test_true_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE boolean_tests:test1 SET value = $val;",
         vars={"val": True},
     )
-    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;").first()
     assert result[0]["value"] is True
 
 
@@ -106,7 +106,7 @@ async def test_false_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE boolean_tests:test2 SET value = $val;",
         vars={"val": False},
     )
-    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;").first()
     assert result[0]["value"] is False
 
 
@@ -117,7 +117,7 @@ async def test_boolean_fields_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE boolean_tests:test3 SET is_active = $active, is_admin = $admin, is_verified = $verified;",
         vars={"active": True, "admin": False, "verified": True},
     )
-    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM boolean_tests;").first()
     assert result[0]["is_active"] is True
     assert result[0]["is_admin"] is False
     assert result[0]["is_verified"] is True

--- a/tests/unit_tests/data_types/test_datetimes.py
+++ b/tests/unit_tests/data_types/test_datetimes.py
@@ -135,7 +135,7 @@ async def test_native_datetime(surrealdb_connection: Any) -> None:
     )
     compact_test_outcome = await surrealdb_connection.query(
         "SELECT * FROM datetime_tests;"
-    )
+    ).first()
     assert compact_test_outcome[0]["datetime"] == now
     outcome = compact_test_outcome[0]["datetime"]
     assert now.isoformat() == outcome.isoformat()
@@ -154,7 +154,7 @@ async def test_datetime_iso_format(surrealdb_connection: Any) -> None:
     )
     compact_test_outcome = await surrealdb_connection.query(
         "SELECT * FROM datetime_tests;"
-    )
+    ).first()
     assert str(compact_test_outcome[0]["datetime"]) == str(iso_datetime_obj)
     date_str = compact_test_outcome[0]["datetime"].isoformat()
     if sys.version_info >= (3, 11):

--- a/tests/unit_tests/data_types/test_decimal.py
+++ b/tests/unit_tests/data_types/test_decimal.py
@@ -120,7 +120,7 @@ async def test_dec_literal(surrealdb_connection: Any) -> None:
     await surrealdb_connection.query(
         "CREATE numeric_tests:literal_test SET value = 99.99dec;"
     )
-    result = await surrealdb_connection.query("SELECT * FROM numeric_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM numeric_tests;").first()
     stored_value = result[0]["value"]
     assert str(stored_value) == "99.99"
     assert isinstance(stored_value, decimal.Decimal)
@@ -132,10 +132,12 @@ async def test_float_parameter(surrealdb_connection: Any) -> None:
     initial_result = await surrealdb_connection.query(
         "CREATE numeric_tests:float_test SET value = $float_val;",
         vars={"float_val": float_value},
-    )
+    ).first()
     assert isinstance(initial_result[0]["value"], float)
     assert initial_result[0]["value"] == 3.141592653589793
-    second_result = await surrealdb_connection.query("SELECT * FROM numeric_tests;")
+    second_result = await surrealdb_connection.query(
+        "SELECT * FROM numeric_tests;"
+    ).first()
     assert isinstance(second_result[0]["value"], float)
     assert second_result[0]["value"] == 3.141592653589793
 
@@ -146,9 +148,11 @@ async def test_decimal_parameter(surrealdb_connection: Any) -> None:
     initial_result = await surrealdb_connection.query(
         "CREATE numeric_tests:decimal_test SET value = $decimal_val;",
         vars={"decimal_val": decimal_value},
-    )
+    ).first()
     assert isinstance(initial_result[0]["value"], decimal.Decimal)
     assert initial_result[0]["value"] == decimal.Decimal("3.141592653589793")
-    second_result = await surrealdb_connection.query("SELECT * FROM numeric_tests;")
+    second_result = await surrealdb_connection.query(
+        "SELECT * FROM numeric_tests;"
+    ).first()
     assert isinstance(second_result[0]["value"], decimal.Decimal)
     assert second_result[0]["value"] == decimal.Decimal("3.141592653589793")

--- a/tests/unit_tests/data_types/test_geometry.py
+++ b/tests/unit_tests/data_types/test_geometry.py
@@ -445,9 +445,11 @@ async def test_geometry_point_db_insert_and_retrieve(surrealdb_connection: Any) 
     """
     initial_result = await surrealdb_connection.query(
         create_query, vars={"geo": geometry_dict}
-    )
+    ).first()
     assert "geometry" in initial_result[0]
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "Point"
     assert stored_geo["coordinates"] == [1.23, 4.56]
@@ -464,7 +466,7 @@ async def test_geometry_point_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_point1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": my_point})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
     assert isinstance(stored_geo_obj, GeometryPoint)
     assert stored_geo_obj == my_point
@@ -489,7 +491,7 @@ async def test_geometry_point_mixed_coordinates(surrealdb_connection: Any) -> No
     """
     results = await surrealdb_connection.query(
         create_query, vars={"geo": geometry_dict}
-    )
+    ).first()
     stored_geo_obj = results[0]["geometry"]
     assert stored_geo_obj == geometry_dict
 
@@ -520,7 +522,9 @@ async def test_geometry_line_db_insert_and_retrieve(surrealdb_connection: Any) -
         CREATE geometry_tests:line1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "Line"
     assert stored_geo["coordinates"] == [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]
@@ -537,7 +541,7 @@ async def test_geometry_line_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_line1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": line})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
     assert isinstance(stored_geo_obj, GeometryLine)
     assert stored_geo_obj == line
@@ -588,7 +592,9 @@ async def test_geometry_polygon_db_insert_and_retrieve(
         CREATE geometry_tests:polygon1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "Polygon"
     assert stored_geo["coordinates"] == [
@@ -615,7 +621,7 @@ async def test_geometry_polygon_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_polygon1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": polygon})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
 
     assert isinstance(stored_geo_obj, GeometryPolygon)
@@ -768,7 +774,9 @@ async def test_geometry_multipoint_db_insert_and_retrieve(
         CREATE geometry_tests:multipoint1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "MultiPoint"
     assert stored_geo["coordinates"] == [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
@@ -787,7 +795,7 @@ async def test_geometry_multipoint_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_multipoint1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": mp})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
     assert isinstance(stored_geo_obj, GeometryMultiPoint)
     assert stored_geo_obj == mp
@@ -820,7 +828,9 @@ async def test_geometry_multiline_db_insert_and_retrieve(
         CREATE geometry_tests:multiline1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "MultiLineString"
     assert stored_geo["coordinates"] == [
@@ -840,7 +850,7 @@ async def test_geometry_multiline_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_multiline1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": ml})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
     assert isinstance(stored_geo_obj, GeometryMultiLine)
     assert stored_geo_obj == ml
@@ -893,7 +903,9 @@ async def test_geometry_multipolygon_db_insert_and_retrieve(
         CREATE geometry_tests:multipolygon1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "MultiPolygon"
     assert stored_geo["coordinates"] == [
@@ -934,7 +946,7 @@ async def test_geometry_multipolygon_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_multipolygon1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": multipolygon})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
 
     assert isinstance(stored_geo_obj, GeometryMultiPolygon)
@@ -967,7 +979,9 @@ async def test_geometry_collection_db_insert_and_retrieve(
         CREATE geometry_tests:collection1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": geometry_dict})
-    select_result = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    select_result = await surrealdb_connection.query(
+        "SELECT * FROM geometry_tests;"
+    ).first()
     stored_geo = select_result[0]["geometry"]
     assert stored_geo["type"] == "GeometryCollection"
     assert len(stored_geo["geometries"]) == 2
@@ -984,7 +998,7 @@ async def test_geometry_collection_db_insert_and_retrieve_as_python_object(
         CREATE geometry_tests:obj_collection1 SET geometry = $geo;
     """
     await surrealdb_connection.query(create_query, vars={"geo": gc})
-    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;")
+    results = await surrealdb_connection.query("SELECT * FROM geometry_tests;").first()
     stored_geo_obj = results[0]["geometry"]
     assert isinstance(stored_geo_obj, GeometryCollection)
     assert stored_geo_obj == gc

--- a/tests/unit_tests/data_types/test_none.py
+++ b/tests/unit_tests/data_types/test_none.py
@@ -119,7 +119,7 @@ async def test_none(surrealdb_connection: Any) -> None:
     assert "Dave" == outcome["name"]
     assert 34 == outcome["age"]
 
-    outcome = await surrealdb_connection.query("SELECT * FROM person")
+    outcome = await surrealdb_connection.query("SELECT * FROM person").first()
     assert 2 == len(outcome)
 
 
@@ -134,7 +134,7 @@ async def test_none_with_query(surrealdb_connection: Any) -> None:
     outcome = await surrealdb_connection.query(
         "UPSERT person MERGE {id: $id, name: $name, nums: $nums}",
         {"id": [1, 2], "name": "John", "nums": [None]},
-    )
+    ).first()
     record_check = RecordID(table_name="person", identifier=[1, 2])
     if len(outcome) > 0:
         assert record_check == outcome[0]["id"]
@@ -145,7 +145,7 @@ async def test_none_with_query(surrealdb_connection: Any) -> None:
     outcome = await surrealdb_connection.query(
         "UPSERT person MERGE {id: $id, name: $name, nums: $nums}",
         {"id": [3, 4], "name": "Dave", "nums": [None]},
-    )
+    ).first()
     record_check = RecordID(table_name="person", identifier=[3, 4])
     if len(outcome) > 0:
         assert record_check == outcome[0]["id"]
@@ -153,5 +153,5 @@ async def test_none_with_query(surrealdb_connection: Any) -> None:
         nums_value = outcome[0].get("nums")
         assert nums_value in [[None], []]
 
-    outcome = await surrealdb_connection.query("SELECT * FROM person")
+    outcome = await surrealdb_connection.query("SELECT * FROM person").first()
     assert len(outcome) in [0, 2]

--- a/tests/unit_tests/data_types/test_numbers.py
+++ b/tests/unit_tests/data_types/test_numbers.py
@@ -176,7 +176,7 @@ async def test_positive_int_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test1 SET value = $val;",
         vars={"val": test_int},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == test_int
 
 
@@ -188,7 +188,7 @@ async def test_negative_int_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test2 SET value = $val;",
         vars={"val": test_int},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == test_int
 
 
@@ -199,7 +199,7 @@ async def test_zero_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test3 SET value = $val;",
         vars={"val": 0},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == 0
 
 
@@ -211,7 +211,7 @@ async def test_large_int_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test4 SET value = $val;",
         vars={"val": test_int},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == test_int
 
 
@@ -224,7 +224,7 @@ async def test_float_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test5 SET value = $val;",
         vars={"val": test_float},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == test_float
 
 
@@ -236,7 +236,7 @@ async def test_negative_float_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test6 SET value = $val;",
         vars={"val": test_float},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["value"] == test_float
 
 
@@ -247,6 +247,6 @@ async def test_mixed_numbers_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE number_tests:test7 SET int_val = $int_val, float_val = $float_val;",
         vars={"int_val": 100, "float_val": 99.99},
     )
-    result = await surrealdb_connection.query("SELECT * FROM number_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM number_tests;").first()
     assert result[0]["int_val"] == 100
     assert result[0]["float_val"] == 99.99

--- a/tests/unit_tests/data_types/test_objects.py
+++ b/tests/unit_tests/data_types/test_objects.py
@@ -187,7 +187,7 @@ async def test_empty_object_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE object_tests:test1 SET value = $val;",
         vars={"val": test_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["value"] == test_obj
 
 
@@ -199,7 +199,7 @@ async def test_simple_object_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE object_tests:test2 SET value = $val;",
         vars={"val": test_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["value"] == test_obj
 
 
@@ -211,7 +211,7 @@ async def test_nested_object_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE object_tests:test3 SET value = $val;",
         vars={"val": test_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["value"] == test_obj
 
 
@@ -229,7 +229,7 @@ async def test_object_with_mixed_types_db_roundtrip(surrealdb_connection: Any) -
         "CREATE object_tests:test4 SET value = $val;",
         vars={"val": test_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["value"] == test_obj
 
 
@@ -249,7 +249,7 @@ async def test_object_with_arrays_and_nested_objects_db_roundtrip(
         "CREATE object_tests:test5 SET value = $val;",
         vars={"val": test_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["value"] == test_obj
 
 
@@ -260,7 +260,7 @@ async def test_top_level_object_fields_db_roundtrip(surrealdb_connection: Any) -
         "CREATE object_tests:test6 SET name = $name, age = $age, active = $active;",
         vars={"name": "Charlie", "age": 35, "active": True},
     )
-    result = await surrealdb_connection.query("SELECT * FROM object_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM object_tests;").first()
     assert result[0]["name"] == "Charlie"
     assert result[0]["age"] == 35
     assert result[0]["active"] is True

--- a/tests/unit_tests/data_types/test_range.py
+++ b/tests/unit_tests/data_types/test_range.py
@@ -281,7 +281,7 @@ async def test_range_inclusive_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE range_tests:test1 SET range_val = $val;",
         vars={"val": range_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["range_val"] == range_obj
 
 
@@ -293,7 +293,7 @@ async def test_range_exclusive_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE range_tests:test2 SET range_val = $val;",
         vars={"val": range_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["range_val"] == range_obj
 
 
@@ -305,7 +305,7 @@ async def test_range_mixed_bounds_db_roundtrip(surrealdb_connection: Any) -> Non
         "CREATE range_tests:test3 SET range_val = $val;",
         vars={"val": range_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["range_val"] == range_obj
 
 
@@ -317,7 +317,7 @@ async def test_string_range_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE range_tests:test4 SET range_val = $val;",
         vars={"val": range_obj},
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["range_val"] == range_obj
 
 
@@ -332,7 +332,7 @@ async def test_multiple_ranges_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE range_tests:test5 SET r1 = $range1, r2 = $range2;",
         vars=ranges,
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["r1"] == ranges["range1"]
     assert result[0]["r2"] == ranges["range2"]
 
@@ -349,5 +349,5 @@ async def test_range_in_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE range_tests:test6 SET ranges = $val;",
         vars={"val": ranges_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM range_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM range_tests;").first()
     assert result[0]["ranges"] == ranges_array

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -364,7 +364,7 @@ async def test_record_id_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE record_id_tests:test1 SET user_ref = $val;",
         vars={"val": record_id},
     )
-    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;").first()
     assert result[0]["user_ref"] == record_id
 
 
@@ -376,7 +376,7 @@ async def test_record_id_with_int_db_roundtrip(surrealdb_connection: Any) -> Non
         "CREATE record_id_tests:test2 SET user_ref = $val;",
         vars={"val": record_id},
     )
-    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;").first()
     assert result[0]["user_ref"] == record_id
 
 
@@ -388,7 +388,7 @@ async def test_record_id_with_array_db_roundtrip(surrealdb_connection: Any) -> N
         "CREATE record_id_tests:test3 SET event_ref = $val;",
         vars={"val": record_id},
     )
-    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;").first()
     assert result[0]["event_ref"] == record_id
 
 
@@ -413,7 +413,7 @@ async def test_multiple_record_ids_db_roundtrip(surrealdb_connection: Any) -> No
         "CREATE record_id_tests:test4 SET user_ref = $user, post_ref = $post, comment_ref = $comment;",
         vars=record_ids,
     )
-    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;").first()
     assert result[0]["user_ref"] == record_ids["user"]
     assert result[0]["post_ref"] == record_ids["post"]
     assert result[0]["comment_ref"] == record_ids["comment"]
@@ -427,7 +427,7 @@ async def test_record_id_with_object_db_roundtrip(surrealdb_connection: Any) -> 
         "CREATE record_id_tests:test5 SET person_ref = $val;",
         vars={"val": record_id},
     )
-    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM record_id_tests;").first()
     assert result[0]["person_ref"] == record_id
 
 
@@ -495,7 +495,7 @@ async def test_relate_with_bound_record_id_vars(
 
     quoted_res = await surrealdb_connection.query(
         "SELECT * FROM record_id_tests:`231`;"
-    )
+    ).first()
     quoted_id = quoted_res[0]["id"]
     assert quoted_id.id == "231"  # the raw id is the plain string "231"
 
@@ -506,7 +506,7 @@ async def test_relate_with_bound_record_id_vars(
 
     result = await surrealdb_connection.query(
         "SELECT ->owns->record_id_tests.* AS companies FROM record_id_tests:alice;"
-    )
+    ).first()
     companies = result[0]["companies"]
     assert len(companies) == 1
     assert companies[0]["name"] == "Quoted Company"
@@ -531,11 +531,13 @@ async def test_bound_record_id_var_treats_hostile_id_as_inert_data(
     res = await surrealdb_connection.query(
         "RELATE $a->owns->$b;",
         vars={"a": RecordID("record_id_tests", "alice"), "b": hostile},
-    )
+    ).first()
     assert res[0]["out"] == hostile  # edge points at the literal string id
 
     # The table (and alice) survived: the hostile id was data, not syntax.
-    alive = await surrealdb_connection.query("SELECT * FROM record_id_tests:alice;")
+    alive = await surrealdb_connection.query(
+        "SELECT * FROM record_id_tests:alice;"
+    ).first()
     assert alive[0]["name"] == "Alice"
 
 
@@ -565,7 +567,7 @@ async def test_relate_with_manually_quoted_numeric_string_id(
 
     quoted_res = await surrealdb_connection.query(
         "SELECT * FROM record_id_tests:`231`;"
-    )
+    ).first()
     quoted_id = quoted_res[0]["id"]
     assert quoted_id.id == "231"  # the raw id is the plain string "231"
 
@@ -576,7 +578,7 @@ async def test_relate_with_manually_quoted_numeric_string_id(
 
     result = await surrealdb_connection.query(
         "SELECT ->owns->record_id_tests.* AS companies FROM record_id_tests:alice;"
-    )
+    ).first()
     companies = result[0]["companies"]
     assert len(companies) == 1
     assert companies[0]["name"] == "Quoted Company"

--- a/tests/unit_tests/data_types/test_strings.py
+++ b/tests/unit_tests/data_types/test_strings.py
@@ -104,7 +104,7 @@ async def test_string_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE string_tests:test1 SET value = $val;",
         vars={"val": test_string},
     )
-    result = await surrealdb_connection.query("SELECT * FROM string_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM string_tests;").first()
     assert result[0]["value"] == test_string
 
 
@@ -116,7 +116,7 @@ async def test_empty_string_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE string_tests:test2 SET value = $val;",
         vars={"val": test_string},
     )
-    result = await surrealdb_connection.query("SELECT * FROM string_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM string_tests;").first()
     assert result[0]["value"] == test_string
 
 
@@ -128,7 +128,7 @@ async def test_unicode_string_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE string_tests:test3 SET value = $val;",
         vars={"val": test_string},
     )
-    result = await surrealdb_connection.query("SELECT * FROM string_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM string_tests;").first()
     assert result[0]["value"] == test_string
 
 
@@ -140,5 +140,5 @@ async def test_multiline_string_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE string_tests:test4 SET value = $val;",
         vars={"val": test_string},
     )
-    result = await surrealdb_connection.query("SELECT * FROM string_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM string_tests;").first()
     assert result[0]["value"] == test_string

--- a/tests/unit_tests/data_types/test_table.py
+++ b/tests/unit_tests/data_types/test_table.py
@@ -139,7 +139,7 @@ async def test_table_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE table_tests:test1 SET table_ref = $val;",
         vars={"val": table},
     )
-    result = await surrealdb_connection.query("SELECT * FROM table_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM table_tests;").first()
     assert result[0]["table_ref"] == table
 
 
@@ -156,7 +156,7 @@ async def test_multiple_tables_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE table_tests:test2 SET t1 = $table1, t2 = $table2, t3 = $table3;",
         vars=tables,
     )
-    result = await surrealdb_connection.query("SELECT * FROM table_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM table_tests;").first()
     assert result[0]["t1"] == tables["table1"]
     assert result[0]["t2"] == tables["table2"]
     assert result[0]["t3"] == tables["table3"]
@@ -175,5 +175,5 @@ async def test_table_in_array_db_roundtrip(surrealdb_connection: Any) -> None:
         "CREATE table_tests:test3 SET tables = $val;",
         vars={"val": tables_array},
     )
-    result = await surrealdb_connection.query("SELECT * FROM table_tests;")
+    result = await surrealdb_connection.query("SELECT * FROM table_tests;").first()
     assert result[0]["tables"] == tables_array


### PR DESCRIPTION
Finalizes the v3 stable **return semantics** across three coupled, breaking changes. Type checks (`ruff`, `mypy`, `pyright`) are green on `src/` and `tests/`, and the full unit suite passes against a live SurrealDB 3.2.1 server.

## A) Eager sync builders

The magic-consumption model is gone. `_SyncBuilderMixin` and all of its auto-executing dunders (`__bool__`, `__eq__`, `__ne__`, `__getattr__`, `__getitem__`, `__iter__`, `__len__`, `__contains__`, and the pending-`repr`/`str`) are **removed**, so inspecting a sync builder can never fire a query or mutation.

Sync connection methods are now **eager**:

- `select(resource)` and `delete(resource)` run immediately and return the result (never a builder).
- `create/update/upsert(record, data)` and `insert(table, data)` run immediately and return the result.
- The no-data forms — `create(record)`, `insert(table)` — return a builder whose clause methods (`.content` / `.replace` / `.merge` / `.patch` / `.relation`) and `.execute()` run the operation and return the result.

**Async behaviour is unchanged**: async builders stay awaitable, async clause methods return `self`, and `await` runs the op.

## B) `query()` always a sequence

`AsyncQueryBuilder.execute()` and `SyncQueryBuilder.execute()` now **always** return `list[Value]` — one entry per statement, even for a single statement (previously a bare `Value` for one statement, a `tuple` for many). Added `.first()` (async coroutine / sync method) returning the first statement's result, or `None` when there are no statements. `.into(cls)` (positional statement→field mapping) is unchanged.

```python
rows  = await db.query("SELECT * FROM person")          # [people_list]
first = await db.query("SELECT * FROM person").first()  # people_list
db.query("DELETE tmp;").execute()                       # sync: explicit run
```

## C) `select()` unwrap + overloads

- `select(RecordID(...))` (or a single `"table:id"` string) → `dict[str, Value] | None` (`None` when the record is absent).
- `select(Table(...))` (or a bare table-name string) → `list[Value]`.

`@overload` sets mirroring the `delete()` overloads were added to `async_template`, `sync_template`, all four connections, and the session/transaction classes, and the single-record unwrap is implemented in each connection's `select()`.

## User-facing migration

| Before | After |
| --- | --- |
| `db.query("SELECT 1")` → single result | `db.query("SELECT 1")` → `[result]` (use `.first()` / `[0]`) |
| Sync `db.create(rec)[...]` (magic auto-exec) | `db.create(rec, data)` eager, or `db.create(rec).execute()` |
| Sync `db.query("DELETE x")` on consume | `db.query("DELETE x").execute()` (returns list) |
| `db.select(RecordID(...))` → `[record]` | `db.select(RecordID(...))` → `record` dict or `None` |

## Tests & docs

- Updated every test that relied on the removed sync magic consumption (explicit `.execute()`), on the query single-statement bare `Value` (now `.first()` / list), and on `select(RecordID)` returning a list (now `dict | None`).
- Updated README API sections (eager sync, query sequence + `.first()`, `select()` unwrap, migration table) and added a `CHANGELOG.md` entry under `[Unreleased]`.

## Verification

- `uv run ruff check src/` + `ruff format` — clean
- `uv run mypy --explicit-package-bases src/` — clean
- `uv run pyright src/` — 0 errors
- `uv run mypy --explicit-package-bases tests/` — clean
- `uv run pytest tests/unit_tests --ignore=tests/unit_tests/connections/embedded` against a live SurrealDB **3.2.1** server — **733 passed, 0 failed** (14 `session_txn` tests skip on a plain `surreal start` server due to anonymous-session auth config; unrelated to this change). Without a server the connection tests self-skip as designed.

