### PR TITLE
Release 3.0.0-beta.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build wheels
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
@@ -97,7 +97,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build wheels
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
@@ -125,7 +125,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build wheels
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
@@ -152,7 +152,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build wheels
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
@@ -176,7 +176,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Build sdist
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist
@@ -212,7 +212,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 
@@ -243,6 +243,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true

--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0 # need full history
 
-      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const tag = context.payload.release.tag_name;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.2] - 2026-08-10
+
+A maintenance beta. No API changes: the notable part is that the embedded engine moves from SurrealDB 3.0 to 3.2, and that the dependency surface is now watched rather than hand-bumped.
+
 ### Changed
 - The `surrealdb-embedded` extension now builds against `surrealdb-core` 3.2.4, up from 3.0.5, so `mem://`, `file://` and `surrealkv://` connections run the 3.2 engine and pick up everything that landed in 3.1 and 3.2. The native glue moved with the `RpcProtocol` trait: its session map is now keyed by a concrete `Uuid` rather than `Option<Uuid>`, so the embedded connection's single implicit session is registered under a generated id and every request without a session id routes to it. Behaviour is unchanged - the embedded connection has never supported `attach`/`detach` or client-side transactions, and `use`/`signin` state still persists across calls on a connection. CBOR request decoding now bounds nesting with the datastore's `max_object_parsing_depth` (default 100), matching what the server applies to its own parsers.
 - Refreshed the rest of the dependency surface: every pinned GitHub Actions workflow dependency moved to its current release, the Python lockfile moved to current (notably `mypy` 2.3.0 and `ruff` 0.16.2), and the CI/docker-compose SurrealDB server versions moved to the latest patch of each series already covered (`v2.1.9`, `v3.0.5`). `aiohttp` stays capped below 3.14 for resolution only - `aioresponses` 0.7.9 still cannot construct 3.14's `ClientResponse` - and the cap remains absent from published wheel metadata.
@@ -200,7 +204,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.1...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.2...HEAD
+[3.0.0-beta.2]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.1...v3.0.0-beta.2
 [3.0.0-beta.1]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...v3.0.0-beta.1
 [3.0.0-alpha.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.3...v3.0.0-alpha.4
 [3.0.0-alpha.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.2...v3.0.0-alpha.3

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -41,7 +41,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.1",
+    "surrealdb-embedded==3.0.0-beta.2",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1580,7 +1580,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b1"
+version = "3.0.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1665,7 +1665,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b1"
+version = "3.0.0b2"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Cut `3.0.0-beta.2`. The only change since `3.0.0-beta.1` is #303, which moved the embedded engine from SurrealDB 3.0 to 3.2 and refreshed the dependency surface, so this is a maintenance beta with no API changes.

It also carries a fix that has to land before any release can succeed — see below.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Two commits.

### 1. `Pin the annotated-tag actions to their commit SHAs` — please read this one

**#303 left `main` unable to publish a release.** Three of the actions it re-pinned use *annotated* tags, so `git/ref/tags/<tag>` resolves to the tag object rather than the commit it points at, and `uses:` cannot resolve a tag object:

| action | #303 pinned | correct commit |
|---|---|---|
| `actions/github-script` v9.0.0 | `d746ffe` | `3a2844b` |
| `PyO3/maturin-action` v1.51.0 | `3e2bdf6` | `e83996d` |
| `pypa/gh-action-pypi-publish` v1.14.2 | `a892a5a` | `dc37677` |

That would have failed every wheel build and both PyPI uploads in `build.yml`, plus the single step in `release-comment.yml`. `ci.yml` was unaffected because every action it uses publishes lightweight tags — which is precisely why #303 went green on 36 checks and this was invisible.

`maturin-action` lands back on `e83996d`, the value it already held before #303: v1.51.0 was already the pinned release there, so that "bump" was a no-op that only broke the pin.

Dependabot #304 independently proposed these same three commits, so that PR becomes redundant once this merges. The fix is included here rather than taken from #304 because it has to be in the tagged commit for the release build to work at all.

### 2. `Release 3.0.0-beta.2`

Standard release mechanics: version bumped in the four places that must stay in lockstep (`pyproject.toml` `version`, the `surrealdb-embedded==` pin in its `embedded` extra, `embedded/pyproject.toml`, `embedded/Cargo.toml`), both lockfiles refreshed (`uv.lock` normalises to `3.0.0b2`; `embedded/Cargo.lock` is a minimal one-line version refresh), and the changelog `[Unreleased]` section promoted with a fresh empty one and both compare links updated.

No `Development Status` classifier move — both packages are already `4 - Beta` from beta.1.

## What is your testing strategy?

- `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` — all clean.
- `uv build --wheel` produces `surrealdb-3.0.0b2-py3-none-any.whl` and `surrealdb/py.typed` is present in it, mirroring the CI packaging job.
- `importlib.metadata.version("surrealdb")` reports `3.0.0b2` after `uv sync`, confirming the four version sites and `uv.lock` agree.
- Rebuilt the embedded extension at the new version and ran the full suite.
- Verified every one of the ten action pins resolves to a real commit, and that each matches the commit its version comment names — the check that should have run on #303.

The release build itself (`build.yml`) only runs on `release: published`, so the corrected pins in it are verified by inspection against the GitHub API rather than by CI on this PR.

## Is this related to any issues?

Supersedes #304. Releases #303.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
