### PR TITLE
Map all transport failures onto the SurrealError hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TransportError`, a new branch of the error hierarchy for failures that produced no structured server response, alongside the existing `ServerError` branch. `ConnectionUnavailableError` now derives from it, joined by `TransportTimeoutError` (the request timed out) and `HttpStatusError` (a non-2xx HTTP response, carrying `.status`, `.body`, and `.url`). The split is what retry logic keys on: a `TransportError` may succeed if retried, a `ServerError` describes a decision the server already made.
 - `query_raw()`, `info()`, and `version()` on the session and transaction wrapper classes (`AsyncSurrealSession` / `BlockingSurrealSession`, `AsyncSurrealTransaction` / `BlockingSurrealTransaction`). These were the only connection RPCs missing from the wrappers, so calling `session.query_raw(...)` raised `AttributeError` even though the underlying connection method already accepted `session_id` / `txn_id`. Each forwards the session (and, on a transaction, the txn) like every other wrapper method.
+
+### Fixed
+- Transport failures no longer escape as third-party exceptions, so `except SurrealError` now reliably covers every failure the SDK raises. Previously the exception type depended on how a failure was represented: an RPC error in a 2xx body became a `ServerError`, but a non-2xx `/rpc` response leaked `requests.exceptions.HTTPError` or `aiohttp.ClientResponseError`, an unreachable host leaked `requests.exceptions.ConnectionError` / `aiohttp.ClientConnectorError` / `ConnectionRefusedError`, and an undecodable body leaked a CBOR decode error. All four transports (blocking/async, HTTP/WebSocket) now map these to `HttpStatusError`, `ConnectionUnavailableError`, `TransportTimeoutError`, or `UnexpectedResponseError`, each preserving the original exception as `__cause__`. A non-2xx response whose body *does* contain a structured RPC error still maps to its `ServerError` subclass.
 
 ## [3.0.0-alpha.4] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,54 @@ with Surreal("ws://localhost:8000/rpc") as db:
   separate connection per live subscription (or the async client, which
   fans notifications out to per-subscriber queues).
 
+## Error handling
+
+Every error the SDK raises derives from `SurrealError`, so a single
+`except SurrealError` covers all of them regardless of transport.
+
+Below that base, errors split into two branches that mean different things:
+
+| Branch            | Meaning                                                     | Retry?                |
+| ----------------- | ----------------------------------------------------------- | --------------------- |
+| `ServerError`     | The server ran your request and rejected it                  | No — it will fail again |
+| `TransportError`  | The request never produced a structured server response      | Maybe — it may succeed |
+
+`ServerError` mirrors SurrealDB's structured error format, so you can match
+on `kind` and read typed details rather than parsing messages:
+
+```python
+from surrealdb import Surreal
+from surrealdb.errors import NotFoundError, ServerError, SurrealError, TransportError
+
+with Surreal("ws://localhost:8000/rpc") as db:
+    db.signin({"username": "root", "password": "root"})
+    db.use("ns", "db")
+
+    try:
+        db.query("SELECT * FROM nonexistent:1").execute()
+    except NotFoundError as error:
+        print(error.kind, error.table_name)   # NotFound nonexistent
+    except ServerError as error:
+        print(error.kind, error.details)
+    except TransportError as error:
+        print("could not reach the server:", error)
+```
+
+The `TransportError` branch is `ConnectionUnavailableError` (the host was
+unreachable or the socket closed), `TransportTimeoutError` (the request timed
+out), and `HttpStatusError` (a non-2xx HTTP response, carrying `.status`,
+`.body`, and `.url`). Each keeps the underlying library exception as
+`__cause__` when you need the original detail.
+
+Note that a non-2xx HTTP response is reported as `HttpStatusError` rather than
+a `ServerError` subclass, because SurrealDB answers those at the HTTP layer
+with a plain-text or JSON body and no structured RPC error to map. An invalid
+bearer token over HTTP, for example, surfaces as `HttpStatusError` with
+`.status == 401`, not `NotAllowedError`.
+
+Invalid *inputs* are still rejected with plain `ValueError` / `TypeError`
+before anything is sent, following normal Python convention.
+
 ## Migrating from 2.x
 
 v3.0 is a breaking change. Highlights:

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -51,6 +51,7 @@ from surrealdb.errors import (
     ConnectionDetailKind,
     ConnectionUnavailableError,
     ErrorKind,
+    HttpStatusError,
     InternalError,
     InvalidDurationError,
     InvalidGeometryError,
@@ -68,6 +69,8 @@ from surrealdb.errors import (
     SurrealDBMethodError,
     SurrealError,
     ThrownError,
+    TransportError,
+    TransportTimeoutError,
     UnexpectedResponseError,
     UnsupportedEngineError,
     UnsupportedFeatureError,
@@ -135,8 +138,12 @@ __all__ = [
     "NotFoundDetailKind",
     "AlreadyExistsDetailKind",
     "ConnectionDetailKind",
-    # Errors – SDK-side
+    # Errors – transport
+    "TransportError",
     "ConnectionUnavailableError",
+    "TransportTimeoutError",
+    "HttpStatusError",
+    # Errors – SDK-side
     "UnsupportedEngineError",
     "UnsupportedFeatureError",
     "UnexpectedResponseError",

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from types import TracebackType
 from typing import Any, cast, overload
@@ -14,10 +15,14 @@ from surrealdb.connections.builders import (
 )
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
-from surrealdb.data.cbor import decode
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
-from surrealdb.errors import UnsupportedFeatureError, parse_rpc_error
+from surrealdb.errors import (
+    ConnectionUnavailableError,
+    TransportTimeoutError,
+    UnsupportedFeatureError,
+    parse_rpc_error,
+)
 from surrealdb.request_message.message import RequestMessage
 from surrealdb.request_message.methods import RequestMethod
 from surrealdb.types import Tokens, Value, parse_auth_result
@@ -94,19 +99,31 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         operation: str,
         bypass: bool,
     ) -> dict[str, Any]:
-        async with session.request(
-            method="POST",
-            url=url,
-            headers=headers,
-            data=data,
-            timeout=aiohttp.ClientTimeout(total=30),
-        ) as response:
-            response.raise_for_status()
-            raw_cbor = await response.read()
-            result = decode(raw_cbor)
-            if bypass is False:
-                self.check_response_for_error(result, operation)
-            return result
+        try:
+            async with session.request(
+                method="POST",
+                url=url,
+                headers=headers,
+                data=data,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                status = response.status
+                raw_cbor = await response.read()
+        except asyncio.TimeoutError as exc:
+            raise TransportTimeoutError(
+                f"timed out while {operation} against {url}: {exc}"
+            ) from exc
+        except aiohttp.ClientError as exc:
+            raise ConnectionUnavailableError(
+                f"could not reach {url} while {operation}: {exc}"
+            ) from exc
+
+        self.check_status_for_error(status, raw_cbor, url)
+
+        result = self.decode_response(raw_cbor, operation)
+        if bypass is False:
+            self.check_response_for_error(result, operation)
+        return result
 
     def set_token(self, token: str) -> None:
         """

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -28,6 +28,7 @@ from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     ConnectionUnavailableError,
+    TransportTimeoutError,
     UnexpectedResponseError,
     parse_rpc_error,
 )
@@ -122,7 +123,12 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self.qry[query_id] = fut
         try:
             # correlate message to query, send and forget it
-            await self.socket.send(message.WS_CBOR_DESCRIPTOR)
+            try:
+                await self.socket.send(message.WS_CBOR_DESCRIPTOR)
+            except (WebSocketException, OSError) as exc:
+                raise ConnectionUnavailableError(
+                    f"the connection to {self.raw_url} failed while {process}: {exc}"
+                ) from exc
             del message
 
             # wait for response
@@ -155,11 +161,20 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             self.host = self.url.hostname
             self.port = self.url.port
 
-        self.socket = await websockets.connect(
-            self.raw_url,
-            max_size=None,
-            subprotocols=[websockets.Subprotocol("cbor")],
-        )
+        try:
+            self.socket = await websockets.connect(
+                self.raw_url,
+                max_size=None,
+                subprotocols=[websockets.Subprotocol("cbor")],
+            )
+        except asyncio.TimeoutError as exc:
+            raise TransportTimeoutError(
+                f"timed out connecting to {self.raw_url}: {exc}"
+            ) from exc
+        except (WebSocketException, OSError) as exc:
+            raise ConnectionUnavailableError(
+                f"could not connect to {self.raw_url}: {exc}"
+            ) from exc
         self.loop = asyncio.get_running_loop()
         self.recv_task = asyncio.create_task(self._recv_task())
 

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -15,10 +15,14 @@ from surrealdb.connections.builders import (
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
-from surrealdb.data.cbor import decode
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
-from surrealdb.errors import UnsupportedFeatureError, parse_rpc_error
+from surrealdb.errors import (
+    ConnectionUnavailableError,
+    TransportTimeoutError,
+    UnsupportedFeatureError,
+    parse_rpc_error,
+)
 from surrealdb.request_message.message import RequestMessage
 from surrealdb.request_message.methods import RequestMethod
 from surrealdb.types import Tokens, Value, parse_auth_result
@@ -55,14 +59,27 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
 
         # Reuse the pooled session when running inside a context manager,
         # otherwise fall back to a fresh per-request request.
-        if self.session is not None:
-            response = self.session.post(url, headers=headers, data=data, timeout=30)
-        else:
-            response = requests.post(url, headers=headers, data=data, timeout=30)
-        response.raise_for_status()
+        try:
+            if self.session is not None:
+                response = self.session.post(
+                    url, headers=headers, data=data, timeout=30
+                )
+            else:
+                response = requests.post(url, headers=headers, data=data, timeout=30)
+        except requests.exceptions.Timeout as exc:
+            raise TransportTimeoutError(
+                f"timed out while {operation} against {url}: {exc}"
+            ) from exc
+        except requests.exceptions.RequestException as exc:
+            raise ConnectionUnavailableError(
+                f"could not reach {url} while {operation}: {exc}"
+            ) from exc
 
-        raw_cbor = response.content
-        data_dict = cast(dict[str, Any], decode(raw_cbor))
+        self.check_status_for_error(response.status_code, response.content, url)
+
+        data_dict = cast(
+            dict[str, Any], self.decode_response(response.content, operation)
+        )
 
         if not bypass:
             self.check_response_for_error(data_dict, operation)

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -27,11 +27,11 @@ from surrealdb.connections.builders import (
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
-from surrealdb.data.cbor import decode
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     ConnectionUnavailableError,
+    TransportTimeoutError,
     UnexpectedResponseError,
     parse_rpc_error,
 )
@@ -79,6 +79,23 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         # handed off instead of being lost.
         self.live_queues: dict[str, list[queue.Queue[dict[str, Any]]]] = {}
 
+    def _connect_socket(self) -> ClientConnection:
+        """Open the websocket, mapping transport failures to SDK errors."""
+        try:
+            return ws_sync.connect(
+                self.raw_url,
+                max_size=None,
+                subprotocols=[websockets.Subprotocol("cbor")],
+            )
+        except TimeoutError as exc:
+            raise TransportTimeoutError(
+                f"timed out connecting to {self.raw_url}: {exc}"
+            ) from exc
+        except (WebSocketException, OSError) as exc:
+            raise ConnectionUnavailableError(
+                f"could not connect to {self.raw_url}: {exc}"
+            ) from exc
+
     def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
     ) -> dict[str, Any]:
@@ -86,32 +103,39 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         # This prevents race conditions when multiple threads share the same connection
         with self._lock:
             if self.socket is None:
-                self.socket = ws_sync.connect(
-                    self.raw_url,
-                    max_size=None,
-                    subprotocols=[websockets.Subprotocol("cbor")],
-                )
-            self.socket.send(message.WS_CBOR_DESCRIPTOR)
+                self.socket = self._connect_socket()
 
             # Correlate the reply to this request. Live-query notifications
             # carry no top-level "id" and may be delivered between our send and
             # our reply; route those to their live queue (if a subscriber is
             # registered, else drop) and keep reading, so a notification is
             # never returned as an RPC result.
-            while True:
-                data = self.socket.recv()
-                response = decode(data if isinstance(data, bytes) else data.encode())
-                response_id = response.get("id")
-                if response_id is None:
-                    self._route_live_notification(response)
-                    continue
-                if response_id != message.id:
-                    raise UnexpectedResponseError(
-                        f"Response ID mismatch: expected {message.id}, got "
-                        f"{response_id}. This should not happen with proper "
-                        "locking."
+            try:
+                self.socket.send(message.WS_CBOR_DESCRIPTOR)
+                while True:
+                    data = self.socket.recv()
+                    response = self.decode_response(
+                        data if isinstance(data, bytes) else data.encode(), process
                     )
-                break
+                    response_id = response.get("id")
+                    if response_id is None:
+                        self._route_live_notification(response)
+                        continue
+                    if response_id != message.id:
+                        raise UnexpectedResponseError(
+                            f"Response ID mismatch: expected {message.id}, got "
+                            f"{response_id}. This should not happen with proper "
+                            "locking."
+                        )
+                    break
+            except TimeoutError as exc:
+                raise TransportTimeoutError(
+                    f"timed out while {process} on {self.raw_url}: {exc}"
+                ) from exc
+            except (WebSocketException, OSError) as exc:
+                raise ConnectionUnavailableError(
+                    f"the connection to {self.raw_url} failed while {process}: {exc}"
+                ) from exc
 
             if bypass is False:
                 self.check_response_for_error(response, process)
@@ -987,7 +1011,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                         data = self.socket.recv(timeout=_LIVE_RECV_TIMEOUT)
                     except TimeoutError:
                         data = None
-                    except (ConnectionClosed, WebSocketException) as exc:
+                    except (ConnectionClosed, WebSocketException, OSError) as exc:
                         logger.warning("Live subscription socket closed: %s", exc)
                         raise ConnectionUnavailableError(
                             "WebSocket connection closed while subscribed to a "
@@ -997,7 +1021,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                 if data is None:
                     continue
 
-                response = decode(data if isinstance(data, bytes) else data.encode())
+                response = self.decode_response(
+                    data if isinstance(data, bytes) else data.encode(),
+                    "reading a live notification",
+                )
                 if response.get("id") is not None:
                     # Stray RPC reply with no waiter (should not happen while
                     # the lock serialises RPCs); ignore rather than yield it.
@@ -1097,9 +1124,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         Synchronous context manager entry.
         Initializes a websocket connection and returns the connection instance.
         """
-        self.socket = ws_sync.connect(
-            self.raw_url, max_size=None, subprotocols=[websockets.Subprotocol("cbor")]
-        )
+        self.socket = self._connect_socket()
         return self
 
     def __exit__(

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -3,11 +3,14 @@ from typing import Any
 from surrealdb.connections.builders import (
     _resource_to_variable,  # pyright: ignore[reportPrivateUsage]
 )
+from surrealdb.data.cbor import decode
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     ErrorKind,
+    HttpStatusError,
     SurrealError,
+    UnexpectedResponseError,
     parse_query_error,
     parse_rpc_error,
 )
@@ -23,6 +26,19 @@ _NO_RESULT_RPC_CODE = -32000
 # The SurrealQL used to resolve the currently authenticated record for
 # record-level ("scope") users when ``info`` reports no result.
 AUTH_FALLBACK_QUERY = "SELECT * FROM $auth"
+
+# How much of a non-2xx HTTP body to keep in the raised error message. Enough
+# to identify the failure, short enough to stay readable in a traceback.
+_MAX_BODY_CHARS = 300
+
+
+def _body_text(body: bytes) -> str:
+    """Render an HTTP error body as short, printable text."""
+    text = body.decode("utf-8", errors="replace").strip()
+    if len(text) > _MAX_BODY_CHARS:
+        return text[:_MAX_BODY_CHARS] + "..."
+    return text
+
 
 # These are re-exported for backwards compatibility with downstream code
 # that imported them via ``surrealdb.connections.utils_mixin``.
@@ -41,6 +57,39 @@ class UtilsMixin:
         error = response.get("error")
         if error is not None:
             raise parse_rpc_error(error)
+
+    @staticmethod
+    def check_status_for_error(status: int, body: bytes, url: str) -> None:
+        """Raise when an HTTP RPC response carries a non-2xx status.
+
+        A non-2xx ``/rpc`` response normally carries an HTTP-layer body — plain
+        text or a JSON envelope — rather than the CBOR RPC envelope, so there
+        is no structured error to map and the status is reported as
+        :class:`HttpStatusError`. The RPC body is still tried first so that a
+        server which does report a structured error alongside a non-2xx status
+        keeps its ``ServerError`` mapping.
+        """
+        if 200 <= status < 300:
+            return
+        try:
+            decoded = decode(body)
+        except Exception:
+            decoded = None
+        if isinstance(decoded, dict):
+            error = decoded.get("error")
+            if error is not None:
+                raise parse_rpc_error(error)
+        raise HttpStatusError(status, _body_text(body), url)
+
+    @staticmethod
+    def decode_response(body: bytes, process: str) -> Any:
+        """Decode a CBOR response body, or raise ``UnexpectedResponseError``."""
+        try:
+            return decode(body)
+        except Exception as exc:
+            raise UnexpectedResponseError(
+                f"could not decode the response while {process}: {exc}"
+            ) from exc
 
     @staticmethod
     def check_response_for_result(response: dict[str, Any], process: str) -> None:

--- a/src/surrealdb/errors.py
+++ b/src/surrealdb/errors.py
@@ -6,6 +6,11 @@ All errors raised by this SDK extend ``SurrealError`` so that callers can
 the ``ServerError`` sub-tree which mirrors the structured error format
 (kind / details / cause) introduced in SurrealDB 3.x while remaining
 backward-compatible with the legacy code-only format.
+
+Failures that never reached the server, or that came back in a form with no
+structured error to parse, use the ``TransportError`` sub-tree instead.  The
+split is what retry logic keys on: a ``TransportError`` may succeed if tried
+again, a ``ServerError`` describes a decision the server already made.
 """
 
 from __future__ import annotations
@@ -394,8 +399,40 @@ class InternalError(ServerError):
 # ------------------------------------------------------------------ #
 
 
-class ConnectionUnavailableError(SurrealError):
+class TransportError(SurrealError):
+    """Transport-level failure that produced no structured server response.
+
+    Raised when a request could not be sent, could not be completed, or came
+    back in a form the SDK cannot interpret as an RPC result.  Distinct from
+    ``ServerError``, which represents a failure the server described in its
+    own structured error format.
+    """
+
+
+class ConnectionUnavailableError(TransportError):
     """No active connection to the database."""
+
+
+class TransportTimeoutError(TransportError):
+    """The request timed out before the server responded."""
+
+
+class HttpStatusError(TransportError):
+    """The server returned a non-2xx HTTP response for an RPC request.
+
+    Attributes:
+        status: The HTTP status code.
+        body: The response body decoded as text, truncated.  Empty when the
+            response had no body.
+        url: The URL the request was sent to.
+    """
+
+    def __init__(self, status: int, body: str, url: str) -> None:
+        detail = f": {body}" if body else ""
+        super().__init__(f"HTTP {status} from {url}{detail}")
+        self.status: int = status
+        self.body: str = body
+        self.url: str = url
 
 
 class UnsupportedEngineError(SurrealError):

--- a/tests/unit_tests/connections/transport_errors/conftest.py
+++ b/tests/unit_tests/connections/transport_errors/conftest.py
@@ -1,0 +1,14 @@
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_surrealdb_server() -> Generator[None, None, None]:
+    """Override the parent fixture: these tests are fully mocked.
+
+    The transport-error tests stub the HTTP transport with
+    ``responses``/``aioresponses`` and point the websocket transports at a
+    closed port, so they never touch a real SurrealDB server.
+    """
+    yield

--- a/tests/unit_tests/connections/transport_errors/test_transport_errors.py
+++ b/tests/unit_tests/connections/transport_errors/test_transport_errors.py
@@ -1,0 +1,267 @@
+"""Every transport failure surfaces as a ``SurrealError`` (issue #298).
+
+Non-2xx ``/rpc`` responses, unreachable hosts, timeouts and undecodable
+bodies used to escape as ``requests``/``aiohttp``/``websockets`` exceptions,
+so ``except SurrealError`` did not actually cover server failures.
+
+These are fully mocked and need no live server.
+"""
+
+import asyncio
+import socket
+
+import aiohttp
+import pytest
+import requests
+import responses
+from aioresponses import aioresponses
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.cbor import encode
+from surrealdb.errors import (
+    ConnectionUnavailableError,
+    HttpStatusError,
+    NotAllowedError,
+    SurrealError,
+    TransportError,
+    TransportTimeoutError,
+    UnexpectedResponseError,
+)
+
+URL = "http://localhost:8000"
+RPC = f"{URL}/rpc"
+
+
+def _closed_port() -> int:
+    """Return a port with nothing listening on it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+# ------------------------------------------------------------------ #
+#  Hierarchy                                                           #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "error_class",
+    [ConnectionUnavailableError, TransportTimeoutError, HttpStatusError],
+)
+def test_transport_errors_are_surreal_errors(
+    error_class: type[TransportError],
+) -> None:
+    assert issubclass(error_class, TransportError)
+    assert issubclass(error_class, SurrealError)
+
+
+# ------------------------------------------------------------------ #
+#  Blocking HTTP                                                       #
+# ------------------------------------------------------------------ #
+
+
+@responses.activate
+def test_blocking_http_non_2xx_raises_http_status_error() -> None:
+    """A 401 with a plain-text body reports the status, not ``HTTPError``."""
+    responses.add(responses.POST, RPC, body=b"InvalidToken", status=401)
+
+    connection = BlockingHttpSurrealConnection(URL)
+    connection.token = "not-a-valid-bearer-token"
+
+    with pytest.raises(HttpStatusError) as exc_info:
+        connection.version()
+
+    error = exc_info.value
+    assert isinstance(error, SurrealError)
+    assert error.status == 401
+    assert error.body == "InvalidToken"
+    assert error.url == RPC
+
+
+@responses.activate
+def test_blocking_http_non_2xx_json_body_is_preserved() -> None:
+    """The JSON envelope a 400 carries is kept on the error for triage."""
+    body = b'{"code":400,"information":"Parse error"}'
+    responses.add(responses.POST, RPC, body=body, status=400)
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    with pytest.raises(HttpStatusError) as exc_info:
+        connection.version()
+
+    assert exc_info.value.status == 400
+    assert "Parse error" in exc_info.value.body
+
+
+@responses.activate
+def test_blocking_http_non_2xx_with_rpc_body_keeps_server_error() -> None:
+    """A structured RPC error still maps to its ``ServerError`` subclass."""
+    body = encode(
+        {
+            "id": "1",
+            "error": {
+                "kind": "NotAllowed",
+                "code": -32002,
+                "message": "There was a problem with authentication",
+            },
+        }
+    )
+    responses.add(responses.POST, RPC, body=body, status=403)
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    with pytest.raises(NotAllowedError) as exc_info:
+        connection.version()
+
+    assert exc_info.value.kind == "NotAllowed"
+
+
+@responses.activate
+def test_blocking_http_unreachable_host_raises_connection_unavailable() -> None:
+    responses.add(
+        responses.POST, RPC, body=requests.exceptions.ConnectionError("refused")
+    )
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    with pytest.raises(ConnectionUnavailableError):
+        connection.version()
+
+
+@responses.activate
+def test_blocking_http_timeout_raises_transport_timeout() -> None:
+    responses.add(responses.POST, RPC, body=requests.exceptions.ReadTimeout("slow"))
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    with pytest.raises(TransportTimeoutError):
+        connection.version()
+
+
+@responses.activate
+def test_blocking_http_undecodable_2xx_body_raises_unexpected_response() -> None:
+    """A 200 the SDK cannot decode is an SDK error, not a CBOR error."""
+    responses.add(responses.POST, RPC, body=b'{"not":"cbor"}', status=200)
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    with pytest.raises(UnexpectedResponseError):
+        connection.version()
+
+
+@responses.activate
+def test_blocking_http_success_is_unaffected() -> None:
+    responses.add(
+        responses.POST, RPC, body=encode({"id": "1", "result": "3.2.3"}), status=200
+    )
+
+    connection = BlockingHttpSurrealConnection(URL)
+
+    assert connection.version() == "3.2.3"
+
+
+# ------------------------------------------------------------------ #
+#  Async HTTP                                                          #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_async_http_non_2xx_raises_http_status_error() -> None:
+    connection = AsyncHttpSurrealConnection(URL)
+    connection.token = "not-a-valid-bearer-token"
+
+    with aioresponses() as mocked:
+        mocked.post(RPC, status=401, body=b"InvalidToken")
+
+        with pytest.raises(HttpStatusError) as exc_info:
+            await connection.version()
+
+    error = exc_info.value
+    assert isinstance(error, SurrealError)
+    assert error.status == 401
+    assert error.body == "InvalidToken"
+
+
+@pytest.mark.asyncio
+async def test_async_http_non_2xx_with_rpc_body_keeps_server_error() -> None:
+    body = encode(
+        {
+            "id": "1",
+            "error": {
+                "kind": "NotAllowed",
+                "code": -32002,
+                "message": "There was a problem with authentication",
+            },
+        }
+    )
+    connection = AsyncHttpSurrealConnection(URL)
+
+    with aioresponses() as mocked:
+        mocked.post(RPC, status=403, body=body)
+
+        with pytest.raises(NotAllowedError):
+            await connection.version()
+
+
+@pytest.mark.asyncio
+async def test_async_http_unreachable_host_raises_connection_unavailable() -> None:
+    connection = AsyncHttpSurrealConnection(URL)
+
+    with aioresponses() as mocked:
+        mocked.post(RPC, exception=aiohttp.ClientConnectionError("refused"))
+
+        with pytest.raises(ConnectionUnavailableError):
+            await connection.version()
+
+
+@pytest.mark.asyncio
+async def test_async_http_timeout_raises_transport_timeout() -> None:
+    connection = AsyncHttpSurrealConnection(URL)
+
+    with aioresponses() as mocked:
+        mocked.post(RPC, exception=asyncio.TimeoutError())
+
+        with pytest.raises(TransportTimeoutError):
+            await connection.version()
+
+
+@pytest.mark.asyncio
+async def test_async_http_undecodable_2xx_body_raises_unexpected_response() -> None:
+    connection = AsyncHttpSurrealConnection(URL)
+
+    with aioresponses() as mocked:
+        mocked.post(RPC, status=200, body=b'{"not":"cbor"}')
+
+        with pytest.raises(UnexpectedResponseError):
+            await connection.version()
+
+
+# ------------------------------------------------------------------ #
+#  WebSocket                                                           #
+# ------------------------------------------------------------------ #
+
+
+def test_blocking_ws_unreachable_host_raises_connection_unavailable() -> None:
+    connection = BlockingWsSurrealConnection(f"ws://127.0.0.1:{_closed_port()}")
+
+    with pytest.raises(ConnectionUnavailableError):
+        connection.version()
+
+
+def test_blocking_ws_context_manager_unreachable_host_raises() -> None:
+    connection = BlockingWsSurrealConnection(f"ws://127.0.0.1:{_closed_port()}")
+
+    with pytest.raises(ConnectionUnavailableError):
+        with connection:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_async_ws_unreachable_host_raises_connection_unavailable() -> None:
+    connection = AsyncWsSurrealConnection(f"ws://127.0.0.1:{_closed_port()}")
+
+    with pytest.raises(ConnectionUnavailableError):
+        await connection.connect()


### PR DESCRIPTION
Fixes https://github.com/surrealdb/surrealdb.py/issues/298.

## The bug

`errors.py` promises that every error the SDK raises extends `SurrealError`, so `except SurrealError` catches everything. It didn't. The exception type depended on *how* a failure happened to be represented, which is not something callers can predict.

Reproduced against SurrealDB 3.2.3 on `main`:

| Case | Before | After |
| --- | --- | --- |
| HTTP, non-2xx `/rpc` (sync) | `requests.exceptions.HTTPError` | `HttpStatusError` |
| HTTP, non-2xx `/rpc` (async) | `aiohttp.ClientResponseError` | `HttpStatusError` |
| HTTP, unreachable host (sync) | `requests.exceptions.ConnectionError` | `ConnectionUnavailableError` |
| HTTP, unreachable host (async) | `aiohttp.ClientConnectorError` | `ConnectionUnavailableError` |
| WS, unreachable host | `ConnectionRefusedError` | `ConnectionUnavailableError` |
| Undecodable response body | CBOR decode error | `UnexpectedResponseError` |
| RPC error in a 2xx body | `ServerError` subclass | unchanged |

The issue reported the first two rows. The rest are the same hole in the same contract, so this closes all of them.

## The change

A `TransportError` branch alongside `ServerError`, for failures that produced no structured server response:

```
SurrealError
├── ServerError          the server ran your request and rejected it
└── TransportError       the request never produced a structured response
    ├── ConnectionUnavailableError   (existing class, re-parented)
    ├── TransportTimeoutError
    └── HttpStatusError             .status / .body / .url
