### PR TITLE
delete(RecordID) returns dict | None (align with select)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `delete(RecordID)` now returns `dict | None` (the deleted record, or `None` when absent), matching `select`; `delete(Table)` still returns a list.
+
 ## [3.0.0-alpha.2] - 2026-07-16
 
 Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch of issues found in review.

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -304,7 +304,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         )
 
     @overload
-    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
@@ -312,9 +312,10 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
         """Delete records; returns an awaitable builder.
 
-        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record; a
-        ``Table`` (or bare name) to the list of deleted records. ``DELETE`` has
-        no clause methods.
+        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record, or
+        ``None`` when no record was deleted (matching select); a ``Table`` (or
+        bare name) to the list of deleted records. ``DELETE`` has no clause
+        methods.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(),

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -233,7 +233,7 @@ class AsyncTemplate:
         raise NotImplementedError(f"upsert not implemented for: {self}")
 
     @overload
-    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
@@ -241,7 +241,10 @@ class AsyncTemplate:
     def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
         """Delete records.
 
-        Returns an awaitable builder. ``DELETE`` does not support clause methods.
+        Returns an awaitable builder. A ``RecordID`` (or ``"table:id"``)
+        resolves to the deleted record, or ``None`` when no record was
+        deleted (matching select); a ``Table`` (or bare name) resolves to the
+        list of deleted records. ``DELETE`` does not support clause methods.
         """
         raise NotImplementedError(f"delete not implemented for: {self}")
 

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -541,7 +541,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> AsyncCrudBuilder[dict[str, Value]]: ...
+    ) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(
         self,
@@ -567,9 +567,10 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     ) -> AsyncCrudBuilder[Any]:
         """Delete records; returns an awaitable builder.
 
-        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record; a
-        ``Table`` (or bare name) to the list of deleted records. ``DELETE`` has
-        no clause methods.
+        A ``RecordID`` (or ``"table:id"``) resolves to the deleted record, or
+        ``None`` when no record was deleted (matching select); a ``Table`` (or
+        bare name) to the list of deleted records. ``DELETE`` has no clause
+        methods.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
@@ -905,7 +906,7 @@ class AsyncSurrealSession:
         return self._connection.upsert(record, data, session_id=self._session_id)
 
     @overload
-    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
@@ -1061,7 +1062,7 @@ class AsyncSurrealTransaction:
         )
 
     @overload
-    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value]]: ...
+    def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -262,7 +262,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         return builder.content(data)
 
     @overload
-    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
@@ -270,8 +270,9 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def delete(self, record: RecordIdType) -> Value:
         """Delete records eagerly and return the deleted record(s).
 
-        A ``RecordID`` (or ``"table:id"``) returns the single deleted record; a
-        ``Table`` (or bare name) returns the list of deleted records.
+        A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
+        ``None`` when no record was deleted (matching select); a ``Table`` (or
+        bare name) returns the list of deleted records.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -566,7 +566,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> dict[str, Value]: ...
+    ) -> dict[str, Value] | None: ...
     @overload
     def delete(
         self,
@@ -592,8 +592,9 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
     ) -> Value:
         """Delete records eagerly and return the deleted record(s).
 
-        A ``RecordID`` (or ``"table:id"``) returns the single deleted record; a
-        ``Table`` (or bare name) returns the list of deleted records.
+        A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
+        ``None`` when no record was deleted (matching select); a ``Table`` (or
+        bare name) returns the list of deleted records.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
@@ -966,7 +967,7 @@ class BlockingSurrealSession:
         return self._connection.upsert(record, data, session_id=self._session_id)
 
     @overload
-    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
@@ -1120,7 +1121,7 @@ class BlockingSurrealTransaction:
         )
 
     @overload
-    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -307,8 +307,15 @@ class _CrudState:
     def _extract(self, response: dict[str, Any]) -> Any:
         stmts = _check_response(response, self._op_name)
         result = _check_first_statement(stmts)
-        if self._single and isinstance(result, list) and len(result) == 1:
-            return result[0]
+        if self._single and isinstance(result, list):
+            # Single-record DELETE aligns with select's absent-record
+            # handling: an empty result (no record was deleted) unwraps to
+            # None, otherwise the deleted record dict. Other single-record
+            # operations only unwrap the one-element list they produce.
+            if self._operation == "DELETE":
+                return result[0] if result else None
+            if len(result) == 1:
+                return result[0]
         return result
 
 

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -149,13 +149,18 @@ class SyncTemplate:
         raise NotImplementedError(f"upsert not implemented for: {self}")
 
     @overload
