### PR TITLE
Add query_raw/info/version to the session and transaction wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `query_raw()`, `info()`, and `version()` on the session and transaction wrapper classes (`AsyncSurrealSession` / `BlockingSurrealSession`, `AsyncSurrealTransaction` / `BlockingSurrealTransaction`). These were the only connection RPCs missing from the wrappers, so calling `session.query_raw(...)` raised `AttributeError` even though the underlying connection method already accepted `session_id` / `txn_id`. Each forwards the session (and, on a transaction, the txn) like every other wrapper method.
+
 ## [3.0.0-alpha.4] - 2026-07-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -371,7 +371,10 @@ async with AsyncSurreal("ws://localhost:8000/rpc") as db:
 
 The same CRUD builder, query, and `run()` API is available on both
 `AsyncSurrealSession` / `BlockingSurrealSession` and
-`AsyncSurrealTransaction` / `BlockingSurrealTransaction`.
+`AsyncSurrealTransaction` / `BlockingSurrealTransaction`, along with
+`query_raw()`, `info()`, and `version()`. Every one of them scopes to the
+session (and transaction) it was called on, so you never pass `session_id`
+or `txn_id` by hand.
 
 ## `run()` - calling SurrealDB functions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,11 @@ packages = ["src/surrealdb"]
 # --------------------------------------------------
 
 [tool.ruff]
-exclude = ["src/surrealdb/__init__.py"]
+# Markdown is excluded because ruff >= 0.16 formats Python code blocks inside
+# `.md` files, which reflows the hand-aligned examples in our docs (notably
+# `src/surrealdb/spectron/README.md`, which sits under the `./src` path CI
+# checks). Docs prose is not formatter-owned.
+exclude = ["src/surrealdb/__init__.py", "*.md"]
 
 [tool.ruff.lint]
 select = [

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -1000,6 +1000,15 @@ class AsyncSurrealSession:
     ) -> AsyncQueryBuilder:
         return self._connection.query(query, vars, session_id=self._session_id)
 
+    async def query_raw(
+        self,
+        query: str,
+        vars: dict[str, Value] | None = None,
+    ) -> dict[str, Any]:
+        return await self._connection.query_raw(
+            query, vars, session_id=self._session_id
+        )
+
     async def signin(self, vars: dict[str, Value]) -> Tokens:
         return await self._connection.signin(vars, session_id=self._session_id)
 
@@ -1011,6 +1020,12 @@ class AsyncSurrealSession:
 
     async def invalidate(self) -> None:
         await self._connection.invalidate(session_id=self._session_id)
+
+    async def info(self) -> Value:
+        return await self._connection.info(session_id=self._session_id)
+
+    async def version(self) -> str:
+        return await self._connection.version(session_id=self._session_id)
 
     async def let(self, key: str, value: Value) -> None:
         await self._connection.let(key, value, session_id=self._session_id)
@@ -1242,6 +1257,24 @@ class AsyncSurrealTransaction:
             session_id=self._session_id,
             txn_id=self._txn_id,
         )
+
+    async def query_raw(
+        self,
+        query: str,
+        vars: dict[str, Value] | None = None,
+    ) -> dict[str, Any]:
+        return await self._connection.query_raw(
+            query,
+            vars,
+            session_id=self._session_id,
+            txn_id=self._txn_id,
+        )
+
+    async def info(self) -> Value:
+        return await self._connection.info(session_id=self._session_id)
+
+    async def version(self) -> str:
+        return await self._connection.version(session_id=self._session_id)
 
     @overload
     async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -1135,6 +1135,13 @@ class BlockingSurrealSession:
     ) -> SyncQueryBuilder:
         return self._connection.query(query, vars, session_id=self._session_id)
 
+    def query_raw(
+        self,
+        query: str,
+        vars: dict[str, Value] | None = None,
+    ) -> dict[str, Any]:
+        return self._connection.query_raw(query, vars, session_id=self._session_id)
+
     def signin(self, vars: dict[str, Value]) -> Tokens:
         return self._connection.signin(vars, session_id=self._session_id)
 
@@ -1146,6 +1153,12 @@ class BlockingSurrealSession:
 
     def invalidate(self) -> None:
         self._connection.invalidate(session_id=self._session_id)
