### PR TITLE
data_types tests skip cleanly without a server

### DIFF
--- a/tests/unit_tests/data_types/conftest.py
+++ b/tests/unit_tests/data_types/conftest.py
@@ -1,0 +1,36 @@
+import socket
+
+import pytest
+
+
+def _server_reachable(host: str = "127.0.0.1", port: int = 8000) -> bool:
+    """Best-effort TCP probe so we can skip cleanly when no server is up."""
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _require_surrealdb_server(request: pytest.FixtureRequest) -> None:
+    """Skip DB round-trip data-type tests when no SurrealDB is reachable.
+
+    The round-trip tests in this suite request the locally defined
+    ``surrealdb_connection`` fixture, which opens a real connection to a
+    server on ``localhost:8000``. Without this gate a missing server
+    surfaces as a wall of cryptic ``ConnectionRefusedError`` failures
+    (reported as ERROR) inside each connection fixture. With it those
+    tests are skipped with a single, actionable message.
+
+    The pure encode/decode and value-type unit tests in the same files do
+    not request ``surrealdb_connection``, so they keep running serverless.
+    """
+    if "surrealdb_connection" not in request.fixturenames:
+        return
+    if not _server_reachable():
+        pytest.skip(
+            "No SurrealDB server reachable on 127.0.0.1:8000. Start one with "
+            "`surreal start -u root -p root memory --bind 127.0.0.1:8000` "
+            "(or via docker-compose) to run these DB round-trip tests."
+        )


### PR DESCRIPTION
## Summary

The tests under `tests/unit_tests/data_types/` mix pure encode/decode value-type unit tests with DB round-trip tests that open a real connection to a SurrealDB server on `localhost:8000`. Serverless, the round-trip tests ERROR out at fixture setup with a wall of cryptic `ConnectionRefusedError` failures instead of skipping.

This adds `tests/unit_tests/data_types/conftest.py` with an autouse fixture that mirrors the reachability guard already used by the `connections/` suite. It performs a best-effort TCP probe and, when no server is reachable, calls `pytest.skip` so those tests report as SKIPPED rather than ERROR.

## Scoping

The skip is gated on the `surrealdb_connection` fixture (via `request.fixturenames`), which every round-trip test in this suite requests. Pure encode/decode and value-type unit tests do not request that fixture and continue to RUN serverless. The autouse fixture runs before the per-file connection fixture, so the skip happens before any connection attempt.

## Verification

Serverless `uv run pytest tests/unit_tests/data_types -q`:
- Before: pure unit tests pass, round-trip tests ERROR (ConnectionRefused).
- After: 255 passed, 68 skipped, 0 errors.

Also green: `ruff check` + `ruff format` on the new file, `mypy src/`, `pyright src/`, `mypy tests/`.