### PR TITLE
Docs: live-query + Spectron sections; fix batch_async assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,96 @@ result = await db.run("fn::increment", [1])
 greeting = await db.run("fn::greet", ["world"])
 ```
 
+## Live queries
+
+Live queries let you subscribe to changes on a table and receive a
+notification whenever a record is created, updated, or deleted. They are a
+**WebSocket-only** feature (`ws://` or `wss://`).
+
+The API is three methods:
+
+- `live(table, diff=False)` - start a live query on a table and return its
+  `UUID`. Pass `diff=True` to receive JSON Patch diffs instead of full
+  records.
+- `subscribe_live(query_uuid)` - return a generator (async generator for the
+  async client) that yields notification dicts. Each notification has an
+  `"action"` (`"CREATE"`, `"UPDATE"`, or `"DELETE"`) and a `"result"` (the
+  affected record).
+- `kill(query_uuid)` - stop a running live query.
+
+You can also start a live query through `query("LIVE SELECT * FROM ...")`,
+which returns the same `UUID` you can pass to `subscribe_live()`.
+
+### Async
+
+```python
+import asyncio
+from surrealdb import AsyncSurreal
+
+async def main():
+    # Connection that owns the subscription.
+    async with AsyncSurreal("ws://localhost:8000/rpc") as db:
+        await db.signin({"username": "root", "password": "root"})
+        await db.use("ns", "db")
+
+        live_id = await db.live("person")           # -> UUID
+        subscription = await db.subscribe_live(live_id)
+
+        # Drive the mutation on a SEPARATE connection (see caveats below).
+        async with AsyncSurreal("ws://localhost:8000/rpc") as writer:
+            await writer.signin({"username": "root", "password": "root"})
+            await writer.use("ns", "db")
+            await writer.create("person", {"name": "Jaime"})
+
+        # Wait for the notification (guard with a timeout in real code).
+        notification = await asyncio.wait_for(subscription.__anext__(), timeout=10)
+        print(notification["action"])   # "CREATE"
+        print(notification["result"])   # the created record
+
+        await db.kill(live_id)
+
+asyncio.run(main())
+```
+
+### Blocking
+
+```python
+from surrealdb import Surreal
+
+with Surreal("ws://localhost:8000/rpc") as db:
+    db.signin({"username": "root", "password": "root"})
+    db.use("ns", "db")
+
+    live_id = db.live("person")            # -> UUID
+    subscription = db.subscribe_live(live_id)
+
+    # Mutate on a SEPARATE connection so the notification can arrive.
+    with Surreal("ws://localhost:8000/rpc") as writer:
+        writer.signin({"username": "root", "password": "root"})
+        writer.use("ns", "db")
+        writer.create("person", {"name": "Jaime"})
+
+    for notification in subscription:
+        print(notification["action"], notification["result"])
+        break                              # generator blocks for the next one
+
+    db.kill(live_id)
+```
+
+### Caveats
+
+- **Mutate on a separate connection.** The connection that owns a
+  subscription is busy receiving live notifications, so running
+  `CREATE`/`UPDATE`/`DELETE` on that *same* connection races the query
+  responses against the incoming notifications. Perform the mutations that
+  should trigger notifications on a **second** connection (this is exactly
+  what the test suite does).
+- **Blocking client: one subscriber per connection.** The blocking
+  `subscribe_live()` reads notifications straight off the socket, so a single
+  blocking connection supports only **one** concurrent subscriber. Use a
+  separate connection per live subscription (or the async client, which
+  fans notifications out to per-subscriber queues).
+
 ## Migrating from 2.x
 
 v3.0 is a breaking change. Highlights:
@@ -515,6 +605,29 @@ async with AsyncSurreal("ws://localhost:8000") as db:
 
 For a complete example with configuration options and best practices, see [`examples/logfire/`](examples/logfire/).
 
+## Spectron
+
+[Spectron](https://github.com/surrealdb/spectron) is a memory service, and its
+client is bundled with `surrealdb`. It is **no longer re-exported at the top
+level** - import it from its own submodule:
+
+```python
+from surrealdb.spectron import Spectron, AsyncSpectron
+
+with Spectron(
+    context="acme-prod",
+    endpoint="https://api.spectron.example",
+    api_key="sk-spec-...",
+) as memory:
+    memory.remember("I work at Acme as CTO")
+    hits = memory.recall("what do I do at Acme")
+    print(hits.hits)
+```
+
+`Spectron` is synchronous (backed by `requests`); `AsyncSpectron` is the
+`await`-able equivalent (backed by `aiohttp`). See
+[`src/surrealdb/spectron/README.md`](src/surrealdb/spectron/README.md) for the
+full client documentation.
 
 ## Contributing
 

--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -34,4 +34,6 @@ async def test_batch(async_ws_connection: AsyncWsSurrealConnection) -> None:
             ]
 
         outcome = [t.result() for t in tasks]
-        assert [0 == 1, 4, 9, 16], outcome
+        # Each task returns `$p ** 2` for p in range(5), and the results must
+        # come back in task-creation order regardless of the staggered sleeps.
+        assert outcome == [num**2 for num in range(5)], outcome


### PR DESCRIPTION
## What

Small docs + test-hygiene PR for the 3.0.0 line. Based on `origin/main`; a
rebase is expected once the larger in-flight README/connection PRs land, so
the prose describes the intended behaviour.

### README: Live queries section

The README previously had **zero** mention of live queries. Adds a
"Live queries" section documenting the WebSocket-only `live()`,
`subscribe_live()`, and `kill()` API with both an async and a blocking
example, plus the two important caveats:

- **Mutate on a separate connection** while subscribed — the connection that
  owns a subscription is busy receiving notifications, so writes on the same
  connection race query responses against notifications (this is exactly what
  the test suite does).
- **Blocking client: one subscriber per connection** — `subscribe_live()`
  reads straight off the socket, so a single blocking connection supports only
  one concurrent subscriber.

### README: Spectron note

Adds a short "Spectron" section pointing users at
`from surrealdb.spectron import Spectron, AsyncSpectron` (it is no longer
re-exported at the top level), linking to `src/surrealdb/spectron/README.md`.

### Fix always-true assertion (task_a46a6cf6)

`tests/unit_tests/connections/batch_async/test_async_ws.py` had
`assert [0 == 1, 4, 9, 16], outcome` — a truthy list literal (with `outcome`
as the *message*) that never checked anything. The batching test runs five
concurrent queries returning `$p ** 2` for `p in range(5)` with staggered
sleeps. It now asserts `outcome == [num**2 for num in range(5)]`, verifying
both the values and that results come back in task-creation order.

## Verification

- `ruff check --fix` + `ruff format`: clean
- `mypy --explicit-package-bases src/`: no issues (72 files)
- `pyright src/`: 0 errors
- `mypy --explicit-package-bases tests/`: no issues (163 files)
- `pytest tests/unit_tests --ignore=tests/unit_tests/connections/embedded`:
  394 passed, 289 skipped, 3 xfailed, 65 errors — the 65 errors are
  pre-existing, server-dependent `ConnectionRefusedError`s in `data_types`
  fixtures (no local SurrealDB on :8000) and are identical on `origin/main`.
  No new failures introduced.
