### PR TITLE
Fix test_batch for query() always-sequence semantics

### DIFF
--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -28,7 +28,7 @@ async def test_batch(async_ws_connection: AsyncWsSurrealConnection) -> None:
                     async_ws_connection.query(
                         f"RETURN sleep({sleep_fn}($d)) or $p**2",
                         dict(d=10 if num % 2 else 0, p=num),
-                    ).execute()
+                    ).first()
                 )
                 for num in range(5)
             ]


### PR DESCRIPTION
Main CI failed on `batch_async/test_async_ws.py::test_batch` (Python 3.11+ only — 3.10 bypasses the `asyncio.TaskGroup` path). Each batched task called `query(...).execute()`, which under the v3 return-semantics change now returns a `list[Value]`, so `outcome` was `[[0],[1],[4],[9],[16]]` instead of `[0,1,4,9,16]`. Switch to `.first()` to get each statement's scalar result. One-line test fix.