### PR TITLE
Release 3.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.1] - 2026-08-09
+
+First beta on the 3.0.0 track. The v3 API surface settled over the alpha series is now considered feature-complete, and this release closes the last two gaps in it: every failure the SDK raises is a `SurrealError`, and the session/transaction wrappers expose the full connection RPC set. Both packages move to the `Development Status :: 4 - Beta` classifier.
+
 ### Added
 - `TransportError`, a new branch of the error hierarchy for failures that produced no structured server response, alongside the existing `ServerError` branch. `ConnectionUnavailableError` now derives from it, joined by `TransportTimeoutError` (the request timed out) and `HttpStatusError` (a non-2xx HTTP response, carrying `.status`, `.body`, and `.url`). The split is what retry logic keys on: a `TransportError` may succeed if retried, a `ServerError` describes a decision the server already made.
 - `query_raw()`, `info()`, and `version()` on the session and transaction wrapper classes (`AsyncSurrealSession` / `BlockingSurrealSession`, `AsyncSurrealTransaction` / `BlockingSurrealTransaction`). These were the only connection RPCs missing from the wrappers, so calling `session.query_raw(...)` raised `AttributeError` even though the underlying connection method already accepted `session_id` / `txn_id`. Each forwards the session (and, on a transaction, the txn) like every other wrapper method.
 
 ### Fixed
 - Transport failures no longer escape as third-party exceptions, so `except SurrealError` now reliably covers every failure the SDK raises. Previously the exception type depended on how a failure was represented: an RPC error in a 2xx body became a `ServerError`, but a non-2xx `/rpc` response leaked `requests.exceptions.HTTPError` or `aiohttp.ClientResponseError`, an unreachable host leaked `requests.exceptions.ConnectionError` / `aiohttp.ClientConnectorError` / `ConnectionRefusedError`, and an undecodable body leaked a CBOR decode error. All four transports (blocking/async, HTTP/WebSocket) now map these to `HttpStatusError`, `ConnectionUnavailableError`, `TransportTimeoutError`, or `UnexpectedResponseError`, each preserving the original exception as `__cause__`. A non-2xx response whose body *does* contain a structured RPC error still maps to its `ServerError` subclass.
+
+### Changed
+- Both `surrealdb` and `surrealdb-embedded` now declare `Development Status :: 4 - Beta` instead of `3 - Alpha`. Packaging metadata only; no code changes.
 
 ## [3.0.0-alpha.4] - 2026-07-16
 
@@ -186,7 +193,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.1...HEAD
+[3.0.0-beta.1]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...v3.0.0-beta.1
 [3.0.0-alpha.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.3...v3.0.0-alpha.4
 [3.0.0-alpha.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.2...v3.0.0-alpha.3
 [3.0.0-alpha.2]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.1...v3.0.0-alpha.2

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-alpha.3"
+version = "3.0.0-beta.1"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-alpha.4"
+version = "3.0.0-beta.1"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-alpha.4"
+version = "3.0.0-beta.1"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"
 keywords = ["SurrealDB", "Database", "Embedded"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-alpha.4"
+version = "3.0.0-beta.1"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 keywords = ["SurrealDB", "Database"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
@@ -41,7 +41,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-alpha.4",
+    "surrealdb-embedded==3.0.0-beta.1",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0a4"
+version = "3.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1563,7 +1563,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0a4"
+version = "3.0.0b1"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
First beta on the 3.0.0 track. The v3 API surface settled over the alpha series is now feature-complete, and this release closes the last two gaps in it: the transport error hierarchy (so `except SurrealError` covers every failure the SDK raises) and the missing `query_raw()` / `info()` / `version()` methods on the session and transaction wrappers.

Bumps both packages to `3.0.0-beta.1` (→ `3.0.0b1`), keeps the embedded pin in lockstep, moves both `Development Status` classifiers from `3 - Alpha` to `4 - Beta`, refreshes both lockfiles, and adds the CHANGELOG entry. Also fixes `embedded/Cargo.lock`, which had been left at `3.0.0-alpha.3` by the previous two releases.

Publishing the `v3.0.0-beta.1` GitHub pre-release triggers the PyPI publish for both packages. Install: `pip install --pre surrealdb==3.0.0b1`.
