### PR TITLE
Add into= row-model mapping to select/CRUD/query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Keyword-only `into=` argument on `select`, `create`, `update`, `upsert`, `delete`, and `insert` (async and sync, including the session/transaction wrappers) mapping each returned record onto a model class — a dataclass, a pydantic `BaseModel`, or any class accepting the record's fields as keyword arguments. Return types are narrowed precisely per `@overload`: a single-record target resolves to `Model` (or `Model | None`), a `Table` target to `list[Model]`. The no-data builder forms (`create(record, into=Model)`, `update(record, into=Model)`, `insert(table, into=Model)`) carry the model through their clause methods (`.content` / `.merge` / … / `.execute`). Mapping reuses the existing `_map_to_class` helper.
+- `query(sql).into(Model, rows=True)` maps each **row** of a single statement's result onto `Model`, returning `list[Model]`. The default `.into(cls)` (statements-to-fields) behaviour is unchanged when `rows` is not set.
+
 ### Changed
 - `delete(RecordID)` now returns `dict | None` (the deleted record, or `None` when absent), matching `select`; `delete(Table)` still returns a list.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,51 @@ row = await db.select(RecordID("person", "tobie"))  # dict | None
 rows = await db.select(Table("person"))             # list
 ```
 
+### Mapping rows to a model (`into=`)
+
+Pass the keyword-only `into=` argument to map each returned record onto a model
+class - a dataclass, a pydantic `BaseModel`, or any class whose constructor
+accepts the record's fields as keyword arguments. The return type is narrowed
+precisely per overload: a single-record target resolves to `Model` (or
+`Model | None`), a table target to `list[Model]`.
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Person:
+    id: RecordID
+    name: str
+
+# select: single record -> Person | None, table -> list[Person]
+person = await db.select(RecordID("person", "tobie"), into=Person)  # Person | None
+people = await db.select(Table("person"), into=Person)              # list[Person]
+
+# create / update / upsert / delete map the written record(s) too
+created = await db.create(RecordID("person", "tobie"), {"name": "Tobie"}, into=Person)
+updated = await db.update(Table("person"), {"active": True}, into=Person)  # list[Person]
+
+# insert maps the inserted records
+inserted = await db.insert(Table("person"), [{"name": "A"}], into=Person)  # list[Person]
+
+# the no-data builder form carries the model through its clause methods
+p = await db.create(RecordID("person", "jaime"), into=Person).merge({"name": "Jaime"})
+
+# map each ROW of a single query statement with into(Model, rows=True)
+rows = await db.query("SELECT * FROM person").into(Person, rows=True)  # list[Person]
+```
+
+Sync connections take the same `into=` argument and run eagerly:
+
+```python
+person = db.select(RecordID("person", "tobie"), into=Person)  # Person | None
+created = db.create(RecordID("person", "tobie"), {"name": "Tobie"}, into=Person)
+rows = db.query("SELECT * FROM person").into(Person, rows=True)  # list[Person]
+```
+
+Omitting `into=` leaves the raw `dict` / `list[Value]` results completely
+unchanged.
+
 Sync usage is **eager** - there is no `await` to defer to, so the
 connection methods run single-shot operations immediately and return the
 plain result. A builder is only handed back for the deferred no-data form
@@ -286,6 +331,13 @@ result = await db.query(
     "SELECT * FROM person;"
     "SELECT count() FROM person GROUP ALL"
 ).into(Stats)
