### PR TITLE
Bump pyo3 to 0.29 in the embedded extension

### DIFF
--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -1863,15 +1863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,15 +2118,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -2764,28 +2746,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -2794,18 +2774,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2813,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2825,13 +2805,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -3728,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0"
+version = "3.0.0-alpha.3"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -4264,12 +4243,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/surrealdb_ext/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.2", features = ["extension-module", "abi3-py39"] }
-pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
+pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 surrealdb-core = { version = "3", default-features = false, features = ["kv-mem", "kv-surrealkv"] }
 surrealdb-types = "3"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## What

Bumps the native `surrealdb-embedded` extension from **pyo3 0.27 → 0.29** (and `pyo3-async-runtimes 0.27 → 0.29`), and refreshes `embedded/Cargo.lock`.

## Why

Fixes the two pyo3 security advisories flagged by Dependabot on the default branch:

- **High severity — out-of-bounds read in `PyList` / `PyTuple` iterators.** The iterators could read past the end of the sequence if it was mutated during iteration. Fixed in pyo3 0.29.
- **Missing `Sync` bound.** A soundness fix that closes a gap allowing non-thread-safe access across threads.

`pyo3-async-runtimes` has to move together with pyo3, because its 0.29 release requires `pyo3 ^0.29`. Both were already verified compatible.

## Details

- `embedded/Cargo.toml`: `pyo3` → `"0.29"`, `pyo3-async-runtimes` → `"0.29"`. Features unchanged (`extension-module`, `abi3-py39`; `tokio-runtime`).
- `embedded/Cargo.lock`: regenerated. pyo3 resolves to `0.29.0`, pyo3-async-runtimes to `0.29.0`. The now-unused `indoc`, `memoffset` and `unindent` transitive deps drop out.
- **No source changes needed.** The extension already uses the modern `Bound<'py, T>` API, so it compiles cleanly against pyo3 0.29 — none of the 0.28/0.29 breaking changes (free-threaded default, `Clone`+`FromPyObject` opt-in, buffer API, `PyClassInitializer`, UTF-8 error handling) touch the patterns used here.
- Scope is limited to `embedded/`; the pure-Python `surrealdb` package is untouched. Package version is intentionally left unchanged (release is a separate step).

## Testing

- `cargo audit` on the refreshed lockfile: no pyo3 advisories remain.
- Built the extension locally with `maturin develop` (pyo3 0.29): clean build, no warnings from the crate.
- `pytest tests/unit_tests/connections/embedded`: **25 passed**.
- `ruff check src/` and `mypy --explicit-package-bases src/` on the pure-Python side: unaffected (unchanged, still green).

CI's `test-embedded` job will validate the build on all target platforms.