-    def delete(self, record: RecordID) -> dict[str, Value]: ...
+    def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
     def delete(self, record: str) -> Value: ...
     def delete(self, record: RecordIdType) -> Value:
-        """Delete records eagerly and return the deleted record(s)."""
+        """Delete records eagerly and return the deleted record(s).
+
+        A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
+        ``None`` when no record was deleted (matching select); a ``Table``
+        (or bare name) returns the list of deleted records.
+        """
         raise NotImplementedError(f"delete not implemented for: {self}")
 
     def info(self) -> Value:

--- a/tests/unit_tests/connections/delete/test_async_http.py
+++ b/tests/unit_tests/connections/delete/test_async_http.py
@@ -49,6 +49,28 @@ async def test_delete_record_id(
 
 
 @pytest.mark.asyncio
+async def test_delete_record_id_absent(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;")
+
+    # Deleting an absent record returns None (matching select).
+    outcome = await async_http_connection.delete(RecordID("user", "missing"))
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_delete_string_absent(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query("DELETE user;")
+
+    # Deleting an absent "table:id" record returns None (matching select).
+    outcome = await async_http_connection.delete("user:missing")
+    assert outcome is None
+
+
+@pytest.mark.asyncio
 async def test_delete_table(async_http_connection: AsyncHttpSurrealConnection) -> None:
     await async_http_connection.query("DELETE user;")
     await async_http_connection.query("CREATE user:tobie SET name = 'Tobie';")

--- a/tests/unit_tests/connections/delete/test_async_ws.py
+++ b/tests/unit_tests/connections/delete/test_async_ws.py
@@ -49,6 +49,28 @@ async def test_delete_record_id(
 
 
 @pytest.mark.asyncio
+async def test_delete_record_id_absent(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;")
+
+    # Deleting an absent record returns None (matching select).
+    outcome = await async_ws_connection.delete(RecordID("user", "missing"))
+    assert outcome is None
+
+
+@pytest.mark.asyncio
+async def test_delete_string_absent(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DELETE user;")
+
+    # Deleting an absent "table:id" record returns None (matching select).
+    outcome = await async_ws_connection.delete("user:missing")
+    assert outcome is None
+
+
+@pytest.mark.asyncio
 async def test_delete_table(async_ws_connection: AsyncWsSurrealConnection) -> None:
     await async_ws_connection.query("DELETE user;")
     await async_ws_connection.query("CREATE user:tobie SET name = 'Tobie';")

--- a/tests/unit_tests/connections/delete/test_blocking_http.py
+++ b/tests/unit_tests/connections/delete/test_blocking_http.py
@@ -72,6 +72,26 @@ def test_delete_record_id(
     assert outcome == []
 
 
+def test_delete_record_id_absent(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+
+    # Deleting an absent record returns None (matching select).
+    outcome = blocking_http_connection.delete(RecordID("user", "missing"))
+    assert outcome is None
+
+
+def test_delete_string_absent(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query("DELETE user;").execute()
+
+    # Deleting an absent "table:id" record returns None (matching select).
+    outcome = blocking_http_connection.delete("user:missing")
+    assert outcome is None
+
+
 def test_delete_table(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
     blocking_http_connection.query("DELETE user;").execute()
     blocking_http_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()

--- a/tests/unit_tests/connections/delete/test_blocking_ws.py
+++ b/tests/unit_tests/connections/delete/test_blocking_ws.py
@@ -46,6 +46,26 @@ def test_delete_record_id(
     assert outcome == []
 
 
+def test_delete_record_id_absent(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+
+    # Deleting an absent record returns None (matching select).
+    outcome = blocking_ws_connection.delete(RecordID("user", "missing"))
+    assert outcome is None
+
+
+def test_delete_string_absent(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DELETE user;").execute()
+
+    # Deleting an absent "table:id" record returns None (matching select).
+    outcome = blocking_ws_connection.delete("user:missing")
+    assert outcome is None
+
+
 def test_delete_table(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
     blocking_ws_connection.query("DELETE user;").execute()
     blocking_ws_connection.query("CREATE user:tobie SET name = 'Tobie';").execute()

--- a/tests/unit_tests/test_connection_typing.py
+++ b/tests/unit_tests/test_connection_typing.py
@@ -64,7 +64,8 @@ def test_async_session_crud_overload_precision() -> None:
     assert_type(session.upsert("person"), AsyncCrudBuilder[Value])
 
     assert_type(
-        session.delete(RecordID("person", 1)), AsyncCrudBuilder[dict[str, Value]]
+        session.delete(RecordID("person", 1)),
+        AsyncCrudBuilder[dict[str, Value] | None],
     )
     assert_type(session.delete(Table("person")), AsyncCrudBuilder[list[Value]])
     assert_type(session.delete("person"), AsyncCrudBuilder[Value])
@@ -91,7 +92,10 @@ def test_async_transaction_crud_overload_precision() -> None:
     assert_type(txn.upsert(Table("person")), AsyncCrudBuilder[list[Value]])
     assert_type(txn.upsert("person"), AsyncCrudBuilder[Value])
 
-    assert_type(txn.delete(RecordID("person", 1)), AsyncCrudBuilder[dict[str, Value]])
+    assert_type(
+        txn.delete(RecordID("person", 1)),
+        AsyncCrudBuilder[dict[str, Value] | None],
+    )
     assert_type(txn.delete(Table("person")), AsyncCrudBuilder[list[Value]])
     assert_type(txn.delete("person"), AsyncCrudBuilder[Value])
 
@@ -124,7 +128,7 @@ def test_blocking_session_crud_overload_precision() -> None:
     assert_type(session.upsert("person"), SyncCrudBuilder[Value])
 
     # delete is eager on sync connections: it returns the result directly.
-    assert_type(session.delete(RecordID("person", 1)), dict[str, Value])
+    assert_type(session.delete(RecordID("person", 1)), dict[str, Value] | None)
     assert_type(session.delete(Table("person")), list[Value])
     assert_type(session.delete("person"), Value)
 
@@ -151,6 +155,6 @@ def test_blocking_transaction_crud_overload_precision() -> None:
     assert_type(txn.upsert("person"), SyncCrudBuilder[Value])
 
     # delete is eager on sync connections: it returns the result directly.
-    assert_type(txn.delete(RecordID("person", 1)), dict[str, Value])
+    assert_type(txn.delete(RecordID("person", 1)), dict[str, Value] | None)
     assert_type(txn.delete(Table("person")), list[Value])
     assert_type(txn.delete("person"), Value)


### PR DESCRIPTION
## Summary

Aligns single-record `delete` with `select`'s absent-record handling.

Previously, deleting an **absent** `RecordID` returned `[]`, which was inconsistent with `select(RecordID)` (which returns `dict[str, Value] | None`). Now:

- `delete(RecordID)` and `delete("table:id")` return `dict[str, Value] | None` — the deleted record, or `None` when no record was deleted (the server returns an empty result).
- `delete(Table)` / bare table name still returns `list[Value]`.

## Implementation

- The single-record `DELETE` path in the CRUD builder's `_extract` now reuses the same unwrap semantics `select` uses: an empty result unwraps to `None`, a one-element result to the deleted record dict. Other single-record CRUD operations (`create` / `update` / `upsert`) keep their existing one-element unwrap unchanged.
- Updated the `delete` `@overload` sets so a `RecordID` target resolves to `dict[str, Value] | None` on both templates, all four connections (async/blocking x ws/http), and the session/transaction wrapper classes.
- Async and sync stay in parity: `await db.delete(record_id)` and eager `db.delete(record_id)` both yield `dict | None`.

## Tests

- Added absent-record delete tests (`RecordID` and `"table:id"` forms) asserting `None`, across sync and async, following the existing select-test patterns. They self-skip when no server is reachable.
- Refreshed the `assert_type` guards in `test_connection_typing.py` for `delete(RecordID)`.

## Verification

- `ruff check` / `ruff format`: clean on edited files.
- `mypy --explicit-package-bases src/`: pass. `pyright src/`: pass. `mypy --explicit-package-bases tests/`: pass.
- `pytest` (delete, select, v3_api, typing, and the full non-embedded connections suite) run against a local server: all pass, no regressions.