### PR TITLE
Add connect() to the blocking websocket connection, and fix the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `connect()` now exists on `BlockingWsSurrealConnection`. It was the only connection class without it, so calling `connect()` raised `AttributeError` there while the other five transports connected - the same transport-agnostic breakage that adding `connect()` to the HTTP connections in 3.0.0-beta.4 was meant to remove. It opens the socket eagerly (the connection otherwise connects lazily on first use), is a no-op when already connected, and re-points the connection when passed a url, matching the other transports. Both connection templates now declare `connect()` as well, so a transport that omits it fails with a diagnosable `NotImplementedError` rather than `AttributeError`.
+- The README no longer states that the embedded database is included in the default install. It is an optional native extension behind the `embedded` extra, so the documented `pip install surrealdb` left readers without the engine they had just been told they had. The section now shows `pip install 'surrealdb[embedded]'`, and its source-build command gained the `--manifest-path embedded/Cargo.toml` it needs to build the Rust crate rather than the root project.
+
 ## [3.0.0-beta.4] - 2026-08-10
 
 Seven defects found by verifying the 3.0.0-beta.3 artifacts as a user installs them, rather than from the working tree. Most sit on the default `pip install surrealdb` path, which the test suite never exercised because it always has the optional engine present.

--- a/README.md
+++ b/README.md
@@ -551,24 +551,27 @@ SurrealDB can also run embedded directly within your Python application natively
 
 ### Installation
 
-The embedded database is included when you install `surrealdb`.
-
-Install the SDK using `pip`:
+The embedded database ships as an optional native extension, `surrealdb-embedded`,
+so it is **not** part of the default install. Request it with the `embedded` extra:
 
 ```bash
-pip install surrealdb
+pip install 'surrealdb[embedded]'
 ```
 
 Or install using `uv`:
 
 ```bash
-uv add surrealdb
+uv add 'surrealdb[embedded]'
 ```
+
+Without the extra, an embedded URL raises `UnsupportedEngineError` telling you to
+install it - the remote `http://`, `https://`, `ws://` and `wss://` connections work
+either way.
 
 For source builds, you'll need Rust toolchain and maturin:
 
 ```sh
-uv run maturin develop --release
+uv run maturin develop --release --manifest-path embedded/Cargo.toml
 ```
 
 ### In-Memory Database

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -96,6 +96,29 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                 f"could not connect to {self.raw_url}: {exc}"
             ) from exc
 
+    def connect(self, url: str | None = None) -> None:
+        """Open the websocket.
+
+        ``_send`` connects lazily on first use, so this is not required - but
+        it was the only connection class without it, which meant code written
+        against the connection API raised ``AttributeError`` here while every
+        other transport connected. Calling it eagerly also surfaces an
+        unreachable endpoint at ``connect()`` rather than at the first query.
+
+        Idempotent: a no-op when the socket is already open. Passing *url*
+        re-points the connection, matching the other transports.
+        """
+        if self.socket:
+            return
+
+        if url is not None:
+            self.url = Url(url)
+            self.raw_url = f"{self.url.raw_url}/rpc"
+            self.host = self.url.hostname
+            self.port = self.url.port
+
+        self.socket = self._connect_socket()
+
     def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
     ) -> dict[str, Any]:

--- a/src/surrealdb/connections/sync_template.py
+++ b/src/surrealdb/connections/sync_template.py
@@ -15,6 +15,16 @@ from surrealdb.types import Tokens, Value
 
 
 class SyncTemplate:
+    def connect(self, url: str | None = None) -> None:
+        """Connects to a local or remote database endpoint.
+
+        Declared here so the contract is part of the template rather than
+        implemented ad hoc: a class that forgets it used to raise
+        ``AttributeError`` rather than a diagnosable ``NotImplementedError``.
+        Every concrete connection overrides this.
+        """
+        raise NotImplementedError(f"connect not implemented for: {self}")
+
     def close(self) -> None:
         """Closes the persistent connection to the database."""
         raise NotImplementedError(f"close not implemented for: {self}")