+
+    def info(self) -> Value:
+        return self._connection.info(session_id=self._session_id)
+
+    def version(self) -> str:
+        return self._connection.version(session_id=self._session_id)
 
     def let(self, key: str, value: Value) -> None:
         self._connection.let(key, value, session_id=self._session_id)
@@ -1362,6 +1375,24 @@ class BlockingSurrealTransaction:
             session_id=self._session_id,
             txn_id=self._txn_id,
         )
+
+    def query_raw(
+        self,
+        query: str,
+        vars: dict[str, Value] | None = None,
+    ) -> dict[str, Any]:
+        return self._connection.query_raw(
+            query,
+            vars,
+            session_id=self._session_id,
+            txn_id=self._txn_id,
+        )
+
+    def info(self) -> Value:
+        return self._connection.info(session_id=self._session_id)
+
+    def version(self) -> str:
+        return self._connection.version(session_id=self._session_id)
 
     @overload
     def select(self, record: RecordID, *, into: type[M]) -> M | None: ...

--- a/tests/unit_tests/test_session_forwarding.py
+++ b/tests/unit_tests/test_session_forwarding.py
@@ -1,0 +1,186 @@
+"""Session / transaction wrappers forward the non-builder RPCs too.
+
+``AsyncSurrealSession`` / ``BlockingSurrealSession`` (and the transaction
+equivalents) wrap a connection and thread ``session`` / ``txn`` onto every
+operation. ``query_raw``, ``info``, and ``version`` were missing from that
+sweep, so calling them on a session raised ``AttributeError`` even though
+the underlying connection methods already accepted the context.
+
+These server-independent tests pin the forwarding: the wrapper must reach
+the connection method *and* stamp the session (and, for a transaction,
+the txn) onto the outgoing request message.
+"""
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from surrealdb.connections.async_ws import (
+    AsyncSurrealSession,
+    AsyncSurrealTransaction,
+    AsyncWsSurrealConnection,
+)
+from surrealdb.connections.blocking_ws import (
+    BlockingSurrealSession,
+    BlockingSurrealTransaction,
+    BlockingWsSurrealConnection,
+)
+from surrealdb.request_message.message import RequestMessage
+from surrealdb.request_message.methods import RequestMethod
+
+
+def _capture(store: dict[str, Any]) -> Any:
+    def fake_send(
+        message: RequestMessage, process: str, bypass: bool = False
+    ) -> dict[str, Any]:
+        store["message"] = message
+        return {"result": []}
+
+    return fake_send
+
+
+def _async_capture(store: dict[str, Any]) -> Any:
+    async def fake_send(
+        message: RequestMessage, process: str, bypass: bool = False
+    ) -> dict[str, Any]:
+        store["message"] = message
+        return {"result": []}
+
+    return fake_send
+
+
+async def test_async_session_query_raw_forwards_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _async_capture(store))
+    session_id = uuid4()
+    session = AsyncSurrealSession(conn, session_id)
+
+    await session.query_raw("SELECT * FROM person WHERE age > $age", vars={"age": 18})
+
+    message = store["message"]
+    assert message.method == RequestMethod.QUERY
+    assert message.kwargs["query"] == "SELECT * FROM person WHERE age > $age"
+    assert message.kwargs["params"] == {"age": 18}
+    assert message.kwargs["session"] == session_id
+    assert "txn" not in message.kwargs
+
+
+async def test_async_session_info_and_version_forward_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _async_capture(store))
+    session_id = uuid4()
+    session = AsyncSurrealSession(conn, session_id)
+
+    await session.info()
+    assert store["message"].method == RequestMethod.INFO
+    assert store["message"].kwargs["session"] == session_id
+
+    await session.version()
+    assert store["message"].method == RequestMethod.VERSION
+    assert store["message"].kwargs["session"] == session_id
+
+
+async def test_async_transaction_query_raw_forwards_session_and_txn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _async_capture(store))
+    session_id, txn_id = uuid4(), uuid4()
+    txn = AsyncSurrealTransaction(conn, session_id, txn_id)
+
+    await txn.query_raw("INFO FOR DB")
+
+    message = store["message"]
+    assert message.kwargs["session"] == session_id
+    assert message.kwargs["txn"] == txn_id
+
+
+async def test_async_transaction_info_and_version_forward_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = AsyncWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _async_capture(store))
+    session_id, txn_id = uuid4(), uuid4()
+    txn = AsyncSurrealTransaction(conn, session_id, txn_id)
+
+    await txn.info()
+    assert store["message"].kwargs["session"] == session_id
+
+    await txn.version()
+    assert store["message"].kwargs["session"] == session_id
+
+
+def test_blocking_session_query_raw_forwards_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _capture(store))
+    session_id = uuid4()
+    session = BlockingSurrealSession(conn, session_id)
+
+    session.query_raw("SELECT * FROM person WHERE age > $age", {"age": 21})
+
+    message = store["message"]
+    assert message.kwargs["params"] == {"age": 21}
+    assert message.kwargs["session"] == session_id
+    assert "txn" not in message.kwargs
+
+
+def test_blocking_session_info_and_version_forward_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _capture(store))
+    session_id = uuid4()
+    session = BlockingSurrealSession(conn, session_id)
+
+    session.info()
+    assert store["message"].method == RequestMethod.INFO
+    assert store["message"].kwargs["session"] == session_id
+
+    session.version()
+    assert store["message"].method == RequestMethod.VERSION
+    assert store["message"].kwargs["session"] == session_id
+
+
+def test_blocking_transaction_query_raw_forwards_session_and_txn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _capture(store))
+    session_id, txn_id = uuid4(), uuid4()
+    txn = BlockingSurrealTransaction(conn, session_id, txn_id)
+
+    txn.query_raw("INFO FOR DB")
+
+    message = store["message"]
+    assert message.kwargs["session"] == session_id
+    assert message.kwargs["txn"] == txn_id
+
+
+def test_blocking_transaction_info_and_version_forward_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = BlockingWsSurrealConnection("ws://localhost:8000/rpc")
+    store: dict[str, Any] = {}
+    monkeypatch.setattr(conn, "_send", _capture(store))
+    session_id, txn_id = uuid4(), uuid4()
+    txn = BlockingSurrealTransaction(conn, session_id, txn_id)
+
+    txn.info()
+    assert store["message"].kwargs["session"] == session_id
+
+    txn.version()
+    assert store["message"].kwargs["session"] == session_id


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

