### PR TITLE
Release 3.0.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.4] - 2026-07-16
+
+### Security
+- Bump the embedded extension's `pyo3` to 0.29.0 (and `pyo3-async-runtimes` to 0.29), fixing a high-severity out-of-bounds read in `PyList` / `PyTuple` iterators and a missing `Sync` bound on `PyCFunction::new_closure`. Affects the native `surrealdb-embedded` package only; no API changes.
+
 ## [3.0.0-alpha.3] - 2026-07-16
 
 Follow-up to `3.0.0-alpha.2`: adds the `into=` row-model API, fixes session authentication propagation, aligns `delete` with `select`, and re-enables mypy type-checking on the test suite.
@@ -174,7 +179,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.3...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...HEAD
+[3.0.0-alpha.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.3...v3.0.0-alpha.4
 [3.0.0-alpha.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.2...v3.0.0-alpha.3
 [3.0.0-alpha.2]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.1...v3.0.0-alpha.2
 [3.0.0-alpha.1]: https://github.com/surrealdb/surrealdb.py/compare/v2.0.1...v3.0.0-alpha.1

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-alpha.3"
+version = "3.0.0-alpha.4"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-alpha.3"
+version = "3.0.0-alpha.4"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-alpha.3"
+version = "3.0.0-alpha.4"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -41,7 +41,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-alpha.3",
+    "surrealdb-embedded==3.0.0-alpha.4",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0a3"
+version = "3.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1563,7 +1563,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0a3"
+version = "3.0.0a4"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Fourth alpha on the 3.0.0 track — ships the **pyo3 0.29 security fix** (high-severity OOB read + missing Sync bound) for the native `surrealdb-embedded` package. Bumps both packages to `3.0.0-alpha.4` (→ `3.0.0a4`), keeps the embedded pin in lockstep, refreshes the lockfile, and adds the CHANGELOG entry. Publishing the `v3.0.0-alpha.4` GitHub pre-release triggers the PyPI publish. Install: `pip install --pre surrealdb==3.0.0a4`.