### PR TITLE
Release 3.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.3] - 2026-08-10
+
+A small correctness and dependency release. Embedded connections now report the engine version they actually run, and the `aiohttp` floor moves onto the release carrying CVE-2026-34993's fix.
+
 ### Fixed
 - `version()` on an embedded connection now reports the SurrealDB engine version rather than the version of the `surrealdb-embedded` extension. The RPC handler formatted the extension crate's own `CARGO_PKG_VERSION`, so `mem://`, `file://` and `surrealkv://` connections answered `surrealdb-3.0.0-beta.2` while the engine they actually run is `surrealdb-core` 3.2.4 - the opposite of what the same call returns over HTTP or WebSocket, and misleading in the very release that moved the embedded engine to 3.2. Both the async and blocking implementations now read `surrealdb_core::env::VERSION`, which is compiled into the engine and so cannot disagree with what the wheel links. The extension's own version remains available as `importlib.metadata.version("surrealdb-embedded")`. Embedded version strings carry no `+<date>.<sha>` build metadata, because that suffix is derived from a git checkout of the SurrealDB monorepo and does not exist for an engine built from a published crate.
 
@@ -211,7 +215,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.2...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.3...HEAD
+[3.0.0-beta.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.2...v3.0.0-beta.3
 [3.0.0-beta.2]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.1...v3.0.0-beta.2
 [3.0.0-beta.1]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...v3.0.0-beta.1
 [3.0.0-alpha.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.3...v3.0.0-alpha.4

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -46,7 +46,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.2",
+    "surrealdb-embedded==3.0.0-beta.3",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b2"
+version = "3.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1662,7 +1662,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b2"
+version = "3.0.0b3"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Cut `3.0.0-beta.3`. Two user-facing changes have landed since `3.0.0-beta.2`, and neither reaches users without a release.

The `version()` fix in particular is worth shipping promptly: beta.2's headline change was moving the embedded engine from SurrealDB 3.0 to 3.2, and a beta.2 user who calls `version()` to confirm that sees `surrealdb-3.0.0-beta.2`. The release currently contradicts its own changelog from the only API that can verify it.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Release mechanics only — no source changes.

- Version bumped in the four sites that must stay in lockstep: `pyproject.toml` `version`, the `surrealdb-embedded==` pin in its `embedded` extra, `embedded/pyproject.toml`, `embedded/Cargo.toml`.
- Both lockfiles refreshed: `uv.lock` normalises to `3.0.0b3`; `embedded/Cargo.lock` is a one-line version refresh.
- Changelog `[Unreleased]` promoted with a fresh empty section and both compare links updated.

No `Development Status` classifier move — both packages are already `4 - Beta`.

### What ships

- **#306** — `version()` on an embedded connection reports the SurrealDB engine version (`surrealdb-3.2.4`) rather than the extension's own version.
- **#307** — the `aiohttp` floor moves to `>=3.14.0`, the first release carrying the fix for CVE-2026-34993 (GHSA-jg22-mg44-37j8). The vulnerable `CookieJar.load()` path is not reachable through this SDK, so this is hygiene rather than an exploitable fix.

#307 also dropped `aioresponses` and the `aiohttp<3.14` cap, but that is test infrastructure and invisible to users.

**Worth flagging:** the `aiohttp` floor bump is the one non-additive change here. Anyone pinned to `aiohttp<3.14` for unrelated reasons will hit a resolution conflict on upgrade. That is acceptable on a beta line and is precisely why it is better shipped now than carried into stable.

## What is your testing strategy?

Verified at the release version, with the extension rebuilt and a live SurrealDB 3.2.3:

- **HTTP: 1029 passed**, 1 xfailed, 3 xpassed
- **WebSocket: 1029 passed**, 1 xfailed, 3 xpassed
- `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.
- `uv build --wheel` produces `surrealdb-3.0.0b3-py3-none-any.whl` with `surrealdb/py.typed` present, mirroring the CI packaging job.
- All four version sites verified programmatically to hold the same string; `importlib.metadata` reports `3.0.0b3` for both packages.
- Confirmed the two versions stay correctly distinct: the `surrealdb-embedded` package is `3.0.0b3` while `version()` returns `surrealdb-3.2.4`, which is the separation #306 introduced.

## Is this related to any issues?

Releases #306 and #307.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