--- a/tests/unit_tests/test_connection_typing.py
+++ b/tests/unit_tests/test_connection_typing.py
@@ -13,8 +13,10 @@ below (``Any`` does not match the asserted concrete type).
 
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
+
+import pytest
 
 if sys.version_info >= (3, 11):
     from typing import assert_type
@@ -339,3 +341,79 @@ def test_blocking_wrapper_into_overload_precision() -> None:
         assert_type(
             wrapper.insert(Table("person"), into=_Person), SyncInsertBuilder[_Person]
         )
+
+
+def test_every_connection_class_exposes_connect() -> None:
+    """``connect()`` exists on every transport, not just most of them.
+
+    ``BlockingWsSurrealConnection`` was the one connection class without it, so
+    ``connect()`` raised ``AttributeError`` there while the other five
+    connected - which is exactly the transport-agnostic breakage that adding it
+    to the HTTP connections was meant to remove.
+
+    Asserted over the classes rather than one at a time so a new transport
+    cannot quietly omit it.
+    """
+    import inspect
+
+    from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+    from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+    from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+    from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+    # `list[Any]`: these are heterogeneous connection classes, and the point of
+    # the test is to reach `connect` on each without a shared static base.
+    classes: list[Any] = [
+        AsyncHttpSurrealConnection,
+        AsyncWsSurrealConnection,
+        BlockingHttpSurrealConnection,
+        BlockingWsSurrealConnection,
+    ]
+    try:  # only present with the optional native engine installed
+        from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection
+        from surrealdb.connections.blocking_embedded import (
+            BlockingEmbeddedSurrealConnection,
+        )
+    except ImportError:
+        pass
+    else:
+        classes += [AsyncEmbeddedSurrealConnection, BlockingEmbeddedSurrealConnection]
+
+    # `hasattr` is not enough: both templates now declare `connect()` as a
+    # raising stub, so an inherited one would satisfy it. Require each concrete
+    # class to override, which is what the mutation test exercises.
+    from surrealdb.connections.async_template import AsyncTemplate
+    from surrealdb.connections.sync_template import SyncTemplate
+
+    stubs = (SyncTemplate.connect, AsyncTemplate.connect)
+    missing = [
+        cls.__name__
+        for cls in classes
+        if not hasattr(cls, "connect") or cls.connect in stubs
+    ]
+    assert missing == [], f"connection classes not implementing connect(): {missing}"
+
+    # `url` must be optional everywhere, so `connect()` works with no argument.
+    for cls in classes:
+        signature = inspect.signature(cls.connect)
+        url = signature.parameters["url"]
+        assert url.default is None, f"{cls.__name__}.connect url is not optional"
+
+
+def test_blocking_ws_connect_is_idempotent_and_maps_errors() -> None:
+    """The new blocking websocket ``connect()`` behaves like its async twin."""
+    import socket
+
+    from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+    from surrealdb.errors import SurrealError
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        closed_port = int(probe.getsockname()[1])
+
+    connection = BlockingWsSurrealConnection(f"ws://127.0.0.1:{closed_port}")
+
+    # An unreachable endpoint fails inside the error hierarchy, not with a
+    # raw OSError, and not with AttributeError as it did before.
+    with pytest.raises(SurrealError):
+        connection.connect()


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Verifying the published 3.0.0-beta.4 artifacts turned up two gaps. The first is an **incomplete fix of my own** from that release.

```python
>>> Surreal('ws://127.0.0.1:8000/').connect()
AttributeError: 'BlockingWsSurrealConnection' object has no attribute 'connect'
```

beta.4 added `connect()` to the HTTP connections, with a docstring claiming it "exists so code written against the connection API works on every transport." That was not true: `BlockingWsSurrealConnection` was the only one of the six connection classes with no `connect()` **at all** — so transport-agnostic code still broke, just on blocking websockets instead of HTTP, and with a plain `AttributeError` rather than the `NotImplementedError` the HTTP path used to give. I added it to both HTTP transports and checked `async_ws`, but never checked `blocking_ws`.

