### PR TITLE
Fix session/txn test-probe so tests run against a real server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `delete(RecordID)` now returns `dict | None` (the deleted record, or `None` when absent), matching `select`; `delete(Table)` still returns a list.
 
+### Fixed
+- `new_session()` now propagates the connection's authentication to the new session, so session-scoped operations run with the connection's identity. Previously a freshly attached session was unauthenticated and its writes silently no-opped (the server returned an empty result with no error). `authenticate()` also records the connection's token so it can be replayed.
+
 ## [3.0.0-alpha.2] - 2026-07-16
 
 Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch of issues found in review.

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -167,6 +167,10 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             kwargs["session"] = session_id
         message = RequestMessage(RequestMethod.AUTHENTICATE, **kwargs)
         await self._send(message, "authenticating")
+        # Record the token as the connection identity so new_session() can
+        # replay it — only when authenticating the connection, not a sub-session.
+        if session_id is None:
+            self.token = token
 
     async def invalidate(self, session_id: UUID | None = None) -> None:
         kwargs: dict[str, Any] = {}

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -749,6 +749,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
 
     async def new_session(self) -> "AsyncSurrealSession":
         session_id = await self.attach()
+        # A freshly attached session starts unauthenticated on the server -
+        # it does not inherit the socket's auth automatically. Replay the
+        # connection's current token so the new session shares the same
+        # identity, matching the documented usage where you sign in once on
+        # the connection and then open sessions from it. Callers can still
+        # sign in / invalidate on the session to change its identity.
+        if self.token is not None:
+            await self.authenticate(self.token, session_id=session_id)
         return AsyncSurrealSession(self, session_id)
 
     async def close(self) -> None:

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -137,6 +137,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         message = RequestMessage(RequestMethod.AUTHENTICATE, **kwargs)
         self.id = message.id
         self._send(message, "authenticating")
+        # Record the token as the connection identity so new_session() can
+        # replay it — only when authenticating the connection, not a sub-session.
+        if session_id is None:
+            self.token = token
 
     def invalidate(self, session_id: UUID | None = None) -> None:
         kwargs: dict[str, Any] = {}

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -840,6 +840,14 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
 
     def new_session(self) -> "BlockingSurrealSession":
         session_id = self.attach()
+        # A freshly attached session starts unauthenticated on the server -
+        # it does not inherit the socket's auth automatically. Replay the
+        # connection's current token so the new session shares the same
+        # identity, matching the documented usage where you sign in once on
+        # the connection and then open sessions from it. Callers can still
+        # sign in / invalidate on the session to change its identity.
+        if self.token is not None:
+            self.authenticate(self.token, session_id=session_id)
         return BlockingSurrealSession(self, session_id)
 
     def close(self) -> None:

--- a/tests/unit_tests/connections/session_txn/conftest.py
+++ b/tests/unit_tests/connections/session_txn/conftest.py
@@ -57,9 +57,13 @@ def session_txn_requires_v3(
             "DEFINE TABLE session_txn_probe SCHEMALESS;"
         ).execute()
         try:
-            # Mirror what the actual tests do - no signin on the session.
+            # The session inherits the connection's root auth (see
+            # new_session), so - like the actual tests - it does not sign in
+            # again. ``.first()`` returns the first statement's rows (a list of
+            # record dicts); ``.execute()`` would wrap that in an outer
+            # per-statement list, so the row check below would never see a dict.
             session.create("session_txn_probe:check", {"probe": True})
-            result = session.query("SELECT * FROM session_txn_probe;").execute()
+            result = session.query("SELECT * FROM session_txn_probe;").first()
         except Exception as exc:  # noqa: BLE001 - capture for skip decision
             probe_error = exc
     finally:

--- a/tests/unit_tests/connections/session_txn/test_transaction_blocking_ws.py
+++ b/tests/unit_tests/connections/session_txn/test_transaction_blocking_ws.py
@@ -10,10 +10,10 @@ from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 def setup_table(
     blocking_ws_connection: BlockingWsSurrealConnection,
 ) -> Generator[None, None, None]:
-    blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_test;")
-    blocking_ws_connection.query("DEFINE TABLE session_txn_test SCHEMALESS;")
+    blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_test;").execute()
+    blocking_ws_connection.query("DEFINE TABLE session_txn_test SCHEMALESS;").execute()
     yield
-    blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_test;")
+    blocking_ws_connection.query("REMOVE TABLE IF EXISTS session_txn_test;").execute()
 
 
 def test_transaction_commit(


### PR DESCRIPTION
## Summary

The multi-session and client-side transaction integration tests
(`tests/unit_tests/connections/session_txn/`) self-skipped **even against a
real SurrealDB 3.x server**, including the v3 leg in CI (which runs
`surreal start --allow-all -u root -p root`). The autouse probe in
`conftest.py` concluded "session-scoped create/query returned empty" and
skipped, so the tests gave zero coverage. I reproduced this locally against a
real `surreal` v3.0.0 server and traced it to two independent bugs.

## Root causes

1. **A freshly attached session was unauthenticated.** Signing in on the
   connection authenticates the socket's default session only; a session
   opened with `new_session()`/`attach()` starts with no auth on the server
   and does **not** inherit the socket's root identity. Session-scoped writes
   then silently returned an empty result (no error raised), so the probe saw
   nothing persisted and skipped. This also means the documented usage in the
   README (sign in on the connection, then open a session and create records)
   silently failed to persist for real users.

   Fix: `new_session()` on both WebSocket connections now replays the
   connection's current token onto the new session via `authenticate(...)`, so
   the session shares the connection's identity. Callers can still sign in /
   invalidate on a session to change it.

2. **The probe's skip guard inspected the wrong nesting level.**
   `query().execute()` returns one entry per statement (a list of per-statement
   row lists), so iterating the result yielded lists, never record dicts, and
   the `any(r.get("probe") ...)` guard was always false - the probe would have
   skipped on a legitimate non-empty result too. The probe now uses `.first()`,
   which returns the first statement's rows directly.

Additionally, the blocking transaction tests' `setup_table` fixture built its
`REMOVE`/`DEFINE TABLE` statements but never called `.execute()`, so the table
was never created (the async and blocking-session fixtures already execute
theirs). Fixed so those tests exercise the intended table.

## Validation

Ran against a real `surreal` v3.0.0 server started exactly as CI does
(`start --allow-all -u root -p root`), over both `SURREALDB_URL=ws://` and
`http://`:

- All **14** session/txn tests now RUN and PASS (previously 14 skipped).
- They still self-skip cleanly when no server is reachable.
- Broader connection suite: 312 passed, 1 xfailed - no regressions from the
  `new_session` change.
- `ruff`, `mypy` (src + tests), `pyright` all clean.

No session/txn assertions were changed.