+```
+
+Or map each **row** of a single statement's result onto a model with
+`.into(Model, rows=True)`, which returns `list[Model]`:
+
+```python
+people = await db.query("SELECT * FROM person").into(Person, rows=True)  # list[Person]
 ```
 
 For the raw server response (status, time, error per statement), keep

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -9,6 +9,8 @@ from surrealdb.connections.builders import (
     AsyncCrudBuilder,
     AsyncInsertBuilder,
     AsyncQueryBuilder,
+    M,
+    _map_result,
 )
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
@@ -218,6 +220,10 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
 
     @overload
     def create(
+        self, record: RecordIdType, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def create(
         self, record: RecordID, data: Value | None = None
     ) -> AsyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -229,14 +235,19 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[dict[str, Value]]: ...
     def create(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Create a record; returns an awaitable builder.
 
         ``await db.create(record, data)`` is sugar for
         ``await db.create(record).content(data)``. Clause methods
         (``.content`` / ``.replace`` / ``.merge`` / ``.patch``) return the
-        builder so it stays awaitable.
+        builder so it stays awaitable. Pass ``into=Model`` to map the created
+        record onto ``Model``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
@@ -245,8 +256,21 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
             op_name="create",
             data=data,
             always_unwrap=True,
+            into=into,
         )
 
+    @overload
+    def update(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def update(
         self, record: RecordID, data: Value | None = None
@@ -260,12 +284,17 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[Value]: ...
     def update(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Update records; returns an awaitable builder.
 
         Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
-        ``.patch`` return the builder so it stays awaitable.
+        ``.patch`` return the builder so it stays awaitable. Pass ``into=Model``
+        to map the returned record(s) onto ``Model`` / ``list[Model]``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
@@ -273,8 +302,21 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
             record=record,
             op_name="update",
             data=data,
+            into=into,
         )
 
+    @overload
+    def upsert(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def upsert(
         self, record: RecordID, data: Value | None = None
@@ -288,12 +330,17 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[Value]: ...
     def upsert(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Insert or update records; returns an awaitable builder.
 
         Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
-        ``.patch`` return the builder so it stays awaitable.
+        ``.patch`` return the builder so it stays awaitable. Pass ``into=Model``
+        to map the returned record(s) onto ``Model`` / ``list[Model]``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
@@ -301,46 +348,76 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
             record=record,
             op_name="upsert",
             data=data,
+            into=into,
         )
 
+    @overload
+    def delete(
+        self, record: RecordID, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | None]: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def delete(
+        self, record: str, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M] | None]: ...
     @overload
     def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
     def delete(self, record: str) -> AsyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
+    def delete(
+        self, record: RecordIdType, *, into: type[M] | None = None
+    ) -> AsyncCrudBuilder[Any]:
         """Delete records; returns an awaitable builder.
 
         A ``RecordID`` (or ``"table:id"``) resolves to the deleted record, or
         ``None`` when no record was deleted (matching select); a ``Table`` (or
         bare name) to the list of deleted records. ``DELETE`` has no clause
-        methods.
+        methods. Pass ``into=Model`` to map the deleted record(s) onto ``Model``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(),
             operation="DELETE",
             record=record,
             op_name="delete",
+            into=into,
         )
 
+    @overload
+    def insert(
+        self, table: str | Table, data: Value | None = None, *, relation: bool = False
+    ) -> AsyncInsertBuilder[Value]: ...
+    @overload
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
+        into: type[M],
         relation: bool = False,
-    ) -> AsyncInsertBuilder:
+    ) -> AsyncInsertBuilder[M]: ...
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
+        relation: bool = False,
+    ) -> AsyncInsertBuilder[Any]:
         """Insert record(s) or relation(s); returns an awaitable builder.
 
         Pass ``relation=True`` (or chain ``.relation()``) for ``INSERT
-        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it.
+        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it. Pass
+        ``into=Model`` to map the inserted records onto ``list[Model]``.
         """
         return AsyncInsertBuilder(
             executor=self._make_executor(),
             table=table,
             data=data,
             relation=relation,
+            into=into,
         )
 
     async def run(
@@ -367,17 +444,23 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.vars.pop(key)
 
     @overload
+    async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    async def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    async def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     async def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     async def select(self, record: Table) -> list[Value]: ...
     @overload
     async def select(self, record: str) -> Value: ...
-    async def select(self, record: RecordIdType) -> Value:
+    async def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Select records.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
-        list of records.
+        list of records. Pass ``into=Model`` to map each record onto ``Model``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -391,9 +474,14 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         # result list to the record dict, or None when the record is absent.
         if self._is_single_record_operation(record):
             if isinstance(result, list):
-                return result[0] if result else None
-            return result
-        return result
+                value: Any = result[0] if result else None
+            else:
+                value = result
+        else:
+            value = result
+        if into is not None:
+            return _map_result(into, value)
+        return value
 
     async def version(self) -> str:
         message = RequestMessage(RequestMethod.VERSION)

--- a/src/surrealdb/connections/async_template.py
+++ b/src/surrealdb/connections/async_template.py
@@ -6,6 +6,7 @@ from surrealdb.connections.builders import (
     AsyncCrudBuilder,
     AsyncInsertBuilder,
     AsyncQueryBuilder,
+    M,
 )
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
@@ -124,7 +125,9 @@ class AsyncTemplate:
 
         Use ``.first()`` for the first statement's result, or ``.into(MyResult)``
         to map the N statement results positionally onto a dataclass or any
-        class accepting keyword arguments.
+        class accepting keyword arguments. ``.into(Model, rows=True)`` instead
+        maps each ROW of the single statement result onto ``Model``, returning
+        ``list[Model]``.
 
         Args:
             query: SurrealQL statement(s).
@@ -135,27 +138,43 @@ class AsyncTemplate:
             first = await db.query('SELECT * FROM person').first()
             many = await db.query('SELECT * FROM person; SELECT count() FROM person GROUP ALL')
             mapped = await db.query('CREATE ...; SELECT ...').into(MyResult)
+            people = await db.query('SELECT * FROM person').into(Person, rows=True)
         """
         raise NotImplementedError(f"query not implemented for: {self}")
 
+    @overload
+    async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    async def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    async def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
     @overload
     async def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     async def select(self, record: Table) -> list[Value]: ...
     @overload
     async def select(self, record: str) -> Value: ...
-    async def select(self, record: RecordIdType) -> Value:
+    async def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Select all records in a table or a specific record.
 
         A ``RecordID`` (or ``"table:id"`` string) returns the record dict, or
         ``None`` when it is absent. A ``Table`` (or bare table-name string)
         returns the list of records.
 
+        Pass ``into=Model`` to map each record onto a model class (dataclass,
+        pydantic ``BaseModel``, or any kwargs-constructible class): a single
+        record resolves to ``Model | None``, a table to ``list[Model]``.
+
         Args:
             record: The table or record ID to select.
+            into: Optional model class to map the selected record(s) onto.
         """
         raise NotImplementedError(f"select not implemented for: {self}")
 
+    @overload
+    def create(
+        self, record: RecordIdType, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
     @overload
     def create(
         self, record: RecordID, data: Value | None = None
@@ -169,7 +188,11 @@ class AsyncTemplate:
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[dict[str, Value]]: ...
     def create(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Create a record.
 
@@ -181,15 +204,30 @@ class AsyncTemplate:
         - ``.patch(data)``    -> ``CREATE ... PATCH $data``
 
         ``db.create(record, data)`` is sugar for ``db.create(record).content(data)``.
+        Pass ``into=Model`` to map the created record onto ``Model`` (the
+        builder and its clause methods then resolve to ``Model``).
 
         Example:
             await db.create(RecordID('person', 'tobie'), {'name': 'Tobie'})
             await db.create(RecordID('person', 'tobie')).merge({'name': 'Tobie'})
+            await db.create(RecordID('person', 'tobie'), data, into=Person)
         """
         raise NotImplementedError(f"create not implemented for: {self}")
 
     @overload
     def update(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(
         self, record: RecordID, data: Value | None = None
     ) -> AsyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -201,15 +239,33 @@ class AsyncTemplate:
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[Value]: ...
     def update(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Update records (replacing the existing data by default).
 
         Returns an awaitable builder. Optional clause methods:
         ``.content(data)``, ``.replace(data)``, ``.merge(data)``, ``.patch(data)``.
+        Pass ``into=Model`` to map the returned record(s) onto ``Model`` (a
+        ``RecordID`` target resolves to ``Model``, a ``Table`` to ``list[Model]``).
         """
         raise NotImplementedError(f"update not implemented for: {self}")
 
+    @overload
+    def upsert(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def upsert(
         self, record: RecordID, data: Value | None = None
@@ -223,28 +279,47 @@ class AsyncTemplate:
         self, record: str, data: Value | None = None
     ) -> AsyncCrudBuilder[Value]: ...
     def upsert(
-        self, record: RecordIdType, data: Value | None = None
+        self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Insert or update records.
 
         Returns an awaitable builder. Optional clause methods:
         ``.content(data)``, ``.replace(data)``, ``.merge(data)``, ``.patch(data)``.
+        Pass ``into=Model`` to map the returned record(s) onto ``Model`` (a
+        ``RecordID`` target resolves to ``Model``, a ``Table`` to ``list[Model]``).
         """
         raise NotImplementedError(f"upsert not implemented for: {self}")
 
+    @overload
+    def delete(
+        self, record: RecordID, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | None]: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def delete(
+        self, record: str, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M] | None]: ...
     @overload
     def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
     def delete(self, record: str) -> AsyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
+    def delete(
+        self, record: RecordIdType, *, into: type[M] | None = None
+    ) -> AsyncCrudBuilder[Any]:
         """Delete records.
 
         Returns an awaitable builder. A ``RecordID`` (or ``"table:id"``)
         resolves to the deleted record, or ``None`` when no record was
         deleted (matching select); a ``Table`` (or bare name) resolves to the
         list of deleted records. ``DELETE`` does not support clause methods.
+        Pass ``into=Model`` to map the deleted record(s) onto ``Model``.
         """
         raise NotImplementedError(f"delete not implemented for: {self}")
 
@@ -252,22 +327,38 @@ class AsyncTemplate:
         """Return the record of the authenticated record user."""
         raise NotImplementedError(f"info not implemented for: {self}")
 
+    @overload
+    def insert(
+        self, table: str | Table, data: Value | None = None, *, relation: bool = False
+    ) -> AsyncInsertBuilder[Value]: ...
+    @overload
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
+        into: type[M],
         relation: bool = False,
-    ) -> AsyncInsertBuilder:
+    ) -> AsyncInsertBuilder[M]: ...
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
+        relation: bool = False,
+    ) -> AsyncInsertBuilder[Any]:
         """Insert one or multiple records (or relations) into a table.
 
         Pass ``relation=True`` to issue ``INSERT RELATION INTO``, or chain
-        ``.relation()`` on the returned builder.
+        ``.relation()`` on the returned builder. Pass ``into=Model`` to map the
+        inserted records onto ``list[Model]``.
 
         Example:
             await db.insert(Table('person'), [{...}, {...}])
             await db.insert(Table('likes'), {...}, relation=True)
             await db.insert(Table('likes')).relation().content({...})
+            await db.insert(Table('person'), [{...}], into=Person)
         """
         raise NotImplementedError(f"insert not implemented for: {self}")
 

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -18,6 +18,8 @@ from surrealdb.connections.builders import (
     AsyncCrudBuilder,
     AsyncInsertBuilder,
     AsyncQueryBuilder,
+    M,
+    _map_result,
 )
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
@@ -325,6 +327,33 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | None: ...
+    @overload
+    async def select(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
+    @overload
+    async def select(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | list[M] | None: ...
+    @overload
+    async def select(
+        self,
+        record: RecordID,
+        *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> dict[str, Value] | None: ...
@@ -348,14 +377,15 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> Value:
+    ) -> Any:
         """Select records.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
-        list of records.
+        list of records. Pass ``into=Model`` to map each record onto ``Model``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -371,9 +401,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         # result list to the record dict, or None when the record is absent.
         if self._is_single_record_operation(record):
             if isinstance(result, list):
-                return result[0] if result else None
-            return result
-        return result
+                value: Any = result[0] if result else None
+            else:
+                value = result
+        else:
+            value = result
+        if into is not None:
+            return _map_result(into, value)
+        return value
 
     def _make_executor(
         self,
@@ -394,6 +429,16 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     @overload
     def create(
         self,
+        record: RecordIdType,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def create(
+        self,
         record: RecordID,
         data: Value | None = None,
         *,
@@ -423,6 +468,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value | None = None,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
@@ -431,7 +477,8 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         ``await db.create(record, data)`` is sugar for
         ``await db.create(record).content(data)``. Clause methods
         (``.content`` / ``.replace`` / ``.merge`` / ``.patch``) return the
-        builder so it stays awaitable.
+        builder so it stays awaitable. Pass ``into=Model`` to map the created
+        record onto ``Model``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
@@ -440,8 +487,39 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             op_name="create",
             data=data,
             always_unwrap=True,
+            into=into,
         )
 
+    @overload
+    def update(
+        self,
+        record: RecordID,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self,
+        record: Table,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self,
+        record: str,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def update(
         self,
@@ -474,13 +552,15 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value | None = None,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Update records; returns an awaitable builder.
 
         Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
-        ``.patch`` return the builder so it stays awaitable.
+        ``.patch`` return the builder so it stays awaitable. Pass ``into=Model``
+        to map the returned record(s) onto ``Model`` / ``list[Model]``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
@@ -488,8 +568,39 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             record=record,
             op_name="update",
             data=data,
+            into=into,
         )
 
+    @overload
+    def upsert(
+        self,
+        record: RecordID,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self,
+        record: Table,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self,
+        record: str,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def upsert(
         self,
@@ -522,13 +633,15 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value | None = None,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
         """Insert or update records; returns an awaitable builder.
 
         Optional clause methods ``.content`` / ``.replace`` / ``.merge`` /
-        ``.patch`` return the builder so it stays awaitable.
+        ``.patch`` return the builder so it stays awaitable. Pass ``into=Model``
+        to map the returned record(s) onto ``Model`` / ``list[Model]``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
@@ -536,8 +649,36 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             record=record,
             op_name="upsert",
             data=data,
+            into=into,
         )
 
+    @overload
+    def delete(
+        self,
+        record: RecordID,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M | None]: ...
+    @overload
+    def delete(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def delete(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncCrudBuilder[M | list[M] | None]: ...
     @overload
     def delete(
         self,
@@ -566,6 +707,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> AsyncCrudBuilder[Any]:
@@ -574,15 +716,17 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         A ``RecordID`` (or ``"table:id"``) resolves to the deleted record, or
         ``None`` when no record was deleted (matching select); a ``Table`` (or
         bare name) to the list of deleted records. ``DELETE`` has no clause
-        methods.
+        methods. Pass ``into=Model`` to map the deleted record(s) onto ``Model``.
         """
         return AsyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="DELETE",
             record=record,
             op_name="delete",
+            into=into,
         )
 
+    @overload
     def insert(
         self,
         table: str | Table,
@@ -591,17 +735,40 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         relation: bool = False,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> AsyncInsertBuilder:
+    ) -> AsyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M],
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncInsertBuilder[M]: ...
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> AsyncInsertBuilder[Any]:
         """Insert record(s) or relation(s); returns an awaitable builder.
 
         Pass ``relation=True`` (or chain ``.relation()``) for ``INSERT
-        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it.
+        RELATION INTO``. Awaiting the builder (or ``.execute()``) runs it. Pass
+        ``into=Model`` to map the inserted records onto ``list[Model]``.
         """
         return AsyncInsertBuilder(
             executor=self._make_executor(session_id, txn_id),
             table=table,
             data=data,
             relation=relation,
+            into=into,
         )
 
     async def run(
@@ -852,14 +1019,28 @@ class AsyncSurrealSession:
         await self._connection.unset(key, session_id=self._session_id)
 
     @overload
+    async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    async def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    async def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     async def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     async def select(self, record: Table) -> list[Value]: ...
     @overload
     async def select(self, record: str) -> Value: ...
-    async def select(self, record: RecordIdType) -> Value:
-        return await self._connection.select(record, session_id=self._session_id)
+    async def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return await self._connection.select(record, session_id=self._session_id)
+        return await self._connection.select(
+            record, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def create(
+        self, record: RecordIdType, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
     @overload
     def create(
         self, record: RecordID, data: Value | None = None
@@ -876,9 +1057,27 @@ class AsyncSurrealSession:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
-        return self._connection.create(record, data, session_id=self._session_id)
+        if into is None:
+            return self._connection.create(record, data, session_id=self._session_id)
+        return self._connection.create(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def update(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def update(
         self, record: RecordID, data: Value | None = None
@@ -895,9 +1094,27 @@ class AsyncSurrealSession:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
-        return self._connection.update(record, data, session_id=self._session_id)
+        if into is None:
+            return self._connection.update(record, data, session_id=self._session_id)
+        return self._connection.update(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def upsert(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def upsert(
         self, record: RecordID, data: Value | None = None
@@ -914,27 +1131,65 @@ class AsyncSurrealSession:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
-        return self._connection.upsert(record, data, session_id=self._session_id)
+        if into is None:
+            return self._connection.upsert(record, data, session_id=self._session_id)
+        return self._connection.upsert(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def delete(
+        self, record: RecordID, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | None]: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def delete(
+        self, record: str, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M] | None]: ...
     @overload
     def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
     def delete(self, record: str) -> AsyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
-        return self._connection.delete(record, session_id=self._session_id)
+    def delete(
+        self, record: RecordIdType, *, into: type[M] | None = None
+    ) -> AsyncCrudBuilder[Any]:
+        if into is None:
+            return self._connection.delete(record, session_id=self._session_id)
+        return self._connection.delete(record, into=into, session_id=self._session_id)
 
+    @overload
+    def insert(
+        self, table: str | Table, data: Value | None = None, *, relation: bool = False
+    ) -> AsyncInsertBuilder[Value]: ...
+    @overload
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
+        into: type[M],
         relation: bool = False,
-    ) -> AsyncInsertBuilder:
+    ) -> AsyncInsertBuilder[M]: ...
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
+        relation: bool = False,
+    ) -> AsyncInsertBuilder[Any]:
+        if into is None:
+            return self._connection.insert(
+                table, data, relation=relation, session_id=self._session_id
+            )
         return self._connection.insert(
-            table, data, relation=relation, session_id=self._session_id
+            table, data, into=into, relation=relation, session_id=self._session_id
         )
 
     async def run(
@@ -989,18 +1244,30 @@ class AsyncSurrealTransaction:
         )
 
     @overload
+    async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    async def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    async def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     async def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     async def select(self, record: Table) -> list[Value]: ...
     @overload
     async def select(self, record: str) -> Value: ...
-    async def select(self, record: RecordIdType) -> Value:
+    async def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return await self._connection.select(
+                record, session_id=self._session_id, txn_id=self._txn_id
+            )
         return await self._connection.select(
-            record,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def create(
+        self, record: RecordIdType, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
     @overload
     def create(
         self, record: RecordID, data: Value | None = None
@@ -1017,14 +1284,29 @@ class AsyncSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        if into is None:
+            return self._connection.create(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.create(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def update(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def update(
         self, record: RecordID, data: Value | None = None
@@ -1041,14 +1323,29 @@ class AsyncSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        if into is None:
+            return self._connection.update(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.update(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def upsert(
+        self, record: RecordID, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self, record: Table, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self, record: str, data: Value | None = None, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M]]: ...
     @overload
     def upsert(
         self, record: RecordID, data: Value | None = None
@@ -1065,37 +1362,77 @@ class AsyncSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value | None = None,
+        *,
+        into: type[M] | None = None,
     ) -> AsyncCrudBuilder[Any]:
+        if into is None:
+            return self._connection.upsert(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.upsert(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def delete(
+        self, record: RecordID, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | None]: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> AsyncCrudBuilder[list[M]]: ...
+    @overload
+    def delete(
+        self, record: str, *, into: type[M]
+    ) -> AsyncCrudBuilder[M | list[M] | None]: ...
     @overload
     def delete(self, record: RecordID) -> AsyncCrudBuilder[dict[str, Value] | None]: ...
     @overload
     def delete(self, record: Table) -> AsyncCrudBuilder[list[Value]]: ...
     @overload
     def delete(self, record: str) -> AsyncCrudBuilder[Value]: ...
-    def delete(self, record: RecordIdType) -> AsyncCrudBuilder[Any]:
+    def delete(
+        self, record: RecordIdType, *, into: type[M] | None = None
+    ) -> AsyncCrudBuilder[Any]:
+        if into is None:
+            return self._connection.delete(
+                record, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.delete(
-            record,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def insert(
+        self, table: str | Table, data: Value | None = None, *, relation: bool = False
+    ) -> AsyncInsertBuilder[Value]: ...
+    @overload
     def insert(
         self,
         table: str | Table,
         data: Value | None = None,
         *,
+        into: type[M],
         relation: bool = False,
-    ) -> AsyncInsertBuilder:
+    ) -> AsyncInsertBuilder[M]: ...
+    def insert(
+        self,
+        table: str | Table,
+        data: Value | None = None,
+        *,
+        into: type[M] | None = None,
+        relation: bool = False,
+    ) -> AsyncInsertBuilder[Any]:
+        if into is None:
+            return self._connection.insert(
+                table,
+                data,
+                relation=relation,
+                session_id=self._session_id,
+                txn_id=self._txn_id,
+            )
         return self._connection.insert(
             table,
             data,
+            into=into,
             relation=relation,
             session_id=self._session_id,
             txn_id=self._txn_id,

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -6,9 +6,11 @@ import requests
 
 from surrealdb.connections.builders import (
     _UNSET,
+    M,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
+    _map_result,
 )
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
@@ -174,12 +176,16 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     # the no-data form returns a builder so the caller can pick a clause.
 
     @overload
+    def create(self, record: RecordIdType, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value, *, into: type[M]) -> M: ...
+    @overload
     def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
     def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Create a record (eager).
 
         ``db.create(record, data)`` runs ``CREATE ... CONTENT $data``
@@ -187,18 +193,32 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         ``CONTENT NULL``). ``db.create(record)`` (no data) returns a
         :class:`SyncCrudBuilder` so the caller can pick a terminal clause
         (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` / ``.execute``).