The second is a documentation bug that is **live on the PyPI project page right now**:

> ### Installation
> The embedded database is included when you install `surrealdb`.
> ```bash
> pip install surrealdb
> ```

That is wrong — the engine is an optional native extension behind the `embedded` extra. Anyone following it verbatim gets a bare install and no engine, which is precisely the misconception the bare-install fixes in beta.4 were about. Because the README is embedded in the wheel metadata, it renders on PyPI.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

### `connect()` on the blocking websocket connection

Mirrors `AsyncWsSurrealConnection.connect()` exactly: no-op when the socket is already open, re-points the connection when passed a url, then opens the socket via the existing `_connect_socket()` so transport failures still map to `TransportTimeoutError` / `ConnectionUnavailableError`.

The connection already connected lazily on first `_send`, so this is not required — but calling it eagerly now surfaces an unreachable endpoint at `connect()` rather than at the first query, which is what the other transports do.

Both templates now declare `connect()`, so a transport that omits it fails with a diagnosable `NotImplementedError` instead of `AttributeError`.

**A subtlety worth reviewing.** Declaring it on `SyncTemplate` *weakened my own guard*: a `hasattr` check is now satisfied by the inherited raising stub, so a class that forgets to override would pass. The test therefore asserts each concrete class's `connect` is not the template's. I caught this because the mutation check below failed on only one of the two tests — the `hasattr` one sailed through.

### README

The embedded section now shows `pip install 'surrealdb[embedded]'` / `uv add 'surrealdb[embedded]'`, states plainly that the engine is not in the default install, and notes that remote connections work either way. Its source-build command also gained the `--manifest-path embedded/Cargo.toml` it was missing — without it, `maturin develop` runs against the root project, whose backend is hatchling.

The top-level "How to install" section is unchanged and correct: `pip install surrealdb` is right for the base package.

## What is your testing strategy?

**1049 passed** on HTTP and WebSocket against a live SurrealDB 3.2.3 (up from 1047; +2 tests). `ruff`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.

Verified `connect()` against a real server, including idempotency:

```
connect() OK, raw_url = ws://127.0.0.1:8000/rpc
```

Two new tests in `test_connection_typing.py`:

- `test_every_connection_class_exposes_connect` — asserts over the classes rather than one at a time, so a new transport cannot quietly omit it, and requires a real override rather than the inherited stub. Also asserts `url` is optional everywhere, so bare `connect()` works.
- `test_blocking_ws_connect_is_idempotent_and_maps_errors` — an unreachable endpoint raises inside the `SurrealError` hierarchy.

**Both are mutation-verified.** Removing `connect()` from `blocking_ws` again fails both:

```
FAILED test_every_connection_class_exposes_connect
FAILED test_blocking_ws_connect_is_idempotent_and_maps_errors
```

## Is this related to any issues?

Follow-up from verifying 3.0.0-beta.4. Completes the `connect()` work started in #309.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md

---

### Known, not addressed here

Also surfaced by the beta.4 verification, left for separate PRs:

- **`surrealkv+versioned://` is advertised but broken.** `UnsupportedEngineError`'s own hint text lists it as supported, but every attempt fails with `RuntimeError: Failed to create datastore: ... Unable to load the specified datastore`, raised below the Python wrapper. Reproduced identically on 3.0.0b3, so it predates this work — and being a bare `RuntimeError`, it escapes the error hierarchy that #309 tightened for URL schemes.
- **The trimmed sdist still ships `[tool.uv.sources]`** pointing at the `embedded/` directory that trimming removed, so `uv sync` inside an extracted sdist fails. PEP 517 builds and `pip install` are unaffected.
- **`scripts/build.sh` and `AGENTS.md`** carry the same missing `--manifest-path` as the README did. Dev-facing rather than published, so not in this PR.
- **No `surrealdb.__version__`** attribute; `importlib.metadata.version("surrealdb")` is the only way to read it.