```

That split is what retry logic actually keys on: a `TransportError` may succeed if retried, a `ServerError` describes a decision the server already made. Re-parenting `ConnectionUnavailableError` is backwards compatible — it remains a `SurrealError`.

All four transports (blocking/async × HTTP/WebSocket) now map their failures onto that branch and keep the original exception as `__cause__`.

## Two things worth reviewing

**Non-2xx responses do not become `ServerError` subclasses.** The issue suggested mapping structured RPC errors found in non-2xx bodies. I probed what the server actually sends and that path is essentially unreachable today — RPC errors always come back `200` with an `error` body, while non-2xx is answered at the HTTP layer:

- `401` → `content-length: 12`, plain text `InvalidToken`
- `400` → JSON `{"code":400,"information":"Parse error",...}`, an HTTP envelope, not the RPC shape

So an invalid bearer token surfaces as `HttpStatusError` with `.status == 401`, not `NotAllowedError`. Deriving `NotAllowedError` from the status alone would mean fabricating a structured `kind` from an HTTP code. The RPC body is still checked first, so a server that ever does report a structured error alongside a non-2xx status keeps its `ServerError` mapping.

**The obvious fix doesn't work.** Simply moving `raise_for_status()` after `decode()` would silently produce garbage: `decode(b"InvalidToken")` returns `b'nvalidTok'` rather than raising. The status check has to gate the decode, and the decode itself is wrapped.

## Testing

- 18 new tests in `tests/unit_tests/connections/transport_errors/`, fully mocked (`responses` / `aioresponses` / a closed port), covering each leak path per transport, the preserved `ServerError` path, and the hierarchy itself.
- Full suite: 1002 passed. The 25 `embedded` failures in my local run are a missing Rust extension build in the venv and reproduce identically on a pristine checkout.
- `./scripts/checks.sh` clean: ruff, ruff format, mypy `src/` + `tests/`, pyright.
- Re-verified end to end against a live SurrealDB 3.2.3.

## Not included

`surrealdb.spectron` has its own self-contained `SpectronError` tree and already wraps its transport failures into `SpectronAPIError`. It's a separate Cloud API client rather than an `/rpc` transport, so `except SurrealError` was never its contract.

Invalid *inputs* still raise plain `ValueError` / `TypeError` before anything is sent, per `AGENTS.md`.