+        Pass ``into=Model`` to map the created record onto ``Model``.
         """
-        builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="CREATE",
             record=record,
             op_name="create",
             always_unwrap=True,
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
+    @overload
+    def update(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def update(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def update(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def update(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -212,24 +232,39 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def update(self, record: str, data: Value) -> Value: ...
     def update(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[Any] | Value:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Update records, replacing existing content by default (eager).
 
         ``db.update(record, data)`` runs eagerly and returns the result
         (``data=None`` runs ``CONTENT NULL``); the no-data form returns a
-        :class:`SyncCrudBuilder` with terminal clause methods.
+        :class:`SyncCrudBuilder` with terminal clause methods. Pass
+        ``into=Model`` to map the returned record(s) onto ``Model`` /
+        ``list[Model]``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPDATE",
             record=record,
             op_name="update",
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
+    @overload
+    def upsert(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def upsert(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def upsert(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def upsert(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -243,72 +278,94 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     @overload
     def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[Any] | Value:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Insert or update records (eager).
 
         ``db.upsert(record, data)`` runs eagerly and returns the result
         (``data=None`` runs ``CONTENT NULL``); the no-data form returns a
-        :class:`SyncCrudBuilder` with terminal clause methods.
+        :class:`SyncCrudBuilder` with terminal clause methods. Pass
+        ``into=Model`` to map the returned record(s) onto ``Model`` /
+        ``list[Model]``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="UPSERT",
             record=record,
             op_name="upsert",
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
     @overload
+    def delete(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def delete(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
     def delete(self, record: str) -> Value: ...
-    def delete(self, record: RecordIdType) -> Value:
+    def delete(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Delete records eagerly and return the deleted record(s).
 
         A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
         ``None`` when no record was deleted (matching select); a ``Table`` (or
-        bare name) returns the list of deleted records.
+        bare name) returns the list of deleted records. Pass ``into=Model`` to
+        map the deleted record(s) onto ``Model``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(),
             operation="DELETE",
             record=record,
             op_name="delete",
+            into=into,
         )
-        return cast(Value, builder.execute())
+        return builder.execute()
 
     @overload
     def insert(
         self, table: str | Table, *, relation: bool = False
-    ) -> SyncInsertBuilder: ...
+    ) -> SyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, *, into: type[M], relation: bool = False
+    ) -> SyncInsertBuilder[M]: ...
     @overload
     def insert(
         self, table: str | Table, data: Value, *, relation: bool = False
     ) -> list[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, into: type[M], relation: bool = False
+    ) -> list[M]: ...
     def insert(
         self,
         table: str | Table,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         relation: bool = False,
-    ) -> SyncInsertBuilder | list[Value]:
+    ) -> Any:
         """Insert record(s) or relation(s) into a table (eager).
 
         ``db.insert(table, data)`` runs immediately and returns the inserted
         records. ``db.insert(table)`` (no data) returns a
         :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
         ``.relation()``) for ``INSERT RELATION INTO`` and run it with
-        ``.content(data)`` / ``.execute()``.
+        ``.content(data)`` / ``.execute()``. Pass ``into=Model`` to map the
+        inserted records onto ``list[Model]``.
         """
-        builder = SyncInsertBuilder(
+        builder: SyncInsertBuilder[Any] = SyncInsertBuilder(
             executor=self._make_executor(),
             table=table,
             relation=relation,
+            into=into,
         )
         if data is _UNSET:
             return builder
@@ -338,17 +395,23 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.vars.pop(key)
 
     @overload
+    def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def select(self, record: Table) -> list[Value]: ...
     @overload
     def select(self, record: str) -> Value: ...
-    def select(self, record: RecordIdType) -> Value:
+    def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Select records eagerly.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
-        list of records.
+        list of records. Pass ``into=Model`` to map each record onto ``Model``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -362,9 +425,14 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         # result list to the record dict, or None when the record is absent.
         if self._is_single_record_operation(record):
             if isinstance(result, list):
-                return result[0] if result else None
-            return result
-        return result
+                value: Any = result[0] if result else None
+            else:
+                value = result
+        else:
+            value = result
+        if into is not None:
+            return _map_result(into, value)
+        return value
 
     def version(self) -> str:
         message = RequestMessage(RequestMethod.VERSION)

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -8,7 +8,7 @@ import threading
 import uuid
 from collections.abc import Generator
 from types import TracebackType
-from typing import Any, cast, overload
+from typing import Any, overload
 from uuid import UUID
 
 import websockets
@@ -18,9 +18,11 @@ from websockets.sync.client import ClientConnection
 
 from surrealdb.connections.builders import (
     _UNSET,
+    M,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
+    _map_result,
 )
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
@@ -298,6 +300,33 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | None: ...
+    @overload
+    def select(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
+    @overload
+    def select(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | list[M] | None: ...
+    @overload
+    def select(
+        self,
+        record: RecordID,
+        *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> dict[str, Value] | None: ...
@@ -321,14 +350,15 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> Value:
+    ) -> Any:
         """Select records eagerly.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
-        list of records.
+        list of records. Pass ``into=Model`` to map each record onto ``Model``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
@@ -344,9 +374,14 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         # result list to the record dict, or None when the record is absent.
         if self._is_single_record_operation(record):
             if isinstance(result, list):