A user on Discord hit `AttributeError: 'AsyncSurrealSession' object has no attribute 'query_raw'` immediately after switching to `new_session()`, and asked whether there was a reason `query_raw()` exists on `AsyncSurreal(ws://…)` but not on a session of the same connection.

There isn't — it's an oversight. The session and transaction wrappers thread `session_id` / `txn_id` through to the connection for every builder, CRUD, and auth method, but `query_raw`, `info`, and `version` were never included in that sweep. The underlying connection methods have always accepted the context kwargs, so the wrappers were the only thing missing.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Adds `query_raw()`, `info()`, and `version()` to all four wrapper classes — `AsyncSurrealSession` / `BlockingSurrealSession` and `AsyncSurrealTransaction` / `BlockingSurrealTransaction`.

Two details worth a reviewer's attention:

- `query_raw` on a **transaction** forwards both `session_id` and `txn_id`; on a **session** it forwards `session_id` only and must not stamp a `txn`. Both are asserted in the tests.
- `info` and `version` are session-scoped RPCs with no txn variant on the connection, so the transaction wrappers forward `session_id` only — matching how `commit()` / `cancel()` already behave.

The embedded connections import the WS session classes rather than defining their own, so they inherit this with no further change.

Also updates the README sessions section (which previously said only "the same CRUD builder, query, and `run()` API") and adds a CHANGELOG entry under `[Unreleased]`.

## What is your testing strategy?

New `tests/unit_tests/test_session_forwarding.py` — 8 server-independent tests that monkeypatch `_send` and assert the outgoing `RequestMessage` carries the right method and the right `session` / `txn` kwargs, including the negative case that a session's `query_raw` does not set `txn`.

Full local run:

- 554 unit tests + 3 xpassed, `ruff check`, `ruff format --check`, and `mypy` on both `src/` and `tests/` all clean.
- The 14 existing `tests/unit_tests/connections/session_txn` integration tests pass against a local SurrealDB 3.2.3 server.
- Manual end-to-end against that same server: `session.version()` returns the server version, `session.query_raw(...)` returns the full `{status, time, result}` envelope, and both work through a transaction.

One thing that is *not* a regression: `info()` returns `None` on a session under root auth — but the connection's `info()` returns `None` there too (root auth has no `INFO` record to resolve), so the wrapper matches existing connection behaviour.

## Is this related to any issues?

No filed issue — reported on Discord.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
