### PR TITLE
Report the engine version from embedded connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `version()` on an embedded connection now reports the SurrealDB engine version rather than the version of the `surrealdb-embedded` extension. The RPC handler formatted the extension crate's own `CARGO_PKG_VERSION`, so `mem://`, `file://` and `surrealkv://` connections answered `surrealdb-3.0.0-beta.2` while the engine they actually run is `surrealdb-core` 3.2.4 - the opposite of what the same call returns over HTTP or WebSocket, and misleading in the very release that moved the embedded engine to 3.2. Both the async and blocking implementations now read `surrealdb_core::env::VERSION`, which is compiled into the engine and so cannot disagree with what the wheel links. The extension's own version remains available as `importlib.metadata.version("surrealdb-embedded")`. Embedded version strings carry no `+<date>.<sha>` build metadata, because that suffix is derived from a git checkout of the SurrealDB monorepo and does not exist for an engine built from a published crate.
+
 ## [3.0.0-beta.2] - 2026-08-10
 
 A maintenance beta. No API changes: the notable part is that the embedded engine moves from SurrealDB 3.0 to 3.2, and that the dependency surface is now watched rather than hand-bumped.

--- a/embedded/src/surrealdb_ext/async_db.rs
+++ b/embedded/src/surrealdb_ext/async_db.rs
@@ -175,9 +175,16 @@ impl RpcProtocol for AsyncEmbeddedDBInner {
     }
 
     fn version_data(&self) -> DbResult {
-        DbResult::Other(PublicValue::String(
-            format!("surrealdb-{}", env!("CARGO_PKG_VERSION")).into(),
-        ))
+        // The engine that is linked, not this wrapper crate. `CARGO_PKG_VERSION`
+        // here would be surrealdb-embedded's own version, which says nothing
+        // about the database being run and disagrees with what the same call
+        // returns over HTTP or WebSocket. `env::VERSION` is baked into
+        // surrealdb-core when it is compiled, so it cannot drift from the
+        // engine actually inside the wheel.
+        DbResult::Other(PublicValue::String(format!(
+            "surrealdb-{}",
+            surrealdb_core::env::VERSION
+        )))
     }
 
     fn session_map(&self) -> &HashMap<Uuid, Arc<RwLock<Session>>> {

--- a/embedded/src/surrealdb_ext/sync_db.rs
+++ b/embedded/src/surrealdb_ext/sync_db.rs
@@ -178,9 +178,16 @@ impl RpcProtocol for SyncEmbeddedDBInner {
     }
 
     fn version_data(&self) -> DbResult {
-        DbResult::Other(PublicValue::String(
-            format!("surrealdb-{}", env!("CARGO_PKG_VERSION")).into(),
-        ))
+        // The engine that is linked, not this wrapper crate. `CARGO_PKG_VERSION`
+        // here would be surrealdb-embedded's own version, which says nothing
+        // about the database being run and disagrees with what the same call
+        // returns over HTTP or WebSocket. `env::VERSION` is baked into
+        // surrealdb-core when it is compiled, so it cannot drift from the
+        // engine actually inside the wheel.
+        DbResult::Other(PublicValue::String(format!(
+            "surrealdb-{}",
+            surrealdb_core::env::VERSION
+        )))
     }
 
     fn session_map(&self) -> &HashMap<Uuid, Arc<RwLock<Session>>> {

--- a/tests/unit_tests/connections/embedded/test_version.py
+++ b/tests/unit_tests/connections/embedded/test_version.py
@@ -1,0 +1,33 @@
+"""Tests that embedded connections report the SurrealDB engine version."""
+
+from surrealdb import AsyncSurreal, Surreal
+
+# The engine floor is the `surrealdb-core = "3"` requirement in
+# embedded/Cargo.toml narrowed to the minor series currently resolved. It is
+# deliberately not compared against the extension's own version: the SDK line
+# and the engine line both track SurrealDB majors, so they will eventually
+# collide on the same number and an inequality would fail bafflingly.
+MINIMUM_ENGINE_VERSION = (3, 2)
+
+
+def _assert_engine_version(version: str) -> None:
+    assert version.startswith("surrealdb-"), version
+    engine = version.removeprefix("surrealdb-")
+    major, minor = engine.split(".")[:2]
+    assert (int(major), int(minor)) >= MINIMUM_ENGINE_VERSION, version
+
+
+def test_blocking_version_reports_engine() -> None:
+    """The blocking embedded connection reports the linked engine version."""
+    with Surreal("mem://") as db:
+        db.use("test", "test")
+
+        _assert_engine_version(db.version())
+
+
+async def test_async_version_reports_engine() -> None:
+    """The async embedded connection reports the linked engine version."""
+    async with AsyncSurreal("mem://") as db:
+        await db.use("test", "test")
+
+        _assert_engine_version(await db.version())


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`db.version()` on an embedded connection reported the version of the `surrealdb-embedded` extension, not the SurrealDB engine it runs.

```
>>> with Surreal("mem://") as db: db.version()
'surrealdb-3.0.0-beta.2'      # before - the Python extension's version
'surrealdb-3.2.4'             # after  - the engine actually linked
```

The same call over HTTP or WebSocket returns the engine version, so embedded was the odd one out. It was most misleading in 3.0.0-beta.2 itself: that release's headline change was moving the embedded engine from SurrealDB 3.0 to 3.2, and `version()` was the only API a user had to confirm it — reporting a string that reads as 3.0.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

`RpcProtocol::version_data()` formatted `env!("CARGO_PKG_VERSION")`, which inside this crate is `surrealdb-embedded`'s own version. Both the async and blocking implementations now read `surrealdb_core::env::VERSION`.

Two lines, no `Cargo.toml` change, no `build.rs`, no new dependency — `surrealdb-core` is already a direct dependency and exports the constant unconditionally (`pub mod env;` carries no `#[cfg]`, so it is reachable under `default-features = false`).

**Why that constant rather than the alternatives.** `env::VERSION` is compiled into the engine, so it cannot disagree with the engine inside the wheel. A `build.rs` reading `cargo metadata`, the `built` crate, or a hardcoded constant policed by a lockfile test all describe the *resolved graph* rather than the *linked artifact*. That distinction is not hypothetical here: `embedded/Cargo.toml` pins only `version = "3"`, and `ci.yml` builds without `--locked`.

**No `+<date>.<sha>` suffix.** A released server reports e.g. `surrealdb-3.2.3+20260721.40522d1`. That build metadata comes from a git checkout of the SurrealDB monorepo, injected at build time; it does not exist for an engine built from a published crate. Its absence is the correct signal rather than something to fake.

**The extension's own version is not lost** — it remains available as `importlib.metadata.version("surrealdb-embedded")`, which returns `3.0.0b2`.

## What is your testing strategy?

Added `tests/unit_tests/connections/embedded/test_version.py`, covering both the blocking and async embedded connections. It runs in the existing `test-embedded` CI job across Python 3.10–3.13 with no workflow change, and needs no live server.

- Verified the actual string: `surrealdb-3.2.4`, matching `embedded/Cargo.lock` exactly.
- The new test is a real regression guard, not decoration — it fails on the pre-fix build, where the assertion reduces to `(3, 0) >= (3, 2)`.
- Embedded suite: 27 passed (was 25). Full suite: 638 passed (was 636).
- `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.

**Reviewers: rebuild the extension before running the test** — a stale `_ext.abi3.so` still returns the old string and the test will fail for the wrong reason:

```bash
uv run maturin develop --release --manifest-path embedded/Cargo.toml
```

The test asserts an engine floor of `(3, 2)` rather than comparing against the extension's version. An inequality between the two would eventually false-positive: both version lines track SurrealDB majors, so `surrealdb-embedded` 3.2.4 and `surrealdb-core` 3.2.4 will plausibly coincide one day and the test would fail bafflingly.

## Is this related to any issues?

Follow-up from the 3.0.0-beta.2 release. Not user-reported.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md

---

### Is this breaking?

No, and I checked rather than assumed. Nothing in `src/surrealdb` parses or branches on the version string — the four call sites are one-line wrapper forwarders. No test asserts an embedded version. No README, docstring or changelog documents the old format. The two conftests that do match on a version string check `"surrealdb-3." in version_str`, which both the old and new values satisfy.

The one thing I could not audit is user code in the wild doing an exact-string match against `surrealdb-3.0.0-beta.2`. Semver-parsing consumers are fine: the official Rust SDK strips the `surrealdb-` prefix and parses the remainder, which both strings satisfy.

### Deliberately not done

- **Chasing the server's `+<date>.<sha>` suffix** — structurally unavailable to a crates.io consumer.
- **Dropping the `surrealdb-` prefix** to match the Rust SDK's local engine. This SDK's own HTTP/WS transports emit it, and two conftests match on it.
- **A composite string** like `surrealdb-3.2.4+py.3.0.0-beta.2` — invents a format no other SurrealDB client produces, to solve a provenance problem nobody has reported.
- **Exposing an engine-version accessor on the PyO3 extension** so the test could assert exact equality — new public API surface for a two-line bugfix.

One honest caveat: the reported value now moves with `surrealdb-core` rather than with this repo's source, so it changes without a diff. That is the intended behaviour — the point is to report what is linked — and `.github/dependabot.yml` already excludes `surrealdb-core`/`surrealdb-types` from grouped Rust updates so each engine bump arrives as its own reviewable PR.