-                return result[0] if result else None
-            return result
-        return result
+                value: Any = result[0] if result else None
+            else:
+                value = result
+        else:
+            value = result
+        if into is not None:
+            return _map_result(into, value)
+        return value
 
     def _make_executor(
         self,
@@ -372,6 +407,25 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[M]: ...
+    @overload
+    def create(
+        self,
+        record: RecordIdType,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M: ...
+    @overload
+    def create(
+        self,
+        record: RecordIdType,
+        *,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> SyncCrudBuilder[dict[str, Value]]: ...
@@ -389,9 +443,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+    ) -> Any:
         """Create a record (eager).
 
         ``db.create(record, data)`` runs ``CREATE ... CONTENT $data``
@@ -399,18 +454,77 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         ``CONTENT NULL``). ``db.create(record)`` (no data) returns a
         :class:`SyncCrudBuilder` so the caller can pick a terminal clause
         (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` / ``.execute``).
+        Pass ``into=Model`` to map the created record onto ``Model``.
         """
-        builder: SyncCrudBuilder[dict[str, Value]] = SyncCrudBuilder(
+        builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="CREATE",
             record=record,
             op_name="create",
             always_unwrap=True,
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
+    @overload
+    def update(
+        self,
+        record: RecordID,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[M]: ...
+    @overload
+    def update(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(
+        self,
+        record: RecordID,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M: ...
+    @overload
+    def update(
+        self,
+        record: Table,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
+    @overload
+    def update(
+        self,
+        record: str,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | list[M]: ...
     @overload
     def update(
         self,
@@ -467,26 +581,87 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any] | Value:
+    ) -> Any:
         """Update records, replacing existing content by default (eager).
 
         ``db.update(record, data)`` runs ``UPDATE ... CONTENT $data``
         immediately and returns the result (``data=None`` runs ``CONTENT
         NULL``). ``db.update(record)`` (no data) returns a
-        :class:`SyncCrudBuilder` with terminal clause methods.
+        :class:`SyncCrudBuilder` with terminal clause methods. Pass
+        ``into=Model`` to map the returned record(s) onto ``Model`` /
+        ``list[Model]``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPDATE",
             record=record,
             op_name="update",
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
+    @overload
+    def upsert(
+        self,
+        record: RecordID,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[M]: ...
+    @overload
+    def upsert(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def upsert(
+        self,
+        record: RecordID,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M: ...
+    @overload
+    def upsert(
+        self,
+        record: Table,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
+    @overload
+    def upsert(
+        self,
+        record: str,
+        data: Value,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | list[M]: ...
     @overload
     def upsert(
         self,
@@ -543,26 +718,57 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         record: RecordIdType,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncCrudBuilder[Any] | Value:
+    ) -> Any:
         """Insert or update records (eager).
 
         ``db.upsert(record, data)`` runs ``UPSERT ... CONTENT $data``
         immediately and returns the result (``data=None`` runs ``CONTENT
         NULL``). ``db.upsert(record)`` (no data) returns a
-        :class:`SyncCrudBuilder` with terminal clause methods.
+        :class:`SyncCrudBuilder` with terminal clause methods. Pass
+        ``into=Model`` to map the returned record(s) onto ``Model`` /
+        ``list[Model]``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="UPSERT",
             record=record,
             op_name="upsert",
+            into=into,
         )
         if data is _UNSET:
             return builder
         return builder.content(data)
 
+    @overload
+    def delete(
+        self,
+        record: RecordID,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | None: ...
+    @overload
+    def delete(
+        self,
+        record: Table,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
+    @overload
+    def delete(
+        self,
+        record: str,
+        *,
+        into: type[M],
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> M | list[M] | None: ...
     @overload
     def delete(
         self,
@@ -591,22 +797,25 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> Value:
+    ) -> Any:
         """Delete records eagerly and return the deleted record(s).
 
         A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
         ``None`` when no record was deleted (matching select); a ``Table`` (or
-        bare name) returns the list of deleted records.
+        bare name) returns the list of deleted records. Pass ``into=Model`` to
+        map the deleted record(s) onto ``Model``.
         """
         builder: SyncCrudBuilder[Any] = SyncCrudBuilder(
             executor=self._make_executor(session_id, txn_id),
             operation="DELETE",
             record=record,
             op_name="delete",
+            into=into,
         )
-        return cast(Value, builder.execute())
+        return builder.execute()
 
     @overload
     def insert(
@@ -616,7 +825,17 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         relation: bool = False,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncInsertBuilder: ...
+    ) -> SyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self,
+        table: str | Table,
+        *,
+        into: type[M],
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> SyncInsertBuilder[M]: ...
     @overload
     def insert(
         self,
@@ -627,27 +846,41 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> list[Value]: ...
+    @overload
+    def insert(
+        self,
+        table: str | Table,
+        data: Value,
+        *,
+        into: type[M],
+        relation: bool = False,
+        session_id: UUID | None = None,
+        txn_id: UUID | None = None,
+    ) -> list[M]: ...
     def insert(
         self,
         table: str | Table,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         relation: bool = False,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
-    ) -> SyncInsertBuilder | list[Value]:
+    ) -> Any:
         """Insert record(s) or relation(s) into a table (eager).
 
         ``db.insert(table, data)`` runs immediately and returns the inserted
         records. ``db.insert(table)`` (no data) returns a
         :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
         ``.relation()``) for ``INSERT RELATION INTO`` and run it with
-        ``.content(data)`` / ``.execute()``.
+        ``.content(data)`` / ``.execute()``. Pass ``into=Model`` to map the
+        inserted records onto ``list[Model]``.
         """
-        builder = SyncInsertBuilder(
+        builder: SyncInsertBuilder[Any] = SyncInsertBuilder(
             executor=self._make_executor(session_id, txn_id),
             table=table,
             relation=relation,
+            into=into,
         )
         if data is _UNSET:
             return builder
@@ -921,14 +1154,26 @@ class BlockingSurrealSession:
         self._connection.unset(key, session_id=self._session_id)
 
     @overload
+    def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def select(self, record: Table) -> list[Value]: ...
     @overload
     def select(self, record: str) -> Value: ...
-    def select(self, record: RecordIdType) -> Value:
-        return self._connection.select(record, session_id=self._session_id)
+    def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return self._connection.select(record, session_id=self._session_id)
+        return self._connection.select(record, into=into, session_id=self._session_id)
 
+    @overload
+    def create(self, record: RecordIdType, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value, *, into: type[M]) -> M: ...
     @overload
     def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -937,9 +1182,27 @@ class BlockingSurrealSession:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
-        return self._connection.create(record, data, session_id=self._session_id)
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.create(record, data, session_id=self._session_id)
+        return self._connection.create(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def update(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def update(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def update(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def update(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -956,9 +1219,27 @@ class BlockingSurrealSession:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[Any] | Value:
-        return self._connection.update(record, data, session_id=self._session_id)
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.update(record, data, session_id=self._session_id)
+        return self._connection.update(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def upsert(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def upsert(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def upsert(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def upsert(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -975,35 +1256,62 @@ class BlockingSurrealSession:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[Any] | Value:
-        return self._connection.upsert(record, data, session_id=self._session_id)
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.upsert(record, data, session_id=self._session_id)
+        return self._connection.upsert(
+            record, data, into=into, session_id=self._session_id
+        )
 
+    @overload
+    def delete(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def delete(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
     @overload
     def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
     def delete(self, record: str) -> Value: ...
-    def delete(self, record: RecordIdType) -> Value:
-        return self._connection.delete(record, session_id=self._session_id)
+    def delete(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return self._connection.delete(record, session_id=self._session_id)
+        return self._connection.delete(record, into=into, session_id=self._session_id)
 
     @overload
     def insert(
         self, table: str | Table, *, relation: bool = False
-    ) -> SyncInsertBuilder: ...
+    ) -> SyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, *, into: type[M], relation: bool = False
+    ) -> SyncInsertBuilder[M]: ...
     @overload
     def insert(
         self, table: str | Table, data: Value, *, relation: bool = False
     ) -> list[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, into: type[M], relation: bool = False
+    ) -> list[M]: ...
     def insert(
         self,
         table: str | Table,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         relation: bool = False,
-    ) -> SyncInsertBuilder | list[Value]:
+    ) -> Any:
+        if into is None:
+            return self._connection.insert(
+                table, data, relation=relation, session_id=self._session_id
+            )
         return self._connection.insert(
-            table, data, relation=relation, session_id=self._session_id
+            table, data, into=into, relation=relation, session_id=self._session_id
         )
 
     def run(
@@ -1056,18 +1364,30 @@ class BlockingSurrealTransaction:
         )
 
     @overload
+    def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    @overload
     def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def select(self, record: Table) -> list[Value]: ...
     @overload
     def select(self, record: str) -> Value: ...
-    def select(self, record: RecordIdType) -> Value:
+    def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return self._connection.select(
+                record, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.select(
-            record,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def create(self, record: RecordIdType, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value, *, into: type[M]) -> M: ...
     @overload
     def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -1076,14 +1396,29 @@ class BlockingSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.create(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.create(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def update(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def update(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def update(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def update(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -1100,14 +1435,29 @@ class BlockingSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[Any] | Value:
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.update(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.update(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def upsert(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def upsert(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def upsert(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def upsert(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -1124,45 +1474,74 @@ class BlockingSurrealTransaction:
         self,
         record: RecordIdType,
         data: Value = _UNSET,
-    ) -> SyncCrudBuilder[Any] | Value:
+        *,
+        into: type[M] | None = None,
+    ) -> Any:
+        if into is None:
+            return self._connection.upsert(
+                record, data, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.upsert(
-            record,
-            data,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, data, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
+    @overload
+    def delete(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def delete(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
     @overload
     def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
     def delete(self, record: str) -> Value: ...
-    def delete(self, record: RecordIdType) -> Value:
+    def delete(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+        if into is None:
+            return self._connection.delete(
+                record, session_id=self._session_id, txn_id=self._txn_id
+            )
         return self._connection.delete(
-            record,
-            session_id=self._session_id,
-            txn_id=self._txn_id,
+            record, into=into, session_id=self._session_id, txn_id=self._txn_id
         )
 
     @overload
     def insert(
         self, table: str | Table, *, relation: bool = False
-    ) -> SyncInsertBuilder: ...
+    ) -> SyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, *, into: type[M], relation: bool = False
+    ) -> SyncInsertBuilder[M]: ...
     @overload
     def insert(
         self, table: str | Table, data: Value, *, relation: bool = False
     ) -> list[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, into: type[M], relation: bool = False
+    ) -> list[M]: ...
     def insert(
         self,
         table: str | Table,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         relation: bool = False,
-    ) -> SyncInsertBuilder | list[Value]:
+    ) -> Any:
+        if into is None:
+            return self._connection.insert(
+                table,
+                data,
+                relation=relation,
+                session_id=self._session_id,
+                txn_id=self._txn_id,
+            )
         return self._connection.insert(
             table,
             data,
+            into=into,
             relation=relation,
             session_id=self._session_id,
             txn_id=self._txn_id,

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -41,6 +41,8 @@ Both :class:`AsyncQueryBuilder` and :class:`SyncQueryBuilder` return
 (fixes the historic silent-discard behaviour, GH issue #232). Use
 ``.first()`` to pull the first statement's result, or ``.into(cls)`` to map
 the N statement results positionally onto a dataclass / class.
+``.into(cls, rows=True)`` instead maps each ROW of the single statement
+result onto ``cls`` and returns ``list[cls]``.
 
 Safety
 ------
@@ -56,9 +58,9 @@ import asyncio
 import inspect
 import re
 import threading
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Generator, Mapping
 from dataclasses import fields, is_dataclass
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 from surrealdb.data.types.record_id import RecordID, RecordIdType, escape_identifier
 from surrealdb.data.types.table import Table
@@ -72,6 +74,17 @@ from surrealdb.types import Value
 
 T = TypeVar("T")
 U = TypeVar("U")
+# Covariant output type for ``AsyncQueryIntoBuilder`` - ``T_co`` only ever
+# appears in return position (``execute`` / ``__await__``), so covariance is
+# sound and lets the ``.into(..., rows=...)`` overloads (whose returns are
+# ``Builder[U]`` vs ``Builder[U | list[U]]``) type-check without overlap
+# conflicts (an invariant generic would reject the narrowing).
+T_co = TypeVar("T_co", covariant=True)
+# Row-model type variable for the ``into=`` mapping surface. ``M`` binds the
+# user's model class so ``select``/``create``/``query().into(..., rows=True)``
+# return precisely typed model instances (``M`` / ``list[M]`` / ``M | None``)
+# rather than the raw ``dict`` / ``list[Value]`` shapes.
+M = TypeVar("M")
 
 AsyncExecutor = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
 SyncExecutor = Callable[[str, dict[str, Any]], dict[str, Any]]
@@ -255,6 +268,7 @@ class _CrudState:
         record: RecordIdType,
         op_name: str,
         always_unwrap: bool,
+        into: type[Any] | None = None,
     ) -> None:
         self._operation = operation
         self._record = record
@@ -263,6 +277,10 @@ class _CrudState:
         self._single = always_unwrap or _is_single_record_operation(record)
         self._mode: str = _Clause.DEFAULT
         self._data: Value | None = None
+        # Optional row-model class. When set, the extracted result is mapped
+        # through ``_map_result`` (which delegates to ``_map_to_class``) before
+        # being returned, so ``into=Model`` yields ``Model`` / ``list[Model]``.
+        self._into: type[Any] | None = into
 
     def _check_not_executed(self) -> None:
         """Raise if this builder has already been executed.
@@ -327,6 +345,7 @@ class _InsertState:
         table: str | Table,
         data: Value | None,
         relation: bool,
+        into: type[Any] | None = None,
     ) -> None:
         if isinstance(table, RecordID):
             raise SurrealError(
@@ -336,6 +355,9 @@ class _InsertState:
         self._table = table
         self._data = data
         self._relation = relation
+        # Optional row-model class; when set the inserted records are mapped
+        # element-wise through ``_map_to_class`` into ``list[into]``.
+        self._into: type[Any] | None = into
 
     def _check_not_executed(self) -> None:
         """Subclasses override to consult their own execution state."""
@@ -392,8 +414,25 @@ class _QueryState:
         return [stmt.get("result") for stmt in stmts]
 
 
-def _map_to_class(cls: type[T], values: list[Any]) -> T:
-    """Map the N statement results positionally onto the fields of ``cls``."""
+def _map_to_class(cls: type[T], values: list[Any] | Mapping[str, Any]) -> T:
+    """Construct ``cls`` from statement results or a single record row.
+
+    Two calling conventions share this one kwargs-construction helper:
+
+    - A ``Mapping`` (a single record dict, as produced by ``select`` /
+      ``create`` / ``query().into(cls, rows=True)`` with ``into=``) is expanded
+      straight into keyword arguments - ``cls(**row)``. This covers
+      dataclasses, pydantic ``BaseModel``, and any class whose constructor
+      accepts the record's fields as keywords.
+    - A ``list`` (the N statement results from ``query().into(cls)``) is mapped
+      positionally onto the fields / constructor parameters of ``cls`` - the
+      historic ``into(cls)`` behaviour, unchanged.
+    """
+    if isinstance(values, Mapping):
+        # Row -> model: the record's keys are the constructor kwargs. Works
+        # uniformly for dataclasses, pydantic models, and plain classes.
+        return cls(**values)
+
     if is_dataclass(cls):
         field_list = list(fields(cls))
         if len(field_list) != len(values):
@@ -427,6 +466,52 @@ def _map_to_class(cls: type[T], values: list[Any]) -> T:
         )
     kwargs = {name: value for name, value in zip(param_names, values, strict=True)}
     return cls(**kwargs)
+
+
+def _statement_rows(values: list[Any]) -> list[Any]:
+    """Return the rows of the first statement result for row-mapping.
+
+    ``query(sql).into(cls, rows=True)`` maps each ROW of a single statement's
+    result. The query builder yields one entry per statement, so row-mapping
+    uses the first statement's result (the common single-``SELECT`` case):
+
+    - a ``list`` result is returned as-is (its elements are the rows),
+    - a scalar / single record is wrapped as a one-row list,
+    - ``None`` (or no statements at all) yields ``[]``.
+    """
+    if not values:
+        return []
+    first = values[0]
+    if isinstance(first, list):
+        return first
+    if first is None:
+        return []
+    return [first]
+
+
+def _map_result(into: type[Any] | None, result: Any) -> Any:
+    """Map an extracted ``select`` / CRUD result onto ``into`` by runtime shape.
+
+    ``into`` is a model class (dataclass, pydantic ``BaseModel``, or any
+    kwargs-constructible class). Mapping follows the shape the operation
+    already produced so the static ``@overload`` return type and the runtime
+    value stay in lock-step:
+
+    - a ``list`` maps element-wise to ``list[into]`` (``Table`` targets),
+    - ``None`` stays ``None`` (an absent single record),
+    - anything else (a record dict) maps to a single ``into`` instance.
+
+    Construction goes through :func:`_map_to_class`, the shared kwargs mapper -
+    there is deliberately no parallel row mapper. ``into=None`` returns the
+    result untouched, so the no-``into`` path is byte-for-byte unchanged.
+    """
+    if into is None:
+        return result
+    if isinstance(result, list):
+        return [_map_to_class(into, row) for row in result]
+    if result is None:
+        return None
+    return _map_to_class(into, result)
 
 
 # ---------------------------------------------------------------------------
@@ -531,8 +616,9 @@ class AsyncCrudBuilder(_CrudState, Generic[T]):
         op_name: str,
         data: Value | None = None,
         always_unwrap: bool = False,
+        into: type[Any] | None = None,
     ) -> None:
-        super().__init__(operation, record, op_name, always_unwrap)
+        super().__init__(operation, record, op_name, always_unwrap, into)
         self._executor = executor
         self._runner = _AsyncCachedRunner()
         if data is not None:
@@ -572,7 +658,7 @@ class AsyncCrudBuilder(_CrudState, Generic[T]):
     async def _do_execute(self) -> T:
         query, variables = self._build()
         response = await self._executor(query, variables)
-        return cast(T, self._extract(response))
+        return cast(T, _map_result(self._into, self._extract(response)))
 
     async def execute(self) -> T:
         return cast(T, await self._runner.run(self._do_execute))
@@ -581,7 +667,7 @@ class AsyncCrudBuilder(_CrudState, Generic[T]):
         return self.execute().__await__()
 
 
-class AsyncInsertBuilder(_InsertState):
+class AsyncInsertBuilder(_InsertState, Generic[T]):
     """Awaitable INSERT builder for async connections (idempotent).
 
     Re-configuring the builder *after* it has executed raises rather than
@@ -594,8 +680,9 @@ class AsyncInsertBuilder(_InsertState):
         table: str | Table,
         data: Value | None = None,
         relation: bool = False,
+        into: type[Any] | None = None,
     ) -> None:
-        super().__init__(table, data, relation)
+        super().__init__(table, data, relation, into)
         self._executor = executor
         self._runner = _AsyncCachedRunner()
 
@@ -613,25 +700,25 @@ class AsyncInsertBuilder(_InsertState):
                 "executed. Create a new builder for a fresh operation."
             )
 
-    def relation(self) -> AsyncInsertBuilder:
+    def relation(self) -> AsyncInsertBuilder[T]:
         self._check_not_executed()
         self._relation = True
         return self
 
-    def content(self, data: Value) -> AsyncInsertBuilder:
+    def content(self, data: Value) -> AsyncInsertBuilder[T]:
         self._check_not_executed()
         self._data = data
         return self
 
-    async def _do_execute(self) -> list[Value]:
+    async def _do_execute(self) -> list[T]:
         query, variables = self._build()
         response = await self._executor(query, variables)
-        return cast(list[Value], self._extract(response))
+        return cast(list[T], _map_result(self._into, self._extract(response)))
 
-    async def execute(self) -> list[Value]:
-        return cast(list[Value], await self._runner.run(self._do_execute))
+    async def execute(self) -> list[T]:
+        return cast(list[T], await self._runner.run(self._do_execute))
 
-    def __await__(self) -> Generator[Any, None, list[Value]]:
+    def __await__(self) -> Generator[Any, None, list[T]]:
         return self.execute().__await__()
 
 
@@ -663,11 +750,32 @@ class AsyncQueryBuilder(_QueryState):
 
         return cast(list[Any], await self._runner.run(_do))
 
-    def into(self, cls: type[U]) -> AsyncQueryIntoBuilder[U]:
-        # Hand the into-builder a reference to *self* so it reuses the
-        # already-fetched (or about-to-be-fetched) values rather than
-        # issuing a second RPC.
-        return AsyncQueryIntoBuilder(self, cls)
+    @overload
+    def into(self, cls: type[U]) -> AsyncQueryIntoBuilder[U]: ...
+    @overload
+    def into(
+        self, cls: type[U], *, rows: Literal[True]
+    ) -> AsyncQueryIntoBuilder[list[U]]: ...
+    @overload
+    def into(
+        self, cls: type[U], *, rows: Literal[False]
+    ) -> AsyncQueryIntoBuilder[U]: ...
+    @overload
+    def into(
+        self, cls: type[U], *, rows: bool
+    ) -> AsyncQueryIntoBuilder[U | list[U]]: ...
+    def into(self, cls: type[U], *, rows: bool = False) -> AsyncQueryIntoBuilder[Any]:
+        """Map the query result onto ``cls``.
+
+        Default (``rows`` unset): map the N statement results positionally onto
+        the fields / constructor parameters of ``cls`` (awaiting yields one
+        ``cls``). ``rows=True``: map each ROW of the single statement result to
+        ``cls`` (awaiting yields ``list[cls]``).
+
+        Either way the into-builder reuses *self*'s cached fetch rather than
+        issuing a second RPC.
+        """
+        return AsyncQueryIntoBuilder(self, cls, rows=rows)
 
     async def execute(self) -> list[Value]:
         return cast("list[Value]", await self._fetch_values())
@@ -683,23 +791,32 @@ class AsyncQueryBuilder(_QueryState):
         return self.execute().__await__()
 
 
-class AsyncQueryIntoBuilder(Generic[T]):
+class AsyncQueryIntoBuilder(Generic[T_co]):
     """Async query builder that maps results onto a user-supplied class.
 
     Reuses the parent :class:`AsyncQueryBuilder`'s cached fetch so that
     ``await q`` and ``await q.into(T)`` together still only round-trip
-    once.
+    once. ``T_co`` is the *output* type: ``U`` for the default statements-to-
+    fields mapping, ``list[U]`` when created with ``rows=True``.
     """
 
-    def __init__(self, parent: AsyncQueryBuilder, cls: type[T]) -> None:
+    def __init__(
+        self, parent: AsyncQueryBuilder, cls: type[Any], rows: bool = False
+    ) -> None:
         self._parent = parent
         self._cls = cls
+        self._rows = rows
 
-    async def execute(self) -> T:
+    async def execute(self) -> T_co:
         values = await self._parent._fetch_values()  # pyright: ignore[reportPrivateUsage]
-        return _map_to_class(self._cls, values)
+        if self._rows:
+            return cast(
+                "T_co",
+                [_map_to_class(self._cls, row) for row in _statement_rows(values)],
+            )
+        return cast("T_co", _map_to_class(self._cls, values))
 
-    def __await__(self) -> Generator[Any, None, T]:
+    def __await__(self) -> Generator[Any, None, T_co]:
         return self.execute().__await__()
 
 
@@ -743,8 +860,9 @@ class SyncCrudBuilder(_CrudState, Generic[T]):
         op_name: str,
         data: Value | None = None,
         always_unwrap: bool = False,
+        into: type[Any] | None = None,
     ) -> None:
-        super().__init__(operation, record, op_name, always_unwrap)
+        super().__init__(operation, record, op_name, always_unwrap, into)
         self._executor = executor
         self._executed = False
         self._cached_result: Any = None
@@ -784,12 +902,12 @@ class SyncCrudBuilder(_CrudState, Generic[T]):
             if not self._executed:
                 query, variables = self._build()
                 response = self._executor(query, variables)
-                self._cached_result = self._extract(response)
+                self._cached_result = _map_result(self._into, self._extract(response))
                 self._executed = True
             return self._cached_result
 
 
-class SyncInsertBuilder(_InsertState):
+class SyncInsertBuilder(_InsertState, Generic[T]):
     """Eager INSERT builder for sync connections.
 
     Handed back only for the deferred no-data form (``db.insert(table)``).
@@ -806,8 +924,9 @@ class SyncInsertBuilder(_InsertState):
         table: str | Table,
         data: Value | None = None,
         relation: bool = False,
+        into: type[Any] | None = None,
     ) -> None:
-        super().__init__(table, data, relation)
+        super().__init__(table, data, relation, into)
         self._executor = executor
         self._executed = False
         self._cached_result: Any = None
@@ -820,25 +939,25 @@ class SyncInsertBuilder(_InsertState):
                 "executed. Create a new builder for a fresh operation."
             )
 
-    def relation(self) -> SyncInsertBuilder:
+    def relation(self) -> SyncInsertBuilder[T]:
         self._check_not_executed()
         self._relation = True
         return self
 
-    def content(self, data: Value) -> list[Value]:
+    def content(self, data: Value) -> list[T]:
         self._check_not_executed()
         self._data = data
-        return cast(list[Value], self._run_once())
+        return cast(list[T], self._run_once())
 
-    def execute(self) -> list[Value]:
-        return cast(list[Value], self._run_once())
+    def execute(self) -> list[T]:
+        return cast(list[T], self._run_once())
 
     def _run_once(self) -> Any:
         with self._lock:
             if not self._executed:
                 query, variables = self._build()
                 response = self._executor(query, variables)
-                self._cached_result = self._extract(response)
+                self._cached_result = _map_result(self._into, self._extract(response))
                 self._executed = True
             return self._cached_result
 
@@ -872,10 +991,28 @@ class SyncQueryBuilder(_QueryState):
         self._cached_values: list[Any] | None = None
         self._lock = threading.Lock()
 
-    def into(self, cls: type[T]) -> T:
-        # Reuse this builder's cached fetch so `.execute()` plus `.into(T)`
-        # on the same instance only issue one RPC.
+    @overload
+    def into(self, cls: type[T]) -> T: ...
+    @overload
+    def into(self, cls: type[T], *, rows: Literal[True]) -> list[T]: ...
+    @overload
+    def into(self, cls: type[T], *, rows: Literal[False]) -> T: ...
+    @overload
+    def into(self, cls: type[T], *, rows: bool) -> T | list[T]: ...
+    def into(self, cls: type[T], *, rows: bool = False) -> Any:
+        """Map the query result onto ``cls``.
+
+        Default (``rows`` unset): map the N statement results positionally onto
+        the fields / constructor parameters of ``cls`` (returns one ``cls``).
+        ``rows=True``: map each ROW of the single statement result to ``cls``
+        (returns ``list[cls]``).
+
+        Reuses this builder's cached fetch so ``.execute()`` plus ``.into(T)``
+        on the same instance only issue one RPC.
+        """
         values = self._run_once()
+        if rows:
+            return [_map_to_class(cls, row) for row in _statement_rows(values)]
         return _map_to_class(cls, values)
 
     def execute(self) -> list[Value]:
@@ -903,8 +1040,10 @@ __all__ = [
     "AsyncInsertBuilder",
     "AsyncQueryBuilder",
     "AsyncQueryIntoBuilder",
+    "M",
     "SyncCrudBuilder",
     "SyncInsertBuilder",
     "SyncQueryBuilder",
     "_UNSET",
+    "_map_result",
 ]

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -489,6 +489,22 @@ def _statement_rows(values: list[Any]) -> list[Any]:
     return [first]
 
 
+def _require_record(into: type[Any], row: Any) -> Mapping[str, Any]:
+    """Ensure a value mapped via ``into=`` is a record object (mapping).
+
+    Raises a clear error rather than letting a non-record value fall through
+    to the positional ``_map_to_class`` path (which would raise an opaque
+    ``TypeError``). Reachable only via a malformed response or a ``SELECT
+    VALUE`` scalar projection through ``.into(cls, rows=True)``.
+    """
+    if not isinstance(row, Mapping):
+        raise UnexpectedResponseError(
+            f"into={into.__name__} expects record (object) rows; "
+            f"got {type(row).__name__}: {row!r}"
+        )
+    return row
+
+
 def _map_result(into: type[Any] | None, result: Any) -> Any:
     """Map an extracted ``select`` / CRUD result onto ``into`` by runtime shape.
 
@@ -508,10 +524,10 @@ def _map_result(into: type[Any] | None, result: Any) -> Any:
     if into is None:
         return result
     if isinstance(result, list):
-        return [_map_to_class(into, row) for row in result]
+        return [_map_to_class(into, _require_record(into, row)) for row in result]
     if result is None:
         return None
-    return _map_to_class(into, result)
+    return _map_to_class(into, _require_record(into, result))
 
 
 # ---------------------------------------------------------------------------
@@ -812,7 +828,10 @@ class AsyncQueryIntoBuilder(Generic[T_co]):
         if self._rows:
             return cast(
                 "T_co",
-                [_map_to_class(self._cls, row) for row in _statement_rows(values)],
+                [
+                    _map_to_class(self._cls, _require_record(self._cls, row))
+                    for row in _statement_rows(values)
+                ],
             )
         return cast("T_co", _map_to_class(self._cls, values))
 
@@ -1012,7 +1031,10 @@ class SyncQueryBuilder(_QueryState):
         """
         values = self._run_once()
         if rows:
-            return [_map_to_class(cls, row) for row in _statement_rows(values)]
+            return [
+                _map_to_class(cls, _require_record(cls, row))
+                for row in _statement_rows(values)
+            ]
         return _map_to_class(cls, values)
 
     def execute(self) -> list[Value]:

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from surrealdb.connections.builders import (
     _UNSET,
+    M,
     SyncCrudBuilder,
     SyncInsertBuilder,
     SyncQueryBuilder,
@@ -61,31 +62,47 @@ class SyncTemplate:
           statements).
         - ``.into(MyResult)`` maps the N statement results positionally onto a
           dataclass or any class accepting keyword arguments.
+        - ``.into(Model, rows=True)`` maps each ROW of the single statement
+          result onto ``Model``, returning ``list[Model]``.
         """
         raise NotImplementedError(f"query not implemented for: {self}")
 
+    @overload
+    def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
     @overload
     def select(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def select(self, record: Table) -> list[Value]: ...
     @overload
     def select(self, record: str) -> Value: ...
-    def select(self, record: RecordIdType) -> Value:
+    def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Select all records in a table or a specific record.
 
         A ``RecordID`` (or ``"table:id"`` string) returns the record dict, or
         ``None`` when it is absent. A ``Table`` (or bare table-name string)
         returns the list of records.
+
+        Pass ``into=Model`` to map each record onto a model class (dataclass,
+        pydantic ``BaseModel``, or any kwargs-constructible class): a single
+        record resolves to ``Model | None``, a table to ``list[Model]``.
         """
         raise NotImplementedError(f"select not implemented for: {self}")
 
+    @overload
+    def create(self, record: RecordIdType, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def create(self, record: RecordIdType, data: Value, *, into: type[M]) -> M: ...
     @overload
     def create(self, record: RecordIdType) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
     def create(self, record: RecordIdType, data: Value) -> dict[str, Value]: ...
     def create(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[dict[str, Value]] | dict[str, Value]:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Create a record.
 
         ``db.create(record, data)`` runs ``CREATE ... CONTENT $data`` eagerly
@@ -98,9 +115,24 @@ class SyncTemplate:
         - ``.merge(data)``    -> ``CREATE ... MERGE $data``
         - ``.patch(data)``    -> ``CREATE ... PATCH $data``
         - ``.execute()``      -> ``CREATE ...`` (no clause)
+
+        Pass ``into=Model`` to map the created record onto ``Model`` (the eager
+        form returns ``Model``; the builder form's clause methods return ``Model``).
         """
         raise NotImplementedError(f"create not implemented for: {self}")
 
+    @overload
+    def update(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def update(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def update(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def update(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def update(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def update(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def update(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -114,17 +146,31 @@ class SyncTemplate:
     @overload
     def update(self, record: str, data: Value) -> Value: ...
     def update(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[Any] | Value:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Update records (replacing the existing data by default).
 
         ``db.update(record, data)`` runs eagerly and returns the result; the
         no-data form returns a :class:`SyncCrudBuilder` with terminal clause
         methods (``.content`` / ``.replace`` / ``.merge`` / ``.patch`` /
-        ``.execute``).
+        ``.execute``). Pass ``into=Model`` to map the returned record(s) onto
+        ``Model`` (a ``RecordID`` target resolves to ``Model``, a ``Table`` to
+        ``list[Model]``).
         """
         raise NotImplementedError(f"update not implemented for: {self}")
 
+    @overload
+    def upsert(self, record: RecordID, *, into: type[M]) -> SyncCrudBuilder[M]: ...
+    @overload
+    def upsert(self, record: Table, *, into: type[M]) -> SyncCrudBuilder[list[M]]: ...
+    @overload
+    def upsert(self, record: str, *, into: type[M]) -> SyncCrudBuilder[M | list[M]]: ...
+    @overload
+    def upsert(self, record: RecordID, data: Value, *, into: type[M]) -> M: ...
+    @overload
+    def upsert(self, record: Table, data: Value, *, into: type[M]) -> list[M]: ...
+    @overload
+    def upsert(self, record: str, data: Value, *, into: type[M]) -> M | list[M]: ...
     @overload
     def upsert(self, record: RecordID) -> SyncCrudBuilder[dict[str, Value]]: ...
     @overload
@@ -138,28 +184,37 @@ class SyncTemplate:
     @overload
     def upsert(self, record: str, data: Value) -> Value: ...
     def upsert(
-        self, record: RecordIdType, data: Value = _UNSET
-    ) -> SyncCrudBuilder[Any] | Value:
+        self, record: RecordIdType, data: Value = _UNSET, *, into: type[M] | None = None
+    ) -> Any:
         """Insert or update records.
 
         ``db.upsert(record, data)`` runs eagerly and returns the result; the
         no-data form returns a :class:`SyncCrudBuilder` with terminal clause
-        methods.
+        methods. Pass ``into=Model`` to map the returned record(s) onto
+        ``Model`` (a ``RecordID`` target resolves to ``Model``, a ``Table`` to
+        ``list[Model]``).
         """
         raise NotImplementedError(f"upsert not implemented for: {self}")
 
+    @overload
+    def delete(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    @overload
+    def delete(self, record: Table, *, into: type[M]) -> list[M]: ...
+    @overload
+    def delete(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
     @overload
     def delete(self, record: RecordID) -> dict[str, Value] | None: ...
     @overload
     def delete(self, record: Table) -> list[Value]: ...
     @overload
     def delete(self, record: str) -> Value: ...
-    def delete(self, record: RecordIdType) -> Value:
+    def delete(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
         """Delete records eagerly and return the deleted record(s).
 
         A ``RecordID`` (or ``"table:id"``) returns the deleted record, or
         ``None`` when no record was deleted (matching select); a ``Table``
-        (or bare name) returns the list of deleted records.
+        (or bare name) returns the list of deleted records. Pass ``into=Model``
+        to map the deleted record(s) onto ``Model``.
         """
         raise NotImplementedError(f"delete not implemented for: {self}")
 
@@ -170,25 +225,35 @@ class SyncTemplate:
     @overload
     def insert(
         self, table: str | Table, *, relation: bool = False
-    ) -> SyncInsertBuilder: ...
+    ) -> SyncInsertBuilder[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, *, into: type[M], relation: bool = False
+    ) -> SyncInsertBuilder[M]: ...
     @overload
     def insert(
         self, table: str | Table, data: Value, *, relation: bool = False
     ) -> list[Value]: ...
+    @overload
+    def insert(
+        self, table: str | Table, data: Value, *, into: type[M], relation: bool = False
+    ) -> list[M]: ...
     def insert(
         self,
         table: str | Table,
         data: Value = _UNSET,
         *,
+        into: type[M] | None = None,
         relation: bool = False,
-    ) -> SyncInsertBuilder | list[Value]:
+    ) -> Any:
         """Insert one or multiple records (or relations) into a table.
 
         ``db.insert(table, data)`` runs eagerly and returns the inserted
         records. ``db.insert(table)`` (no data) returns a
         :class:`SyncInsertBuilder`; pass ``relation=True`` (or chain
         ``.relation()``) for ``INSERT RELATION INTO`` and run it with
-        ``.content(data)`` / ``.execute()``.
+        ``.content(data)`` / ``.execute()``. Pass ``into=Model`` to map the
+        inserted records onto ``list[Model]``.
         """
         raise NotImplementedError(f"insert not implemented for: {self}")
 

--- a/tests/unit_tests/connections/v3_api/test_into_row_model.py
+++ b/tests/unit_tests/connections/v3_api/test_into_row_model.py
@@ -1,0 +1,227 @@
+"""End-to-end tests for the ``into=`` row-model API against a live server.
+
+These use the connection fixtures, so they self-skip when no SurrealDB server
+is reachable (see ``tests/unit_tests/connections/conftest.py``). They prove the
+required round-trips for both the async and sync WebSocket connections:
+
+- ``select(RecordID, into=M) -> M`` / ``select(absent, into=M) -> None``
+- ``select(Table, into=M) -> list[M]``
+- ``create``/``update`` round-trip with ``into=M`` -> ``M``
+- ``query(sql).into(M, rows=True) -> list[M]``
+"""
+
+from collections.abc import AsyncGenerator, Generator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+
+
+@dataclass
+class Person:
+    id: Any
+    name: str
+
+
+@pytest.fixture(autouse=True)
+async def _async_setup(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> AsyncGenerator[None, None]:
+    await async_ws_connection.query("DELETE person;")
+    yield
+    await async_ws_connection.query("DELETE person;")
+
+
+@pytest.fixture(autouse=True)
+def _sync_setup(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> Generator[None, None, None]:
+    blocking_ws_connection.query("DELETE person;").execute()
+    yield
+    blocking_ws_connection.query("DELETE person;").execute()
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_select_record_id_into(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    await async_ws_connection.query("CREATE person:tobie SET name = 'Tobie';")
+    out = await async_ws_connection.select(RecordID("person", "tobie"), into=Person)
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+@pytest.mark.asyncio
+async def test_async_select_absent_into(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    out = await async_ws_connection.select(RecordID("person", "missing"), into=Person)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_async_select_table_into(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    await async_ws_connection.query("CREATE person:tobie SET name = 'Tobie';")
+    await async_ws_connection.query("CREATE person:jaime SET name = 'Jaime';")
+    out = await async_ws_connection.select(Table("person"), into=Person)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert all(isinstance(p, Person) for p in out)
+    assert {p.name for p in out} == {"Tobie", "Jaime"}
+
+
+@pytest.mark.asyncio
+async def test_async_create_into_round_trip(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    out = await async_ws_connection.create(
+        RecordID("person", "tobie"), {"name": "Tobie"}, into=Person
+    )
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+@pytest.mark.asyncio
+async def test_async_update_into_round_trip(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    await async_ws_connection.query("CREATE person:tobie SET name = 'Tobie';")
+    out = await async_ws_connection.update(
+        RecordID("person", "tobie"), {"name": "Updated"}, into=Person
+    )
+    assert isinstance(out, Person)
+    assert out.name == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_async_query_into_rows(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    await async_ws_connection.query("CREATE person:tobie SET name = 'Tobie';")
+    await async_ws_connection.query("CREATE person:jaime SET name = 'Jaime';")
+    out = await async_ws_connection.query("SELECT * FROM person").into(
+        Person, rows=True
+    )
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert all(isinstance(p, Person) for p in out)
+
+
+@pytest.mark.asyncio
+async def test_async_no_data_builder_carries_into(
+    async_ws_connection: AsyncWsSurrealConnection,
+    _async_setup: None,
+    _sync_setup: None,
+) -> None:
+    """The no-data builder form carries M so ``.merge(...)`` returns ``M``."""
+    out = await async_ws_connection.create(
+        RecordID("person", "tobie"), into=Person
+    ).merge({"name": "Tobie"})
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+
+def test_sync_select_record_id_into(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    blocking_ws_connection.query("CREATE person:tobie SET name = 'Tobie';").execute()
+    out = blocking_ws_connection.select(RecordID("person", "tobie"), into=Person)
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_sync_select_absent_into(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    out = blocking_ws_connection.select(RecordID("person", "missing"), into=Person)
+    assert out is None
+
+
+def test_sync_select_table_into(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    blocking_ws_connection.query("CREATE person:tobie SET name = 'Tobie';").execute()
+    blocking_ws_connection.query("CREATE person:jaime SET name = 'Jaime';").execute()
+    out = blocking_ws_connection.select(Table("person"), into=Person)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert all(isinstance(p, Person) for p in out)
+
+
+def test_sync_create_into_round_trip(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    out = blocking_ws_connection.create(
+        RecordID("person", "tobie"), {"name": "Tobie"}, into=Person
+    )
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_sync_update_into_round_trip(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    blocking_ws_connection.query("CREATE person:tobie SET name = 'Tobie';").execute()
+    out = blocking_ws_connection.update(
+        RecordID("person", "tobie"), {"name": "Updated"}, into=Person
+    )
+    assert isinstance(out, Person)
+    assert out.name == "Updated"
+
+
+def test_sync_no_data_builder_carries_into(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    """The no-data (eager) builder form carries M so ``.merge(...)`` returns ``M``."""
+    out = blocking_ws_connection.create(RecordID("person", "tobie"), into=Person).merge(
+        {"name": "Tobie"}
+    )
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_sync_query_into_rows(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    _sync_setup: None,
+) -> None:
+    blocking_ws_connection.query("CREATE person:tobie SET name = 'Tobie';").execute()
+    blocking_ws_connection.query("CREATE person:jaime SET name = 'Jaime';").execute()
+    out = blocking_ws_connection.query("SELECT * FROM person").into(Person, rows=True)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert all(isinstance(p, Person) for p in out)

--- a/tests/unit_tests/test_connection_typing.py
+++ b/tests/unit_tests/test_connection_typing.py
@@ -12,6 +12,7 @@ below (``Any`` does not match the asserted concrete type).
 """
 
 import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -20,20 +21,34 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import assert_type
 
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.async_ws import (
     AsyncSurrealSession,
     AsyncSurrealTransaction,
     AsyncWsSurrealConnection,
 )
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.connections.blocking_ws import (
     BlockingSurrealSession,
     BlockingSurrealTransaction,
     BlockingWsSurrealConnection,
 )
-from surrealdb.connections.builders import AsyncCrudBuilder, SyncCrudBuilder
+from surrealdb.connections.builders import (
+    AsyncCrudBuilder,
+    AsyncInsertBuilder,
+    AsyncQueryIntoBuilder,
+    SyncCrudBuilder,
+    SyncInsertBuilder,
+)
 from surrealdb.data.types.record_id import RecordID
 from surrealdb.data.types.table import Table
 from surrealdb.types import Value
+
+
+@dataclass
+class _Person:
+    id: object
+    name: str
 
 
 def test_async_session_crud_overload_precision() -> None:
@@ -158,3 +173,169 @@ def test_blocking_transaction_crud_overload_precision() -> None:
     assert_type(txn.delete(RecordID("person", 1)), dict[str, Value] | None)
     assert_type(txn.delete(Table("person")), list[Value])
     assert_type(txn.delete("person"), Value)
+
+
+# ---------------------------------------------------------------------------
+# into= row-model overload precision
+# ---------------------------------------------------------------------------
+
+
+async def test_async_connection_into_overload_precision() -> None:
+    if not TYPE_CHECKING:
+        return
+    ws = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    http = AsyncHttpSurrealConnection("http://localhost:8000")
+
+    for conn in (ws, http):
+        # select: single -> M | None, table -> list[M] (async -> awaited).
+        assert_type(
+            await conn.select(RecordID("person", 1), into=_Person), _Person | None
+        )
+        assert_type(await conn.select(Table("person"), into=_Person), list[_Person])
+        assert_type(
+            await conn.select("person", into=_Person), _Person | list[_Person] | None
+        )
+
+        # create is always single -> AsyncCrudBuilder[M].
+        assert_type(
+            conn.create(RecordID("person", 1), into=_Person),
+            AsyncCrudBuilder[_Person],
+        )
+        assert_type(
+            conn.create(RecordID("person", 1), {"name": "x"}, into=_Person),
+            AsyncCrudBuilder[_Person],
+        )
+
+        # update / upsert vary by target.
+        assert_type(
+            conn.update(RecordID("person", 1), into=_Person),
+            AsyncCrudBuilder[_Person],
+        )
+        assert_type(
+            conn.update(Table("person"), into=_Person),
+            AsyncCrudBuilder[list[_Person]],
+        )
+        assert_type(
+            conn.upsert(Table("person"), into=_Person),
+            AsyncCrudBuilder[list[_Person]],
+        )
+
+        # delete single -> M | None, table -> list[M].
+        assert_type(
+            conn.delete(RecordID("person", 1), into=_Person),
+            AsyncCrudBuilder[_Person | None],
+        )
+        assert_type(
+            conn.delete(Table("person"), into=_Person),
+            AsyncCrudBuilder[list[_Person]],
+        )
+
+        # insert always -> AsyncInsertBuilder[M] (awaits to list[M]).
+        assert_type(
+            conn.insert(Table("person"), into=_Person), AsyncInsertBuilder[_Person]
+        )
+        assert_type(conn.insert(Table("person")), AsyncInsertBuilder[Value])
+
+        # query().into(...) row-mapping.
+        q = conn.query("SELECT * FROM person")
+        assert_type(q.into(_Person), AsyncQueryIntoBuilder[_Person])
+        assert_type(q.into(_Person, rows=True), AsyncQueryIntoBuilder[list[_Person]])
+
+
+async def test_async_wrapper_into_overload_precision() -> None:
+    if not TYPE_CHECKING:
+        return
+    conn = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    session = AsyncSurrealSession(conn, uuid4())
+    txn = AsyncSurrealTransaction(conn, uuid4(), uuid4())
+
+    for wrapper in (session, txn):
+        assert_type(
+            await wrapper.select(RecordID("person", 1), into=_Person), _Person | None
+        )
+        assert_type(await wrapper.select(Table("person"), into=_Person), list[_Person])
+        assert_type(
+            wrapper.create(RecordID("person", 1), into=_Person),
+            AsyncCrudBuilder[_Person],
+        )
+        assert_type(
+            wrapper.update(Table("person"), into=_Person),
+            AsyncCrudBuilder[list[_Person]],
+        )
+        assert_type(
+            wrapper.delete(RecordID("person", 1), into=_Person),
+            AsyncCrudBuilder[_Person | None],
+        )
+        assert_type(
+            wrapper.insert(Table("person"), into=_Person), AsyncInsertBuilder[_Person]
+        )
+
+
+def test_blocking_connection_into_overload_precision() -> None:
+    if not TYPE_CHECKING:
+        return
+    ws = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    http = BlockingHttpSurrealConnection("http://localhost:8000")
+
+    for conn in (ws, http):
+        # select is eager: single -> M | None, table -> list[M].
+        assert_type(conn.select(RecordID("person", 1), into=_Person), _Person | None)
+        assert_type(conn.select(Table("person"), into=_Person), list[_Person])
+
+        # no-data create -> builder carrying M; eager data form -> M.
+        assert_type(
+            conn.create(RecordID("person", 1), into=_Person),
+            SyncCrudBuilder[_Person],
+        )
+        assert_type(
+            conn.create(RecordID("person", 1), {"name": "x"}, into=_Person), _Person
+        )
+
+        # update no-data builder vs eager result.
+        assert_type(
+            conn.update(Table("person"), into=_Person),
+            SyncCrudBuilder[list[_Person]],
+        )
+        assert_type(
+            conn.update(Table("person"), {"name": "x"}, into=_Person), list[_Person]
+        )
+
+        # delete is eager on sync: single -> M | None, table -> list[M].
+        assert_type(conn.delete(RecordID("person", 1), into=_Person), _Person | None)
+        assert_type(conn.delete(Table("person"), into=_Person), list[_Person])
+
+        # insert: no-data builder carrying M vs eager list[M].
+        assert_type(
+            conn.insert(Table("person"), into=_Person), SyncInsertBuilder[_Person]
+        )
+        assert_type(
+            conn.insert(Table("person"), [{"name": "x"}], into=_Person), list[_Person]
+        )
+
+        # query().into(...) row-mapping is eager on sync.
+        sq = conn.query("SELECT * FROM person")
+        assert_type(sq.into(_Person), _Person)
+        assert_type(sq.into(_Person, rows=True), list[_Person])
+
+
+def test_blocking_wrapper_into_overload_precision() -> None:
+    if not TYPE_CHECKING:
+        return
+    conn = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    session = BlockingSurrealSession(conn, uuid4())
+    txn = BlockingSurrealTransaction(conn, uuid4(), uuid4())
+
+    for wrapper in (session, txn):
+        assert_type(wrapper.select(RecordID("person", 1), into=_Person), _Person | None)
+        assert_type(wrapper.select(Table("person"), into=_Person), list[_Person])
+        assert_type(
+            wrapper.create(RecordID("person", 1), into=_Person),
+            SyncCrudBuilder[_Person],
+        )
+        assert_type(
+            wrapper.create(RecordID("person", 1), {"name": "x"}, into=_Person), _Person
+        )
+        assert_type(wrapper.delete(RecordID("person", 1), into=_Person), _Person | None)
+        assert_type(
+            wrapper.insert(Table("person"), into=_Person), SyncInsertBuilder[_Person]
+        )

--- a/tests/unit_tests/test_into_mapping.py
+++ b/tests/unit_tests/test_into_mapping.py
@@ -1,0 +1,370 @@
+"""Server-independent tests for the ``into=`` row-model mapping.
+
+These exercise the mapping machinery directly through the builders (with stub
+executors) and through ``select`` (with a monkeypatched ``query_raw``), so they
+run without a SurrealDB server. The live end-to-end coverage lives in
+``tests/unit_tests/connections/v3_api/test_into_row_model.py`` (which self-skips
+when no server is reachable).
+
+Mapping goes through the single shared helper ``_map_to_class`` for every
+supported model kind: dataclasses, pydantic ``BaseModel``, and plain
+kwargs-constructible classes.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.builders import (
+    AsyncCrudBuilder,
+    AsyncQueryBuilder,
+    SyncCrudBuilder,
+    SyncInsertBuilder,
+    SyncQueryBuilder,
+)
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+
+
+@dataclass
+class Person:
+    id: Any
+    name: str
+
+
+class PlainPerson:
+    """A plain (non-dataclass, non-pydantic) kwargs-constructible class."""
+
+    def __init__(self, id: Any, name: str) -> None:
+        self.id = id
+        self.name = name
+
+
+def _ok(payload: Any) -> dict[str, Any]:
+    """Build a single-statement OK response wrapping ``payload``."""
+    return {"result": [{"status": "OK", "result": payload}]}
+
+
+# ---------------------------------------------------------------------------
+# _map_to_class: row (Mapping) branch
+# ---------------------------------------------------------------------------
+
+
+def test_map_row_to_dataclass() -> None:
+    from surrealdb.connections.builders import _map_to_class
+
+    row = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+    out = _map_to_class(Person, row)
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_map_row_to_plain_class() -> None:
+    from surrealdb.connections.builders import _map_to_class
+
+    row = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+    out = _map_to_class(PlainPerson, row)
+    assert isinstance(out, PlainPerson)
+    assert out.name == "Tobie"
+
+
+def test_map_row_to_pydantic() -> None:
+    pydantic = pytest.importorskip("pydantic")
+    from surrealdb.connections.builders import _map_to_class
+
+    class PydModel(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+        id: Any
+        name: str
+
+    row = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+    out = _map_to_class(PydModel, row)
+    assert isinstance(out, PydModel)
+    assert out.name == "Tobie"
+
+
+# ---------------------------------------------------------------------------
+# Async CRUD builders map through into=
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_create_into_returns_model() -> None:
+    record = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+
+    async def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok([record])
+
+    builder: AsyncCrudBuilder[Person] = AsyncCrudBuilder(
+        executor=stub,
+        operation="CREATE",
+        record=RecordID("person", "tobie"),
+        op_name="create",
+        data={"name": "Tobie"},
+        always_unwrap=True,
+        into=Person,
+    )
+    out = await builder
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+@pytest.mark.asyncio
+async def test_async_update_table_into_returns_list_of_models() -> None:
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    async def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok(rows)
+
+    builder: AsyncCrudBuilder[list[Person]] = AsyncCrudBuilder(
+        executor=stub,
+        operation="UPDATE",
+        record=Table("person"),
+        op_name="update",
+        data={"name": "X"},
+        into=Person,
+    )
+    out = await builder
+    assert isinstance(out, list)
+    assert [p.name for p in out] == ["A", "B"]
+    assert all(isinstance(p, Person) for p in out)
+
+
+@pytest.mark.asyncio
+async def test_async_delete_absent_into_returns_none() -> None:
+    async def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok([])
+
+    builder: AsyncCrudBuilder[Person | None] = AsyncCrudBuilder(
+        executor=stub,
+        operation="DELETE",
+        record=RecordID("person", "missing"),
+        op_name="delete",
+        into=Person,
+    )
+    assert await builder is None
+
+
+# ---------------------------------------------------------------------------
+# Sync CRUD builders map through into=
+# ---------------------------------------------------------------------------
+
+
+def test_sync_create_into_returns_model() -> None:
+    record = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok([record])
+
+    builder: SyncCrudBuilder[Person] = SyncCrudBuilder(
+        executor=stub,
+        operation="CREATE",
+        record=RecordID("person", "tobie"),
+        op_name="create",
+        always_unwrap=True,
+        into=Person,
+    )
+    out = builder.content({"name": "Tobie"})
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_sync_insert_into_returns_list_of_models() -> None:
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok(rows)
+
+    builder: SyncInsertBuilder[Person] = SyncInsertBuilder(
+        executor=stub,
+        table=Table("person"),
+        into=Person,
+    )
+    out = builder.content([{"name": "A"}, {"name": "B"}])
+    assert [p.name for p in out] == ["A", "B"]
+    assert all(isinstance(p, Person) for p in out)
+
+
+# ---------------------------------------------------------------------------
+# query().into(cls, rows=True) maps each row of the single statement result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_query_into_rows_returns_list_of_models() -> None:
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    async def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok(rows)
+
+    builder = AsyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+    out = await builder.into(Person, rows=True)
+    assert [p.name for p in out] == ["A", "B"]
+    assert all(isinstance(p, Person) for p in out)
+
+
+def test_sync_query_into_rows_returns_list_of_models() -> None:
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok(rows)
+
+    builder = SyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+    out = builder.into(Person, rows=True)
+    assert [p.name for p in out] == ["A", "B"]
+    assert all(isinstance(p, Person) for p in out)
+
+
+def test_sync_query_into_rows_empty_returns_empty_list() -> None:
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok([])
+
+    builder = SyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+    assert builder.into(Person, rows=True) == []
+
+
+# ---------------------------------------------------------------------------
+# select(..., into=M) mapping via a monkeypatched query_raw (no server)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_select_record_id_into_returns_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncHttpSurrealConnection("http://localhost:8000")
+    record = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+
+    async def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([record])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    out = await conn.select(RecordID("person", "tobie"), into=Person)
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+@pytest.mark.asyncio
+async def test_async_select_absent_into_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncHttpSurrealConnection("http://localhost:8000")
+
+    async def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    assert await conn.select(RecordID("person", "missing"), into=Person) is None
+
+
+@pytest.mark.asyncio
+async def test_async_select_table_into_returns_list_of_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncHttpSurrealConnection("http://localhost:8000")
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    async def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok(rows)
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    out = await conn.select(Table("person"), into=Person)
+    assert isinstance(out, list)
+    assert [p.name for p in out] == ["A", "B"]
+
+
+def test_sync_select_record_id_into_returns_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingHttpSurrealConnection("http://localhost:8000")
+    record = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+
+    def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([record])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    out = conn.select(RecordID("person", "tobie"), into=Person)
+    assert isinstance(out, Person)
+    assert out.name == "Tobie"
+
+
+def test_sync_select_absent_into_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingHttpSurrealConnection("http://localhost:8000")
+
+    def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    assert conn.select(RecordID("person", "missing"), into=Person) is None
+
+
+def test_sync_select_table_into_returns_list_of_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingHttpSurrealConnection("http://localhost:8000")
+    rows = [
+        {"id": RecordID("person", "a"), "name": "A"},
+        {"id": RecordID("person", "b"), "name": "B"},
+    ]
+
+    def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok(rows)
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    out = conn.select(Table("person"), into=Person)
+    assert isinstance(out, list)
+    assert [p.name for p in out] == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# into omitted: behaviour is byte-for-byte unchanged (raw dict / list / None)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_select_without_into_returns_raw_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingHttpSurrealConnection("http://localhost:8000")
+    record = {"id": RecordID("person", "tobie"), "name": "Tobie"}
+
+    def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([record])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+    out = conn.select(RecordID("person", "tobie"))
+    assert out == record
+    assert not isinstance(out, Person)

--- a/tests/unit_tests/test_into_mapping.py
+++ b/tests/unit_tests/test_into_mapping.py
@@ -368,3 +368,15 @@ def test_sync_select_without_into_returns_raw_dict(
     out = conn.select(RecordID("person", "tobie"))
     assert out == record
     assert not isinstance(out, Person)
+
+
+def test_into_rejects_non_record_rows() -> None:
+    """A non-record (scalar) row raises a clear error, not an opaque TypeError."""
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import UnexpectedResponseError
+
+    assert _map_result(Person, None) is None  # absent single record stays None
+    with pytest.raises(UnexpectedResponseError):
+        _map_result(Person, [1, 2])
+    with pytest.raises(UnexpectedResponseError):
+        _map_result(Person, 42)


### PR DESCRIPTION
## Summary

Adds a keyword-only `into=` argument that maps returned record(s) onto a model class — a dataclass, a pydantic `BaseModel`, or any class whose constructor accepts the record's fields as keyword arguments. Runtime mapping reuses the existing `_map_to_class` helper (no parallel mapper), and every return type is narrowed precisely via `@overload` so the typed surface stays exact across async (awaitable) and sync (eager) with strict parity.

## API added

**select** (highest priority — clean):
- `select(RecordID | "table:id", into=M) -> M | None`
- `select(Table | table-name, into=M) -> list[M]`
- Without `into`: unchanged (`dict | None` / `list[Value]`).

**create / update / upsert / delete / insert** map the written/returned record(s):
- Eager/data forms return the model — `create(rec, data, into=M) -> M`; `update(rec, data, into=M) -> M`; `upsert` same; `delete(rec, into=M) -> M | None`; `Table` targets → `list[M]` (create stays single → `M`, matching its dict-only return); `insert(table, data, into=M) -> list[M]`.
- No-data builder forms (`create(rec, into=M)`, `update(rec, into=M)`, `insert(table, into=M)`) return a builder parameterised on `M`, so its clause methods (`.content` / `.merge` / … / `.execute`) resolve to `M` (or `list[M]`).

**query row-mapping**:
- `query(sql).into(Model, rows=True)` maps each ROW of the single statement result to `Model`, returning `list[Model]`. The existing `.into(cls)` statements-to-fields behaviour is the default when `rows` is not set.

## Notes

- `into` is keyword-only; `M` is a `TypeVar`. Behaviour with `into` omitted is byte-for-byte unchanged.
- Overloads applied on both templates, all four connections, and the session/transaction wrapper classes. `AsyncQueryIntoBuilder` is made covariant in its output type so the `rows=` overloads type-check without overlap conflicts.

## Tests

- Server-independent mapping tests (`tests/unit_tests/test_into_mapping.py`) via stub executors + monkeypatched `query_raw`, covering dataclass / pydantic / plain-class models.
- Live end-to-end tests (`tests/unit_tests/connections/v3_api/test_into_row_model.py`) for select present/absent/table, create+update round-trips, `query().into(..., rows=True)`, and the no-data-builder-carries-model path — async and sync. They self-skip without a server.
- `assert_type` typing guards (guarded by `if not TYPE_CHECKING: return`) for connections, session, and transaction wrappers, async and sync.

## Verification

`ruff check` + `ruff format`, `mypy src`, `pyright src`, `mypy tests` all clean; `pytest tests/unit_tests` (ignoring embedded) passes 879 tests against a local SurrealDB server, including the new `into=` suites.