### PR TITLE
Release 3.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.4] - 2026-08-10
+
+Seven defects found by verifying the 3.0.0-beta.3 artifacts as a user installs them, rather than from the working tree. Most sit on the default `pip install surrealdb` path, which the test suite never exercised because it always has the optional engine present.
+
 ### Fixed
 - `from surrealdb import *` no longer raises `AttributeError` on a plain `pip install surrealdb`. `__all__` advertised `AsyncEmbeddedSurrealConnection` and `BlockingEmbeddedSurrealConnection` unconditionally, but both are imported under a `try`/`except ImportError` and are absent without the optional `surrealdb[embedded]` engine - so the default install exported two names that did not exist, breaking star imports and anything that walks `__all__`. They now join `__all__` only when the engine is present, and accessing either without it raises an `AttributeError` naming the extra to install.
 - An unsupported URL scheme now raises `UnsupportedEngineError` rather than a bare `ValueError` escaping from enum construction. `Surreal("ftp://...")`, `Surreal("rocksdb://...")` and `Surreal("localhost:8000")` all previously raised `ValueError: '...' is not a valid UrlScheme`, which `except SurrealError` did not catch - contradicting the guarantee that every failure the SDK raises is a `SurrealError`. The original `ValueError` is preserved as `__cause__`. **This changes the exception type**: code catching `ValueError` from connection construction should catch `SurrealError` (or `UnsupportedEngineError`) instead.
@@ -226,7 +230,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.4...HEAD
+[3.0.0-beta.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.3...v3.0.0-beta.4
 [3.0.0-beta.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.2...v3.0.0-beta.3
 [3.0.0-beta.2]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.1...v3.0.0-beta.2
 [3.0.0-beta.1]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-alpha.4...v3.0.0-beta.1

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.4"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.4"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.4"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.4"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -46,7 +46,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.3",
+    "surrealdb-embedded==3.0.0-beta.4",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b3"
+version = "3.0.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1662,7 +1662,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b3"
+version = "3.0.0b4"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Cut `3.0.0-beta.4`, shipping the seven defects fixed in #309.

Those were found by verifying the beta.3 artifacts the way a user installs them, rather than from the working tree — and most of them sit on the default `pip install surrealdb` path, which the test suite had never exercised because the repo always has the optional engine present. `from surrealdb import *` was broken on that path, and `Surreal("memory")` never worked despite being documented.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Release mechanics only — no source changes.

- Version bumped in the four sites that must stay in lockstep: `pyproject.toml` `version`, the `surrealdb-embedded==` pin in its `embedded` extra, `embedded/pyproject.toml`, `embedded/Cargo.toml`.
- Both lockfiles refreshed: `uv.lock` normalises to `3.0.0b4`; `embedded/Cargo.lock` is a one-line version refresh.
- Changelog `[Unreleased]` promoted with a fresh empty section and both compare links updated.

No `Development Status` classifier move — both packages are already `4 - Beta`.

### What ships

All from #309:

1. `from surrealdb import *` no longer raises `AttributeError` on a bare install
2. Unsupported URL schemes raise `UnsupportedEngineError` instead of escaping as a bare `ValueError` 💥
3. `Surreal("memory")` works, as the README and the SDK's own error message have always claimed
4. `surrealdb-embedded` ships a `py.typed` marker, so its bundled stubs are no longer ignored
5. `connect()` works on the HTTP connections instead of raising `NotImplementedError`
6. A trailing slash no longer doubles the `/rpc` separator (`http://host//rpc`)
7. The sdist carries `src`, `tests` and docs instead of the entire working tree — 480 KB → 220 KB

**The breaking one is item 2.** Code catching `ValueError` from connection construction must catch `SurrealError` (or `UnsupportedEngineError`). This was ratified as the intended behaviour: the guarantee 3.0.0-beta.1 shipped is that every failure the SDK raises is a `SurrealError`, and enum construction was leaking straight past it. A beta is the right place to settle that, before stable freezes the contract.

## What is your testing strategy?

Verified at the release version, with the extension rebuilt and a live SurrealDB 3.2.3:

- **HTTP: 1047 passed**, 1 xfailed, 3 xpassed
- **WebSocket: 1047 passed**, 1 xfailed, 3 xpassed
- `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.
- `uv build` produces `surrealdb-3.0.0b4-py3-none-any.whl` with `surrealdb/py.typed` present, and the sdist stays trimmed (`src`, `tests`, `README.md`, `LICENSE`, `CHANGELOG.md`, `pyproject.toml`).
- All four version sites verified programmatically to hold the same string.

## Is this related to any issues?

Releases #309.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
