### PR TITLE
Fix three unusable dependency floors and six silent wrong-data defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,74 @@ jobs:
             exit 1
           fi
 
+  # Every other job installs the lockfile, which pins current versions - so
+  # nothing here has ever exercised the *declared* minimums. Two of them named
+  # versions at which `import surrealdb` raised, and both shipped.
+  #
+  # Deliberately runs the built wheel out of site-packages with no PYTHONPATH:
+  # the point is what a user gets from `pip install surrealdb`, resolved the
+  # way a user with old pins would resolve it.
+  floors:
+    name: Minimum declared dependency versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9
+        with:
+          version: "latest"
+          enable-cache: true
+
+      # The oldest interpreter we support: the one a user still on old pins is
+      # most likely to be running, and the one old dependencies have wheels for.
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.10"
+
+      - name: Install surrealdb
+        run: curl -sSf https://install.surrealdb.com | sh -s -- --version v3.0.5
+
+      - name: Start surrealdb
+        run: surreal start --allow-all -u root -p root --log trace &
+
+      - name: Wait for startup
+        run: sleep 5
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      # Resolved from pyproject.toml rather than repeated here, so the job
+      # cannot drift from what is declared. `lowest-direct` pins our own
+      # dependencies to their floors while letting everything they pull in
+      # resolve normally - which is what a user with no pins of their own gets,
+      # not an artificial combination no resolver would produce.
+      - name: Resolve the declared floors
+        run: |
+          # Explicit, so the resolve cannot silently land on a different
+          # interpreter than the one the tests then run under - the markers on
+          # some dependencies are keyed to the Python version.
+          uv venv --python 3.10 .floors
+          uv pip compile --python .floors/bin/python \
+            --resolution lowest-direct pyproject.toml -o floor-lock.txt
+          echo "Floors under test:"
+          grep -vE '^\s*#|^$' floor-lock.txt
+
+      # The lock goes in as a *constraint*, so the test tools resolve normally
+      # while every dependency of the SDK is held at its floor.
+      - name: Install the wheel at those floors
+        run: |
+          uv pip install --python .floors/bin/python --constraint floor-lock.txt \
+            dist/*.whl pytest pytest-asyncio hypothesis responses coverage
+          uv pip list --python .floors/bin/python
+
+      - name: Run unit tests against the floors
+        run: .floors/bin/python -m pytest --ignore=tests/unit_tests/connections/embedded
+        env:
+          PYTHONWARNINGS: ignore::ResourceWarning
+
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.surrealdb-version == 'nightly' }}

--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ with Surreal("ws://localhost:8000/rpc") as db:
 
 ### Talking to a SurrealDB 2.x server
 
-Two things behave differently against SurrealDB 2.x, both because of what the
-2.x wire format carries rather than anything the SDK chooses.
+Three things behave differently against SurrealDB 2.x, all because of what the
+2.x server does rather than anything the SDK chooses.
 
 **Error kinds need 3.x.** The subclasses below `ServerError` come from the
 `kind` the server reports, and 2.x does not send one — its error payload has
@@ -532,6 +532,21 @@ arrays — and rejects anything carrying the tag. Send a `list` instead when
 targeting 2.x; a list is what 2.x uses for a `set<…>` field anyway, and the
 server deduplicates it. On 3.x a list is *not* interchangeable with a set: a
 `set<…>` field rejects one.
+
+**`let()` wins over a query's own variables on a 2.x websocket.** Passing a
+variable to `query()` shadows a `let()` binding of the same name for that one
+query — on 3.x, and on HTTP against any version, where the SDK replays `let()`
+bindings itself. On a 2.x websocket `let()` is a server-side session binding and
+that server resolves it the other way round:
+
+```python
+db.let("limit", 99)
+db.query("RETURN $limit", {"limit": 5})   # 5, except on a 2.x websocket: 99
+```
+
+The SDK sends the same request in both cases, so there is nothing for it to fix
+without knowing the server version up front. Use distinct names for session
+bindings and per-query variables if you target 2.x over a websocket.
 
 The `TransportError` branch is `ConnectionUnavailableError` (the host was
 unreachable or the socket closed), `TransportTimeoutError` (the request timed

--- a/examples/django/api/views.py
+++ b/examples/django/api/views.py
@@ -68,7 +68,7 @@ class UserViewSet(viewsets.ViewSet):
 
         db = await get_connection()
         try:
-            result = await db.merge(pk, serializer.validated_data)
+            result = await db.update(pk).merge(serializer.validated_data)
             if not result:
                 return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
 

--- a/examples/embedded/basic_sync.py
+++ b/examples/embedded/basic_sync.py
@@ -29,12 +29,14 @@ def main() -> None:
         print(f"Updated person: {updated}")
 
         # Run a SurrealQL query
+        # `query()` returns a builder; `.execute()` is what runs it. The async
+        # form above is awaited, which runs it - the sync form has to say so.
         result = db.query(
             """
             SELECT * FROM person WHERE age < $max_age
         """,
             {"max_age": 30},
-        )
+        ).execute()
         print(f"Query result: {result}")
 
         # Delete all people

--- a/examples/fastapi/routes/users.py
+++ b/examples/fastapi/routes/users.py
@@ -135,7 +135,7 @@ async def update_user(
                 detail="No fields to update",
             )
 
-        result = await db.merge(user_id, update_data)
+        result = await db.update(user_id).merge(update_data)
 
         if not result:
             raise HTTPException(

--- a/examples/fastmcp/tools.py
+++ b/examples/fastmcp/tools.py
@@ -132,7 +132,7 @@ async def update_user(
             return {"error": "No fields to update"}
 
         db = db_manager.get_db()
-        result = await db.merge(user_id, update_data)
+        result = await db.update(user_id).merge(update_data)
 
         if not result:
             return {"error": f"User {user_id} not found"}

--- a/examples/flask/routes/users.py
+++ b/examples/flask/routes/users.py
@@ -125,7 +125,7 @@ def update_user(user_id):
             return jsonify({"error": "No fields to update"}), 400
 
         db = get_db()
-        result = db.merge(user_id, update_data)
+        result = db.update(user_id).merge(update_data)
 
         if not result:
             return jsonify({"error": f"User {user_id} not found"}), 404

--- a/examples/graphql/schema/mutations.py
+++ b/examples/graphql/schema/mutations.py
@@ -93,7 +93,7 @@ class Mutation:
             if not update_data:
                 raise Exception("No fields to update")
 
-            result = await db.merge(id, update_data)
+            result = await db.update(id).merge(update_data)
 
             if not result:
                 raise Exception(f"User {id} not found")

--- a/examples/jupyter/notebooks/02_crud_operations.ipynb
+++ b/examples/jupyter/notebooks/02_crud_operations.ipynb
@@ -81,14 +81,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Get user ID (use the first user for example)\n",
-    "user_id = users[0][\"id\"]\n",
-    "\n",
-    "# Update the user\n",
-    "updated = await db.merge(user_id, {\"age\": 36})\n",
-    "pretty_print(updated)"
-   ]
+   "source": "# Get user ID (use the first user for example)\nuser_id = users[0][\"id\"]\n\n# Update the user\nupdated = await db.update(user_id).merge({\"age\": 36})\npretty_print(updated)"
   },
   {
    "cell_type": "markdown",

--- a/examples/litestar/controllers/users.py
+++ b/examples/litestar/controllers/users.py
@@ -121,7 +121,7 @@ class UserController(Controller):
             if not update_data:
                 raise InternalServerException("No fields to update")
 
-            result = await db.merge(user_id, update_data)
+            result = await db.update(user_id).merge(update_data)
 
             if not result:
                 raise NotFoundException(f"User {user_id} not found")

--- a/examples/logfire/main.py
+++ b/examples/logfire/main.py
@@ -100,8 +100,7 @@ async def demonstrate_crud_operations(db: Any) -> None:
     # MERGE: Partially update a user (only specified fields)
     # Span: "surrealdb merge"
     print("🔄 Merging user data...")
-    merged_user = await db.merge(
-        user2["id"],
+    merged_user = await db.update(user2["id"]).merge(
         {"role": "moderator"},  # Only update the role field
     )
     print(f"   Merged user: {merged_user['id']}\n")

--- a/examples/quart/routes/users.py
+++ b/examples/quart/routes/users.py
@@ -120,7 +120,7 @@ async def update_user(user_id):
             return jsonify({"error": "No fields to update"}), 400
 
         db = await get_db()
-        result = await db.merge(user_id, update_data)
+        result = await db.update(user_id).merge(update_data)
 
         if not result:
             return jsonify({"error": f"User {user_id} not found"}), 404

--- a/examples/sanic/blueprints/users.py
+++ b/examples/sanic/blueprints/users.py
@@ -146,7 +146,7 @@ async def update_user(request, user_id):
             )
 
         db = db_manager.get_db()
-        result = await db.merge(user_id, update_data)
+        result = await db.update(user_id).merge(update_data)
 
         if not result:
             return response.json(

--- a/examples/starlette/routes/users.py
+++ b/examples/starlette/routes/users.py
@@ -144,7 +144,7 @@ async def update_user(request):
             )
 
         db = db_manager.get_db()
-        result = await db.merge(user_id, update_data)
+        result = await db.update(user_id).merge(update_data)
 
         if not result:
             return JSONResponse(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,26 @@ dependencies = [
     # up keeps users off the affected range. 3.14 still supports Python 3.10,
     # so this costs no platform coverage.
     "aiohttp>=3.14.0",
-    "pydantic-core>=2.0.1",
+    # 2.10.0 is the first release whose `typed-dict` schema takes the
+    # `typed-dict-field` wrappers `cbor_ws` builds. Below it the module-scope
+    # `SchemaValidator` raises `SchemaError` on construction, so `import
+    # surrealdb` fails outright - the declared floor of 2.0.1 named a version
+    # at which the package could not be imported at all.
+    "pydantic-core>=2.10.0",
     "requests>=2.25.0",
-    "typing_extensions>=4.0.0; python_version<'3.12'",
-    "websockets>=10.0",
+    # `Buffer` (PEP 688) lands in 4.6.0. The import is `TYPE_CHECKING`-only, so
+    # an older version still runs - but this package ships `py.typed`, and a
+    # type checker resolving the SDK against 4.0.0 cannot find the name.
+    "typing_extensions>=4.6.0; python_version<'3.12'",
+    # `websockets.sync`, which the whole blocking transport is built on, only
+    # exists from 11.0 - so the declared floor of 10.0 was another version at
+    # which importing the package failed. 11.0 imports but deadlocks: its
+    # message assembler blocks the reader thread until an unread frame is
+    # consumed, and `close()` joins that thread, so closing a connection with
+    # an undelivered live notification never returns. 12.0 through 13.1 avoid
+    # the deadlock but still pay the full 10s close timeout for it. 14.0 is the
+    # first release where closing such a connection is immediate.
+    "websockets>=14.0",
 ]
 
 [project.urls]

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -17,7 +17,11 @@ from surrealdb.connections.builders import (
     _map_result,
 )
 from surrealdb.connections.url import Url
-from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
+from surrealdb.connections.utils_mixin import (
+    AUTH_FALLBACK_QUERY,
+    UtilsMixin,
+    merge_query_vars,
+)
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
@@ -233,14 +237,10 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
     async def query_raw(
         self, query: str, vars: dict[str, Value] | None = None
     ) -> dict[str, Any]:
-        if vars is None:
-            vars = {}
-        for key, value in self.vars.items():
-            vars[key] = value
         message = RequestMessage(
             RequestMethod.QUERY,
             query=query,
-            params=vars,
+            params=merge_query_vars(self.vars, vars),
         )
         self.id = message.id
         response = await self._send(message, "query", bypass=True)
@@ -481,7 +481,12 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.vars[key] = value
 
     async def unset(self, key: str) -> None:
-        self.vars.pop(key)
+        # Unsetting a name that was never set is not an error: the websocket
+        # and embedded engines answer the `unset` RPC for an unknown key
+        # without complaint, and only here did it raise `KeyError` - an
+        # exception outside the `SurrealError` tree, so `except SurrealError`
+        # around transport-agnostic cleanup code did not catch it.
+        self.vars.pop(key, None)
 
     @overload
     async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -46,6 +46,15 @@ logger = logging.getLogger(__name__)
 # (the connection is going away) so waiting consumers do not leak.
 _LIVE_QUEUE_CLOSED = object()
 
+# Sentinel pushed when the reader stops for any other reason - the peer went
+# away, the socket errored, the server restarted. Distinct from
+# ``_LIVE_QUEUE_CLOSED`` because it is not a clean end of stream: the consumer
+# has to hear that notifications stopped arriving because the connection broke,
+# not just that iteration finished. A silent ``return`` here is indistinguishable
+# from a ``kill()``, so a consumer would go on believing it had seen every
+# change to the table.
+_LIVE_QUEUE_BROKEN = object()
+
 
 # Upper bound on how long a single RPC waits for its reply. The blocking
 # transport has had one since it was found hanging on a protocol error; without
@@ -82,6 +91,32 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         # Queues hold live-notification dicts plus the ``_LIVE_QUEUE_CLOSED``
         # sentinel, so the value type is ``Any``.
         self.live_queues: dict[str, list[Queue[Any]]] = {}
+        # Guards socket creation - see `_connect_guard`. Built on first use
+        # rather than here: an `asyncio.Lock` binds to the loop that first
+        # awaits it, and these connections are routinely constructed outside
+        # the loop that ends up running them.
+        self._connect_lock: asyncio.Lock | None = None
+        self._connect_lock_loop: AbstractEventLoop | None = None
+
+    def _connect_guard(self) -> asyncio.Lock:
+        """The lock serialising ``connect()``, bound to the running loop.
+
+        Without it, concurrent first requests each saw ``socket is None`` and
+        each opened one: N sockets and N reader tasks for one connection, of
+        which the object kept only the last. The rest leaked, and every reader
+        but one raced to resolve futures on a socket nobody would ever read
+        the replies from - so most callers got a spurious
+        ``ConnectionUnavailableError`` from a connection that was in fact fine.
+
+        Re-made when the loop changes so a connection reused across
+        ``asyncio.run`` calls - each of which builds and discards a loop - does
+        not fail on a lock bound to a loop that is gone.
+        """
+        loop = asyncio.get_running_loop()
+        if self._connect_lock is None or self._connect_lock_loop is not loop:
+            self._connect_lock = asyncio.Lock()
+            self._connect_lock_loop = loop
+        return self._connect_lock
 
     def _fail_pending(self, error: BaseException) -> None:
         """Hand *error* to every caller currently awaiting a reply."""
@@ -146,6 +181,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                     "WebSocket connection closed before a response was received."
                 )
             )
+            # Live subscribers wait on a queue, not on `self.qry`, so failing
+            # the pending futures left them untouched: nothing would ever be
+            # put in their queue again and `async for` waited forever, with no
+            # timeout on the path. The blocking transport has always raised
+            # `ConnectionUnavailableError` here.
+            for queues in self.live_queues.values():
+                for queue in queues:
+                    queue.put_nowait(_LIVE_QUEUE_BROKEN)
 
     async def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
@@ -196,6 +239,12 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         return response
 
     async def connect(self, url: str | None = None) -> None:
+        # Serialised: `_send` calls this on every request, so the first few
+        # requests of a gathered batch all arrive here at once.
+        async with self._connect_guard():
+            await self._connect_locked(url)
+
+    async def _connect_locked(self, url: str | None = None) -> None:
         if (
             url is not None
             and self.socket is not None
@@ -894,7 +943,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         Pass ``diff=True`` for JSON-Patch notifications. Consume notifications
         with :meth:`subscribe_live` and stop the query with :meth:`kill`.
         """
-        kwargs: dict[str, Any] = {"table": table}
+        kwargs: dict[str, Any] = {"table": table, "diff": diff}
         if session_id is not None:
             kwargs["session"] = session_id
         message = RequestMessage(RequestMethod.LIVE, **kwargs)
@@ -914,6 +963,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         its own queue and receives every notification. The generator ends
         (a plain ``return``, so ``async for`` stops cleanly) when the query is
         killed via :meth:`kill` or the connection is closed via :meth:`close`.
+
+        :raises ConnectionUnavailableError: if the connection drops while the
+            subscription is active. That is not a clean end of stream - some
+            changes to the table went undelivered - so it is raised rather than
+            ending the iteration, matching the blocking transport.
         """
         result_queue: Queue[Any] = Queue()
         suid = str(query_uuid)
@@ -932,6 +986,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                     # consumers so the generator terminates instead of leaking.
                     if ret is _LIVE_QUEUE_CLOSED:
                         return
+                    if ret is _LIVE_QUEUE_BROKEN:
+                        raise ConnectionUnavailableError(
+                            "WebSocket connection closed while subscribed to "
+                            f"live query {suid}."
+                        )
                     yield ret
             finally:
                 # Deregister this consumer's queue when the generator is

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Generator
 from types import TracebackType
-from typing import Any, cast, overload
+from typing import Any, overload
 from uuid import UUID
 
 import requests
@@ -16,7 +16,11 @@ from surrealdb.connections.builders import (
 )
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
-from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
+from surrealdb.connections.utils_mixin import (
+    AUTH_FALLBACK_QUERY,
+    UtilsMixin,
+    merge_query_vars,
+)
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
@@ -96,9 +100,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
 
         self.check_status_for_error(response.status_code, response.content, url)
 
-        data_dict = cast(
-            dict[str, Any], self.decode_response(response.content, operation)
-        )
+        data_dict = self.decode_response(response.content, operation)
 
         if not bypass:
             self.check_response_for_error(data_dict, operation)
@@ -194,14 +196,10 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
     def query_raw(
         self, query: str, vars: dict[str, Value] | None = None
     ) -> dict[str, Any]:
-        if vars is None:
-            vars = {}
-        for key, value in self.vars.items():
-            vars[key] = value
         message = RequestMessage(
             RequestMethod.QUERY,
             query=query,
-            params=vars,
+            params=merge_query_vars(self.vars, vars),
         )
         self.id = message.id
         response = self._send(message, "query", bypass=True)
@@ -435,7 +433,12 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.vars[key] = value
 
     def unset(self, key: str) -> None:
-        self.vars.pop(key)
+        # Unsetting a name that was never set is not an error: the websocket
+        # and embedded engines answer the `unset` RPC for an unknown key
+        # without complaint, and only here did it raise `KeyError` - an
+        # exception outside the `SurrealError` tree, so `except SurrealError`
+        # around transport-agnostic cleanup code did not catch it.
+        self.vars.pop(key, None)
 
     @overload
     def select(self, record: RecordID, *, into: type[M]) -> M | None: ...

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -125,7 +125,18 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         previous endpoint while reporting the new URL. Re-pointing costs the
         server-side session, so the same-url case is left alone: a defensive
         ``connect(url)`` must not quietly discard a completed ``signin()``.
+
+        Serialised on the same lock ``_send`` uses, so two threads opening a
+        connection at once produce one socket rather than one each. Unguarded,
+        both saw ``socket is None``, both connected, and the loser's socket -
+        with its ``recv_events`` and ``keepalive`` threads - was overwritten
+        and leaked with no reference left to close it.
         """
+        with self._lock:
+            self._connect_locked(url)
+
+    def _connect_locked(self, url: str | None = None) -> None:
+        """The body of :meth:`connect`, called with ``self._lock`` held."""
         if url is not None:
             target = Url(url)
             target_raw = f"{target.raw_url}/rpc"
@@ -1023,7 +1034,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         Pass ``diff=True`` for JSON-Patch notifications. Consume notifications
         with :meth:`subscribe_live` and stop the query with :meth:`kill`.
         """
-        kwargs: dict[str, Any] = {"table": table}
+        kwargs: dict[str, Any] = {"table": table, "diff": diff}
         if session_id is not None:
             kwargs["session"] = session_id
         message = RequestMessage(RequestMethod.LIVE, **kwargs)

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -489,6 +489,24 @@ def _statement_rows(values: list[Any]) -> list[Any]:
     return [first]
 
 
+def _require_model_class(cls: Any) -> None:
+    """Reject a non-class model argument, at the call that passed it.
+
+    Every downstream message is formatted with ``cls.__name__``, so a non-class
+    surfaced as ``AttributeError: 'int' object has no attribute '__name__'``
+    raised from inside the SDK's own error formatter - naming neither the
+    argument nor the method that took it, and only after the query had already
+    been sent. Passing something that is not a class is a caller mistake, not
+    an operational failure, so this is a ``TypeError`` and deliberately outside
+    the ``SurrealError`` tree.
+    """
+    if not isinstance(cls, type):
+        raise TypeError(
+            f"into= expects a class to map results onto, got "
+            f"{type(cls).__name__}: {cls!r}"
+        )
+
+
 def _require_record(into: type[Any], row: Any) -> Mapping[str, Any]:
     """Ensure a value mapped via ``into=`` is a record object (mapping).
 
@@ -523,6 +541,7 @@ def _map_result(into: type[Any] | None, result: Any) -> Any:
     """
     if into is None:
         return result
+    _require_model_class(into)
     if isinstance(result, list):
         return [_map_to_class(into, _require_record(into, row)) for row in result]
     if result is None:
@@ -791,6 +810,7 @@ class AsyncQueryBuilder(_QueryState):
         Either way the into-builder reuses *self*'s cached fetch rather than
         issuing a second RPC.
         """
+        _require_model_class(cls)
         return AsyncQueryIntoBuilder(self, cls, rows=rows)
 
     async def execute(self) -> list[Value]:
@@ -1029,6 +1049,7 @@ class SyncQueryBuilder(_QueryState):
         Reuses this builder's cached fetch so ``.execute()`` plus ``.into(T)``
         on the same instance only issue one RPC.
         """
+        _require_model_class(cls)
         values = self._run_once()
         if rows:
             return [

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from typing import Any
 
@@ -61,12 +61,40 @@ AUTH_FALLBACK_QUERY = "SELECT * FROM $auth"
 _MAX_BODY_CHARS = 300
 
 
-def _body_text(body: bytes) -> str:
-    """Render an HTTP error body as short, printable text."""
-    text = body.decode("utf-8", errors="replace").strip()
+def merge_query_vars(
+    session_vars: Mapping[str, Value], call_vars: Mapping[str, Value] | None
+) -> dict[str, Value]:
+    """Combine ``let()`` session variables with one query's own variables.
+
+    The HTTP transports have no server-side session to hold ``let()`` bindings,
+    so they replay them as query parameters. Which side wins when a name appears
+    twice is therefore an SDK decision, and it has to be the same answer the
+    websocket and embedded engines give: there ``let()`` is a real RPC and the
+    parameters sent with a query shadow the session binding for that query
+    alone. Writing the session variables on top instead made
+    ``query("RETURN $limit", {"limit": 5})`` return the ``let()`` value - the
+    caller's own argument, silently ignored, on one transport only.
+
+    The result is always a new dict. Merging into the caller's dict left
+    ``let()`` bindings - including credentials someone had bound to the
+    session - sitting in a dict the caller still held and might reuse.
+    """
+    merged: dict[str, Value] = dict(session_vars)
+    if call_vars:
+        merged.update(call_vars)
+    return merged
+
+
+def _clip(text: str) -> str:
+    """Trim *text* to something that still reads as a traceback line."""
     if len(text) > _MAX_BODY_CHARS:
         return text[:_MAX_BODY_CHARS] + "..."
     return text
+
+
+def _body_text(body: bytes) -> str:
+    """Render an HTTP error body as short, printable text."""
+    return _clip(body.decode("utf-8", errors="replace").strip())
 
 
 # These are re-exported for backwards compatibility with downstream code
@@ -77,6 +105,7 @@ __all__ = [
     "SurrealError",
     "Table",
     "UtilsMixin",
+    "merge_query_vars",
 ]
 
 
@@ -111,14 +140,28 @@ class UtilsMixin:
         raise HttpStatusError(status, _body_text(body), url)
 
     @staticmethod
-    def decode_response(body: bytes, process: str) -> Any:
-        """Decode a CBOR response body, or raise ``UnexpectedResponseError``."""
+    def decode_response(body: bytes, process: str) -> dict[str, Any]:
+        """Decode a CBOR RPC envelope, or raise ``UnexpectedResponseError``.
+
+        The envelope is always a map, and every caller reads it as one. Handing
+        back whatever the body happened to hold meant a response that decoded
+        to a list, a string or a number got as far as ``response.get("error")``
+        and raised ``AttributeError`` - outside the ``SurrealError`` tree, so
+        no documented ``except`` clause caught it, and the message named
+        neither the operation nor what had actually come back.
+        """
         try:
-            return decode(body)
+            decoded = decode(body)
         except Exception as exc:
             raise UnexpectedResponseError(
                 f"could not decode the response while {process}: {exc}"
             ) from exc
+        if not isinstance(decoded, dict):
+            raise UnexpectedResponseError(
+                f"expected a response object while {process}, got "
+                f"{type(decoded).__name__}: {_clip(repr(decoded))}"
+            )
+        return decoded
 
     @staticmethod
     def check_response_for_result(response: dict[str, Any], process: str) -> None:

--- a/src/surrealdb/data/types/datetime.py
+++ b/src/surrealdb/data/types/datetime.py
@@ -93,8 +93,19 @@ class PreciseDatetime(datetime):
         )
 
     def isoformat_with_nanoseconds(self) -> str:
-        """Render with all nine fractional digits, as SurrealDB expects."""
+        """Render with all nine fractional digits, as SurrealDB expects.
+
+        A naive value is read as UTC rather than as the machine's local time.
+        ``astimezone`` assumes local for a naive datetime, while the encoder
+        hands a plain naive ``datetime`` to cbor2 as UTC - so the same wall
+        clock written both ways travelled as two different instants, five hours
+        apart on a US East Coast machine and identical on a UTC one. Which of
+        the two a value took depended on the host, not on anything the caller
+        wrote, and CI runs on UTC so nothing here ever saw the difference.
+        """
+        moment = self if self.tzinfo is not None else self.replace(tzinfo=timezone.utc)
+        utc = moment.astimezone(timezone.utc)
         return (
-            self.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.")
-            + f"{self.microsecond:06d}{self.nanosecond:03d}Z"
+            utc.strftime("%Y-%m-%dT%H:%M:%S.")
+            + f"{utc.microsecond:06d}{self.nanosecond:03d}Z"
         )

--- a/src/surrealdb/errors.py
+++ b/src/surrealdb/errors.py
@@ -560,12 +560,22 @@ def _explain(message: str) -> str:
     return message
 
 
-def parse_rpc_error(raw: dict[str, Any]) -> ServerError:
+def parse_rpc_error(raw: Any) -> ServerError:
     """Parse an RPC-level error response into a ``ServerError``.
 
     Handles both the new format (``kind`` + ``details`` + ``cause``) and
     the legacy format (``code`` + ``message`` only).
+
+    An error that is not an object at all is still turned into a
+    ``ServerError`` carrying its text. SurrealDB 2.x answers some failures -
+    a NUL byte anywhere in a request, for one - with a bare string where the
+    protocol calls for an error object, and reading ``kind`` off that raised
+    ``AttributeError`` from inside the SDK: the caller got no message, and
+    nothing an ``except SurrealError`` would catch.
     """
+    if not isinstance(raw, dict):
+        return InternalError(kind="Internal", message=_explain(str(raw)), code=0)
+
     kind = _resolve_kind(raw.get("kind"), raw.get("code"))
     cause: ServerError | None = None
     if raw.get("cause") is not None:

--- a/src/surrealdb/request_message/descriptors/cbor_ws.py
+++ b/src/surrealdb/request_message/descriptors/cbor_ws.py
@@ -348,7 +348,12 @@ class WsCborDescriptor:
         table = obj.kwargs.get("table")
         if isinstance(table, str):
             table = Table(table)
-        data = {"id": obj.id, "method": obj.method.value, "params": [table]}
+        # The `live` RPC takes `[what, diff]`. Sending only `[what]` left the
+        # server on its default of full records, so `live(table, diff=True)`
+        # was accepted, documented, and typed - and silently delivered
+        # something other than the JSON Patch it promised.
+        params: list[Any] = [table, bool(obj.kwargs.get("diff", False))]
+        data = {"id": obj.id, "method": obj.method.value, "params": params}
         _inject_session_txn(data, obj)
         _validate_payload(data, obj.method)
         return encode(data)

--- a/tests/unit_tests/connections/let/test_precedence.py
+++ b/tests/unit_tests/connections/let/test_precedence.py
@@ -1,0 +1,180 @@
+"""A query's own variables beat ``let()``, and the caller's dict is not touched.
+
+The HTTP transports have no server-side session to hold ``let()`` bindings, so
+they replay them as query parameters. Which side won when a name appeared on
+both was therefore an SDK decision, and it was the wrong one: the session
+values were written *over* the caller's, so
+
+    db.let("limit", 99)
+    db.query("RETURN $limit", {"limit": 5})
+
+returned ``99`` on HTTP and ``5`` on a 3.x websocket - the caller's own
+argument silently ignored, on one transport only.
+
+On the websocket transports ``let()`` is a real RPC, so the *server* decides,
+and the two supported majors decide differently: 3.x shadows the session
+binding with the query's own variables, 2.x does not. That is pinned below
+rather than skipped, so a change in either server is visible here.
+
+The same line merged into the dict the caller passed, so a ``let()`` binding -
+including anything sensitive someone had bound to the session - was left in an
+object the caller still held and could reuse for an unrelated query. Only
+``query_raw`` reached this: ``query`` hands its variables to a builder, which
+copies them. Both are public, and the copy in the builder is incidental, so
+both are covered here.
+
+Run against every transport rather than just the two that were broken, so the
+four cannot drift apart again.
+"""
+
+from typing import Any
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+# ------------------------------------------------------- per-query precedence
+
+
+def test_blocking_http_query_vars_beat_let(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.let("limit", 99)
+
+    assert blocking_http_connection.query("RETURN $limit", {"limit": 5}).first() == 5
+    # The binding is only shadowed for that one query, not consumed.
+    assert blocking_http_connection.query("RETURN $limit").first() == 99
+
+
+async def test_async_http_query_vars_beat_let(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.let("limit", 99)
+
+    assert await async_http_connection.query("RETURN $limit", {"limit": 5}).first() == 5
+    assert await async_http_connection.query("RETURN $limit").first() == 99
+
+
+def _shadows_session_vars(version: str) -> bool:
+    """Whether this server lets a query's own variables shadow ``let()``."""
+    text = (version or "").strip().lower()
+    for prefix in ("surrealdb-", "v"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    try:
+        return int(text.split(".")[0]) >= 3
+    except (ValueError, IndexError):
+        return False
+
+
+def test_blocking_ws_precedence_is_the_servers_to_decide(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.let("limit", 99)
+
+    outcome = blocking_ws_connection.query("RETURN $limit", {"limit": 5}).first()
+
+    expected = 5 if _shadows_session_vars(blocking_ws_connection.version()) else 99
+    assert outcome == expected
+    # Either way the binding survives the query that shadowed it.
+    assert blocking_ws_connection.query("RETURN $limit").first() == 99
+
+
+async def test_async_ws_precedence_is_the_servers_to_decide(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.let("limit", 99)
+
+    outcome = await async_ws_connection.query("RETURN $limit", {"limit": 5}).first()
+
+    expected = 5 if _shadows_session_vars(await async_ws_connection.version()) else 99
+    assert outcome == expected
+    assert await async_ws_connection.query("RETURN $limit").first() == 99
+
+
+# ------------------------------------------------------ caller dict isolation
+
+
+def test_blocking_http_query_raw_does_not_touch_the_callers_vars(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.let("session_secret", "s3cret")
+    mine: dict[str, Any] = {"name": "alice"}
+
+    blocking_http_connection.query_raw("RETURN $name", mine)
+
+    assert mine == {"name": "alice"}
+
+
+async def test_async_http_query_raw_does_not_touch_the_callers_vars(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.let("session_secret", "s3cret")
+    mine: dict[str, Any] = {"name": "alice"}
+
+    await async_http_connection.query_raw("RETURN $name", mine)
+
+    assert mine == {"name": "alice"}
+
+
+def test_blocking_http_query_does_not_touch_the_callers_vars(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """``query`` is only safe because the builder copies; pin that too."""
+    blocking_http_connection.let("session_secret", "s3cret")
+    mine: dict[str, Any] = {"name": "alice"}
+
+    blocking_http_connection.query("RETURN $name", mine).execute()
+
+    assert mine == {"name": "alice"}
+
+
+def test_blocking_http_reusing_a_vars_dict_does_not_leak_session_state(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """The end-to-end shape of the mutation bug, without inspecting the dict.
+
+    A caller who keeps one ``vars`` dict around and reuses it got every
+    ``let()`` binding folded into it by the first ``query_raw``, so a *later*
+    query naming one of those variables still resolved it - even after the
+    binding had been ``unset()``.
+    """
+    reused: dict[str, Any] = {"name": "alice"}
+    blocking_http_connection.let("ghost", "haunting")
+    blocking_http_connection.query_raw("RETURN $name", reused)
+
+    blocking_http_connection.unset("ghost")
+
+    # `$ghost` is unbound now, so it resolves to NONE. Anything else means the
+    # value came back out of the caller's own dict.
+    response = blocking_http_connection.query_raw("RETURN $ghost", reused)
+    assert response["result"][0]["result"] is None
+
+
+# ------------------------------------------------ unset() of an unbound name
+
+
+def test_blocking_http_unset_unknown_key_is_a_no_op(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """Only HTTP raised here, and with ``KeyError`` - outside ``SurrealError``."""
+    blocking_http_connection.unset("never_bound")
+
+
+async def test_async_http_unset_unknown_key_is_a_no_op(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.unset("never_bound")
+
+
+def test_blocking_ws_unset_unknown_key_is_a_no_op(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.unset("never_bound")
+
+
+async def test_async_ws_unset_unknown_key_is_a_no_op(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.unset("never_bound")

--- a/tests/unit_tests/connections/subscribe_live/test_connection_death.py
+++ b/tests/unit_tests/connections/subscribe_live/test_connection_death.py
@@ -1,0 +1,113 @@
+"""A live subscription ends when the connection under it dies.
+
+``_recv_task`` failed every pending RPC future when it stopped, but live
+subscribers do not wait on futures - they wait on a queue, and nothing was ever
+put in theirs again. ``async for`` simply never came back, with no timeout
+anywhere on the path, so a program whose server restarted sat there for as long
+as anyone let it.
+
+It raises rather than returning quietly. A silent ``return`` is what
+:meth:`kill` and :meth:`close` produce, and a consumer that cannot tell those
+apart from a dropped connection goes on believing it has seen every change to
+the table. The blocking transport has always raised here; this is the async
+side catching up.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.errors import ConnectionUnavailableError
+
+# Long enough to be certain a hang is a hang, short enough that a broken
+# implementation does not stall the suite for a minute.
+_DEADLINE = 15.0
+
+
+async def test_async_subscriber_is_woken_when_the_socket_dies(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    query_uuid = await connection.live("user")
+    subscription = await connection.subscribe_live(query_uuid)
+
+    async def drain() -> None:
+        async for _ in subscription:
+            pass
+
+    consumer = asyncio.ensure_future(drain())
+    await asyncio.sleep(0.2)
+
+    # The peer goes away underneath us. Deliberately not `connection.close()`:
+    # that is the orderly path, and it already woke subscribers.
+    await connection.socket.close()
+
+    with pytest.raises(ConnectionUnavailableError):
+        await asyncio.wait_for(consumer, timeout=_DEADLINE)
+
+    await connection.close()
+
+
+async def test_close_still_ends_the_subscription_quietly(
+    connection_params: dict[str, Any],
+) -> None:
+    """The orderly path must not start raising now that the broken one does.
+
+    ``close()`` wakes subscribers before it cancels the reader, and a queue is
+    FIFO, so the clean sentinel is always the one a consumer sees first.
+    """
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    query_uuid = await connection.live("user")
+    subscription = await connection.subscribe_live(query_uuid)
+
+    async def drain() -> None:
+        async for _ in subscription:
+            pass
+
+    consumer = asyncio.ensure_future(drain())
+    await asyncio.sleep(0.2)
+
+    await connection.close()
+
+    # No exception: a deliberate close is a clean end of stream.
+    await asyncio.wait_for(consumer, timeout=_DEADLINE)
+
+
+async def test_kill_still_ends_the_subscription_quietly(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    query_uuid = await connection.live("user")
+    subscription = await connection.subscribe_live(query_uuid)
+
+    async def drain() -> None:
+        async for _ in subscription:
+            pass
+
+    consumer = asyncio.ensure_future(drain())
+    await asyncio.sleep(0.2)
+
+    await connection.kill(query_uuid)
+
+    await asyncio.wait_for(consumer, timeout=_DEADLINE)
+    await connection.close()

--- a/tests/unit_tests/connections/subscribe_live/test_diff.py
+++ b/tests/unit_tests/connections/subscribe_live/test_diff.py
@@ -1,0 +1,99 @@
+"""``live(table, diff=True)`` really does deliver JSON Patch.
+
+The flag never reached the wire - ``prep_live`` encoded only the table - so the
+server stayed on its default and sent whole records. The call was accepted,
+typed and documented the whole time, which is exactly why nothing noticed: the
+only observable difference is the *shape* of a notification nobody asserted on.
+
+Asserted through the server rather than against the request bytes alone (that
+is covered in ``request_message/descriptors/test_cbor_ws.py``), because the
+promise is about what comes back, not about what goes out.
+"""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+
+def _is_json_patch(result: Any) -> bool:
+    """A JSON Patch notification is a list of ``{"op": ..., "path": ...}``."""
+    return (
+        isinstance(result, list)
+        and len(result) > 0
+        and all(isinstance(entry, dict) and "op" in entry for entry in result)
+    )
+
+
+def test_blocking_ws_diff_notifications_are_patches(
+    blocking_ws_connection_with_user: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    query_uuid = blocking_ws_connection_with_user.live("user", diff=True)
+    assert isinstance(query_uuid, UUID)
+
+    subscription = blocking_ws_connection_with_user.subscribe_live(query_uuid)
+    blocking_ws_connection_secondary.query(
+        "CREATE user:diffie SET name = 'Diffie', enabled = true;"
+    ).execute()
+
+    for update in subscription:
+        assert _is_json_patch(update["result"]), (
+            f"diff=True delivered a whole record, not a patch: {update['result']!r}"
+        )
+        break
+    else:  # pragma: no cover - only on a subscription that ends with nothing
+        pytest.fail("no notification arrived")
+
+    blocking_ws_connection_secondary.kill(query_uuid)
+
+
+def test_blocking_ws_without_diff_notifications_are_records(
+    blocking_ws_connection_with_user: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    """The other half of the contract: the default must not change.
+
+    Without this, sending ``diff`` unconditionally could have flipped every
+    existing subscriber to patches and this file would still be green.
+    """
+    query_uuid = blocking_ws_connection_with_user.live("user")
+
+    subscription = blocking_ws_connection_with_user.subscribe_live(query_uuid)
+    blocking_ws_connection_secondary.query(
+        "CREATE user:wholey SET name = 'Wholey', enabled = true;"
+    ).execute()
+
+    for update in subscription:
+        assert isinstance(update["result"], dict)
+        assert update["result"]["name"] == "Wholey"
+        break
+    else:  # pragma: no cover
+        pytest.fail("no notification arrived")
+
+    blocking_ws_connection_secondary.kill(query_uuid)
+
+
+async def test_async_ws_diff_notifications_are_patches(
+    async_ws_connection: AsyncWsSurrealConnection,
+    async_ws_connection_secondary: AsyncWsSurrealConnection,
+) -> None:
+    query_uuid = await async_ws_connection.live("user", diff=True)
+
+    subscription = await async_ws_connection.subscribe_live(query_uuid)
+    await async_ws_connection_secondary.query(
+        "CREATE user:asyncdiff SET name = 'AsyncDiff', enabled = true;"
+    ).execute()
+
+    async for update in subscription:
+        assert _is_json_patch(update["result"]), (
+            f"diff=True delivered a whole record, not a patch: {update['result']!r}"
+        )
+        break
+    else:  # pragma: no cover
+        pytest.fail("no notification arrived")
+
+    await async_ws_connection_secondary.kill(query_uuid)

--- a/tests/unit_tests/connections/test_connect_races.py
+++ b/tests/unit_tests/connections/test_connect_races.py
@@ -1,0 +1,185 @@
+"""Opening one connection from several callers at once opens one socket.
+
+Neither ``connect()`` was serialised, so every caller that arrived before the
+first one finished saw ``socket is None`` and opened its own. The object kept
+whichever finished last; the rest were leaked with no reference left to close
+them, each holding a TCP socket and - on the blocking transport - two
+``websockets`` worker threads.
+
+Async was worse than a leak. Each surplus socket also started a ``_recv_task``,
+and all of them iterate the same ``self.qry``; the first one to notice its own
+socket closing failed every pending future, so callers on the *surviving*
+socket were handed ``ConnectionUnavailableError`` for a connection that was
+working. Measured before the fix: eight concurrent ``signin()`` calls opened
+eight sockets and all eight callers failed.
+
+This is the shape of ordinary code - a thread pool, or an ``asyncio.gather``
+over a shared connection - not of a stress test.
+"""
+
+import asyncio
+import threading
+from typing import Any
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+CALLERS = 8
+
+
+def test_blocking_connect_opens_one_socket_for_concurrent_callers(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    opened: list[Any] = []
+    lock = threading.Lock()
+    open_socket = connection._connect_socket
+
+    def counting_connect() -> Any:
+        socket = open_socket()
+        with lock:
+            opened.append(socket)
+        return socket
+
+    connection._connect_socket = counting_connect  # type: ignore[method-assign]
+
+    # A barrier rather than bare thread starts: without it the first thread
+    # usually finishes connecting before the others begin, and the race the
+    # lock exists for never happens.
+    ready = threading.Barrier(CALLERS)
+
+    def worker() -> None:
+        ready.wait()
+        connection.connect()
+
+    threads = [threading.Thread(target=worker) for _ in range(CALLERS)]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+            assert not thread.is_alive(), "a caller never returned from connect()"
+
+        assert len(opened) == 1, (
+            f"{CALLERS} concurrent callers opened {len(opened)} sockets; "
+            f"{len(opened) - 1} of them are leaked"
+        )
+        assert connection.socket is opened[0]
+        # The one surviving socket is a working connection, not a wedged one.
+        connection.signin(connection_params["vars_params"])
+        connection.use(
+            namespace=connection_params["namespace"],
+            database=connection_params["database_name"],
+        )
+        assert connection.query("RETURN 1").first() == 1
+    finally:
+        connection.close()
+        for socket in opened:
+            try:
+                socket.close_socket()
+            except Exception:
+                pass
+
+
+async def test_async_connect_opens_one_socket_for_concurrent_callers(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    opened: list[Any] = []
+
+    # `connect()` calls `websockets.connect` directly, so the count is taken
+    # there rather than through a seam on the connection.
+    import surrealdb.connections.async_ws as module
+
+    real_connect = module.websockets.connect
+
+    def counting_connect(*args: Any, **kwargs: Any) -> Any:
+        awaitable = real_connect(*args, **kwargs)
+
+        async def record() -> Any:
+            socket = await awaitable
+            opened.append(socket)
+            return socket
+
+        return record()
+
+    module.websockets.connect = counting_connect  # type: ignore[misc,assignment]
+    try:
+        results = await asyncio.gather(
+            *[
+                connection.signin(connection_params["vars_params"])
+                for _ in range(CALLERS)
+            ],
+            return_exceptions=True,
+        )
+    finally:
+        module.websockets.connect = real_connect  # type: ignore[misc]
+
+    failures = [r for r in results if isinstance(r, BaseException)]
+    try:
+        assert not failures, (
+            f"{len(failures)} of {CALLERS} concurrent callers failed on a "
+            f"healthy connection; first was {failures[0]!r}"
+        )
+        assert len(opened) == 1, (
+            f"{CALLERS} concurrent callers opened {len(opened)} sockets; "
+            f"{len(opened) - 1} of them are leaked"
+        )
+        await connection.use(
+            namespace=connection_params["namespace"],
+            database=connection_params["database_name"],
+        )
+        assert await connection.query("RETURN 1").first() == 1
+    finally:
+        await connection.close()
+
+
+async def test_async_connect_survives_a_loop_it_was_not_built_in(
+    connection_params: dict[str, Any],
+) -> None:
+    """The connect lock is per-loop, so a reused connection must not trip on it.
+
+    An ``asyncio.Lock`` binds to the loop it first *waits* on, and stays bound:
+    awaiting it from a second loop raises ``RuntimeError``. Keeping one lock
+    for the lifetime of the connection would therefore break a connection
+    reused across two ``asyncio.run`` calls, each of which builds and discards
+    its own loop.
+
+    Both rounds contend the lock on purpose. An uncontended ``acquire()``
+    returns without ever looking at the loop, so a single caller per round
+    would pass no matter how the lock was built.
+    """
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+
+    def one_round() -> Any:
+        async def run() -> Any:
+            await asyncio.gather(
+                *[
+                    connection.signin(connection_params["vars_params"])
+                    for _ in range(CALLERS)
+                ]
+            )
+            await connection.use(
+                namespace=connection_params["namespace"],
+                database=connection_params["database_name"],
+            )
+            outcome = await connection.query("RETURN 1").first()
+            await connection.close()
+            return outcome
+
+        return asyncio.run(run())
+
+    # `asyncio.run` cannot be called from inside a running loop, so both rounds
+    # go to a worker thread that has none.
+    results: list[Any] = []
+
+    def worker() -> None:
+        results.append(one_round())
+        results.append(one_round())
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=60)
+
+    assert not thread.is_alive()
+    assert results == [1, 1]

--- a/tests/unit_tests/connections/test_nul_byte_errors.py
+++ b/tests/unit_tests/connections/test_nul_byte_errors.py
@@ -1,0 +1,81 @@
+"""A rejected value fails as a ``SurrealError``, on every server version.
+
+SurrealDB 2.x refuses a NUL byte in a record's data, and answers with a bare
+string where the protocol calls for an error object. Reading ``kind`` off that
+string raised ``AttributeError: 'str' object has no attribute 'get'`` from
+inside the SDK - no server message, and nothing an ``except SurrealError``
+would catch. 3.x stores the byte happily.
+
+Written as a property rather than a fixed expectation, so it runs on every leg
+of the server matrix: whether the value is accepted is the server's business,
+but *how a refusal is reported* is the SDK's, and it must never be an exception
+from outside the documented tree.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.errors import SurrealError
+
+NUL_DATA: dict[str, Any] = {"note": "before\x00after"}
+
+
+def _assert_typed(error: BaseException) -> None:
+    assert isinstance(error, SurrealError), (
+        f"a rejected value raised {type(error).__name__}, which callers cannot "
+        f"catch with `except SurrealError`: {error}"
+    )
+    assert str(error), "the server's explanation was lost"
+
+
+def test_blocking_ws_nul_byte(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    try:
+        blocking_ws_connection.create("nul_probe", NUL_DATA)
+    except Exception as error:  # noqa: BLE001 - the type is what is under test
+        _assert_typed(error)
+
+
+def test_blocking_http_nul_byte(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    try:
+        blocking_http_connection.create("nul_probe", NUL_DATA)
+    except Exception as error:  # noqa: BLE001
+        _assert_typed(error)
+
+
+async def test_async_ws_nul_byte(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    try:
+        await async_ws_connection.create("nul_probe", NUL_DATA)
+    except Exception as error:  # noqa: BLE001
+        _assert_typed(error)
+
+
+async def test_async_http_nul_byte(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    try:
+        await async_http_connection.create("nul_probe", NUL_DATA)
+    except Exception as error:  # noqa: BLE001
+        _assert_typed(error)
+
+
+def test_the_probe_itself_is_a_valid_create(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """Guards against the tests above passing because nothing reached the server.
+
+    A ``create`` that failed locally - a rejected table name, say - would still
+    raise a ``SurrealError`` and tell us nothing about how a *server* refusal
+    is reported. The same call with an ordinary value has to succeed.
+    """
+    assert blocking_ws_connection.create("nul_probe", {"note": "plain"}) is not None

--- a/tests/unit_tests/data_types/test_precise_datetime.py
+++ b/tests/unit_tests/data_types/test_precise_datetime.py
@@ -9,9 +9,13 @@ database*, silently.
 from SurrealDB can be written back unchanged.
 """
 
+import contextlib
 import copy
 import datetime as dt
+import os
 import pickle
+import time
+from collections.abc import Iterator
 
 import pytest
 
@@ -24,6 +28,28 @@ from surrealdb.data.types import constants
 def _compact(seconds: int, nanoseconds: int) -> bytes:
     """The `[seconds, nanoseconds]` frame SurrealDB sends for a datetime."""
     return dumps(CBORTag(constants.TAG_DATETIME_COMPACT, [seconds, nanoseconds]))
+
+
+@contextlib.contextmanager
+def _machine_timezone(name: str) -> Iterator[None]:
+    """Run the block as though the machine's local timezone were *name*.
+
+    ``TZ`` plus ``tzset()`` is what CPython reads for the local zone, which is
+    what ``astimezone()`` assumes when given a naive value. CI and most
+    developer machines run on UTC, where the naive-datetime bug below is
+    invisible, so the zone has to be imposed rather than observed.
+    """
+    previous = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if previous is None:
+            del os.environ["TZ"]
+        else:
+            os.environ["TZ"] = previous
+        time.tzset()
 
 
 def test_decoding_keeps_the_sub_microsecond_remainder() -> None:
@@ -65,6 +91,66 @@ def test_a_plain_datetime_is_encoded_exactly_as_before() -> None:
     plain = dt.datetime(2026, 1, 1, 0, 0, 0, 123456, tzinfo=dt.timezone.utc)
 
     assert loads(encode(plain)) == plain
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs a POSIX TZ database")
+@pytest.mark.parametrize(
+    "zone", ["UTC", "America/New_York", "Asia/Tokyo", "Australia/Adelaide"]
+)
+def test_a_naive_value_is_read_as_utc_whatever_the_machine_is_set_to(
+    zone: str,
+) -> None:
+    """The same wall clock must be the same instant on every machine.
+
+    ``astimezone`` treats a naive datetime as *local*, so this rendered a naive
+    ``PreciseDatetime`` in whatever zone the host happened to be configured
+    for - five hours off on a US East Coast machine, and exactly right on a UTC
+    one, which is what every CI leg runs on. Nothing the caller wrote decided
+    which; the host did.
+    """
+    with _machine_timezone(zone):
+        value = PreciseDatetime(2026, 1, 1, 12, 0, 0, nanosecond=7)
+
+        assert value.isoformat_with_nanoseconds() == "2026-01-01T12:00:00.000000007Z"
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs a POSIX TZ database")
+@pytest.mark.parametrize("zone", ["UTC", "America/New_York", "Asia/Tokyo"])
+def test_a_naive_value_agrees_with_a_naive_plain_datetime(zone: str) -> None:
+    """The two spellings of "no timezone" have to mean the same instant.
+
+    ``encode`` passes ``timezone=utc`` to cbor2, so a naive ``datetime`` has
+    always gone out as UTC. A naive ``PreciseDatetime`` is the same value with
+    more digits, and diverging from it turned adding precision into a silent
+    change of instant.
+    """
+    with _machine_timezone(zone):
+        naive = dt.datetime(2026, 1, 1, 12, 0, 0)
+        precise = PreciseDatetime(2026, 1, 1, 12, 0, 0)
+
+        assert loads(encode(naive)) == dt.datetime(
+            2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc
+        )
+        assert precise.isoformat_with_nanoseconds().startswith("2026-01-01T12:00:00")
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs a POSIX TZ database")
+@pytest.mark.parametrize("zone", ["UTC", "America/New_York"])
+def test_an_aware_value_is_still_converted_to_utc(zone: str) -> None:
+    """Reading naive values as UTC must not stop aware ones being converted."""
+    with _machine_timezone(zone):
+        value = PreciseDatetime(
+            2026,
+            1,
+            1,
+            12,
+            0,
+            0,
+            tzinfo=dt.timezone(dt.timedelta(hours=5)),
+            nanosecond=7,
+        )
+
+        assert value.isoformat_with_nanoseconds() == "2026-01-01T07:00:00.000000007Z"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
+++ b/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
@@ -142,6 +142,28 @@ def test_live_pass() -> None:
     assert isinstance(outcome, bytes)
 
 
+@pytest.mark.parametrize("diff", [True, False])
+def test_live_puts_diff_on_the_wire(diff: bool) -> None:
+    """``diff`` is the second parameter of the ``live`` RPC.
+
+    It was never encoded, so the server stayed on its default of full records
+    and ``live(table, diff=True)`` - accepted, typed and documented - silently
+    delivered something other than the JSON Patch it promised.
+    """
+    message = RequestMessage(RequestMethod.LIVE, table="person", diff=diff)
+
+    payload = decode(message.WS_CBOR_DESCRIPTOR)
+
+    assert payload["params"][1] is diff
+
+
+def test_live_defaults_diff_to_false() -> None:
+    """An omitted ``diff`` still has to be a bool, not a missing parameter."""
+    message = RequestMessage(RequestMethod.LIVE, table="person")
+
+    assert decode(message.WS_CBOR_DESCRIPTOR)["params"][1] is False
+
+
 def test_kill_pass() -> None:
     message = RequestMessage(
         RequestMethod.KILL, uuid="0189d6e3-8eac-703a-9a48-d9faa78b44b9"

--- a/tests/unit_tests/test_examples_use_the_real_api.py
+++ b/tests/unit_tests/test_examples_use_the_real_api.py
@@ -1,0 +1,111 @@
+"""Every ``db.<method>()`` in ``examples/`` names a method that exists.
+
+The 3.0 release removed ``db.merge(record, data)`` in favour of
+``db.update(record).merge(data)`` and documented the change in the README's own
+migration table - but every framework example kept calling the old form. Eleven
+files across fastapi, flask, quart, starlette, sanic, litestar, django, graphql,
+fastmcp, logfire and the Jupyter notebooks, all of which fail with
+``AttributeError`` the moment someone runs the example the docs point them at.
+
+Nothing imports or executes the examples, so nothing noticed. This does not run
+them either - most need a framework installed and a server up - but it does
+read them, which is enough to catch a method that no longer exists.
+
+Notebooks are included: the same call was in one of those too.
+"""
+
+import ast
+import json
+import pathlib
+import re
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+_CONNECTIONS: list[type] = [
+    BlockingWsSurrealConnection,
+    AsyncWsSurrealConnection,
+    BlockingHttpSurrealConnection,
+    AsyncHttpSurrealConnection,
+]
+
+# The embedded classes need the optional native extension, which most CI legs
+# do not install. They inherit the websocket API, so leaving them out narrows
+# the accepted set rather than widening it - a missing method is still caught.
+try:
+    from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection
+    from surrealdb.connections.blocking_embedded import (
+        BlockingEmbeddedSurrealConnection,
+    )
+except ImportError:  # pragma: no cover - depends on how the SDK was installed
+    pass
+else:
+    _CONNECTIONS += [BlockingEmbeddedSurrealConnection, AsyncEmbeddedSurrealConnection]
+
+_EXAMPLES = pathlib.Path(__file__).resolve().parents[2] / "examples"
+
+# Examples spell their connection `db` throughout, so this finds the calls
+# without needing to resolve names.
+_DB_CALL = re.compile(r"\bdb\.([A-Za-z_]\w*)\s*\(")
+
+
+def _public_api() -> set[str]:
+    """Every public method reachable on a connection, whichever kind it is."""
+    return {
+        name for cls in _CONNECTIONS for name in dir(cls) if not name.startswith("_")
+    }
+
+
+def _sources() -> list[tuple[pathlib.Path, str]]:
+    """Every example source, with notebook code cells flattened into text."""
+    found: list[tuple[pathlib.Path, str]] = []
+    for path in sorted(_EXAMPLES.rglob("*.py")):
+        found.append((path, path.read_text()))
+    for path in sorted(_EXAMPLES.rglob("*.ipynb")):
+        notebook = json.loads(path.read_text())
+        code = "\n".join(
+            "".join(cell.get("source", ""))
+            for cell in notebook.get("cells", [])
+            if cell.get("cell_type") == "code"
+        )
+        found.append((path, code))
+    return found
+
+
+def test_the_examples_directory_was_found() -> None:
+    """Guards the whole file against silently checking nothing."""
+    sources = _sources()
+    assert len(sources) > 20, f"only found {len(sources)} example sources"
+    assert any("db.select(" in text for _, text in sources)
+
+
+def test_no_example_calls_a_method_that_does_not_exist() -> None:
+    api = _public_api()
+    missing: dict[str, list[str]] = {}
+
+    for path, text in _sources():
+        for match in _DB_CALL.finditer(text):
+            method = match.group(1)
+            if method not in api:
+                missing.setdefault(method, []).append(
+                    str(path.relative_to(_EXAMPLES.parent))
+                )
+
+    assert not missing, "examples call methods the SDK does not have: " + "; ".join(
+        f"db.{method}() in {', '.join(sorted(set(files)))}"
+        for method, files in sorted(missing.items())
+    )
+
+
+def test_every_example_parses() -> None:
+    """An example that is not valid Python cannot be run by anyone."""
+    broken: list[str] = []
+    for path, text in _sources():
+        try:
+            ast.parse(text)
+        except SyntaxError as error:
+            broken.append(f"{path.name}: {error}")
+
+    assert not broken, "examples that do not parse: " + "; ".join(broken)

--- a/tests/unit_tests/test_into_mapping.py
+++ b/tests/unit_tests/test_into_mapping.py
@@ -372,6 +372,83 @@ def test_sync_select_without_into_returns_raw_dict(
     assert not isinstance(out, Person)
 
 
+@pytest.mark.parametrize(
+    "not_a_class",
+    [
+        pytest.param(5, id="int"),
+        pytest.param("Person", id="str"),
+        pytest.param(None, id="none"),
+        pytest.param([Person], id="list"),
+        pytest.param(lambda **kwargs: kwargs, id="function"),
+    ],
+)
+def test_into_rejects_something_that_is_not_a_class(not_a_class: Any) -> None:
+    """A caller mistake reports itself, rather than crashing the formatter.
+
+    Everything downstream renders its complaints with ``cls.__name__``, so a
+    non-class raised ``AttributeError: 'int' object has no attribute
+    '__name__'`` from inside the SDK's own error message - naming neither
+    ``into=`` nor the value - and only after the query had already been sent.
+
+    ``TypeError`` rather than a ``SurrealError``: nothing went wrong with the
+    database.
+    """
+    sent = False
+
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        nonlocal sent
+        sent = True
+        return _ok([])
+
+    builder = SyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+
+    with pytest.raises(TypeError, match="into="):
+        builder.into(not_a_class)
+
+    assert not sent, "the query was sent before the argument was checked"
+
+
+def test_async_into_rejects_something_that_is_not_a_class() -> None:
+    """The async builder validates on the call, not on the await."""
+
+    async def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok([])
+
+    builder = AsyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+
+    with pytest.raises(TypeError, match="into="):
+        builder.into(5)
+
+
+def test_select_into_rejects_something_that_is_not_a_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``into=`` keyword paths land on the same check."""
+    conn = BlockingHttpSurrealConnection("http://localhost:8000")
+
+    def fake_query_raw(
+        query: str, vars: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return _ok([{"id": RecordID("person", "tobie"), "name": "Tobie"}])
+
+    monkeypatch.setattr(conn, "query_raw", fake_query_raw)
+
+    with pytest.raises(TypeError, match="into="):
+        conn.select(RecordID("person", "tobie"), into=5)
+
+
+def test_into_still_accepts_every_supported_model_kind() -> None:
+    """The guard must not turn away the classes that are meant to work."""
+    rows = [{"id": RecordID("person", "a"), "name": "A"}]
+
+    def stub(query: str, params: dict[str, Any]) -> dict[str, Any]:
+        return _ok(rows)
+
+    for model in (Person, PlainPerson):
+        builder = SyncQueryBuilder(executor=stub, query="SELECT * FROM person")
+        assert isinstance(builder.into(model, rows=True)[0], model)
+
+
 def test_into_rejects_non_record_rows() -> None:
     """A non-record (scalar) row raises a clear error, not an opaque TypeError."""
     from surrealdb.connections.builders import _map_result

--- a/tests/unit_tests/test_malformed_responses.py
+++ b/tests/unit_tests/test_malformed_responses.py
@@ -1,0 +1,124 @@
+"""Nothing a server can send should surface as a bare ``AttributeError``.
+
+Three separate places read a value's shape without checking it, and all three
+failed the same way - an ``AttributeError`` raised from inside the SDK, outside
+the ``SurrealError`` tree, with a message naming neither the operation nor the
+value:
+
+* an RPC envelope that decodes to something other than a map;
+* an ``error`` field that is a bare string rather than an object. SurrealDB
+  2.x answers ``create("person", {"a": "x\\x00y"})`` this way - the NUL byte
+  fails serialisation before the error object is built - and reading ``kind``
+  off it raised ``AttributeError: 'str' object has no attribute 'get'``;
+* a non-class passed as ``into=``, which blew up in the SDK's own error
+  formatter while trying to render ``cls.__name__`` for a different complaint.
+
+Server-free: every one of these is about how a value is read, so they run on
+every CI leg rather than only where a server of the right version is up.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.utils_mixin import UtilsMixin
+from surrealdb.data.cbor import encode
+from surrealdb.errors import (
+    ServerError,
+    SurrealError,
+    UnexpectedResponseError,
+    parse_rpc_error,
+)
+
+# ------------------------------------------------------- non-map RPC envelope
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param([1, 2, 3], id="list"),
+        pytest.param("just a string", id="string"),
+        pytest.param(42, id="integer"),
+        pytest.param(None, id="null"),
+        pytest.param(True, id="boolean"),
+    ],
+)
+def test_a_response_that_is_not_a_map_raises_a_surreal_error(payload: Any) -> None:
+    with pytest.raises(UnexpectedResponseError) as caught:
+        UtilsMixin.decode_response(encode(payload), "querying")
+
+    # Both halves of a usable message: what we were doing, and what arrived.
+    assert "querying" in str(caught.value)
+    assert type(payload).__name__ in str(caught.value)
+    assert isinstance(caught.value, SurrealError)
+
+
+def test_a_map_response_is_returned_untouched() -> None:
+    """The guard must not change the ordinary path."""
+    assert UtilsMixin.decode_response(
+        encode({"id": "1", "result": []}), "querying"
+    ) == {
+        "id": "1",
+        "result": [],
+    }
+
+
+def test_an_undecodable_body_still_reports_the_operation() -> None:
+    with pytest.raises(UnexpectedResponseError) as caught:
+        UtilsMixin.decode_response(b"\xff\xff not cbor", "signing in")
+
+    assert "signing in" in str(caught.value)
+
+
+def test_a_huge_non_map_response_is_not_dumped_whole() -> None:
+    """A megabyte of unexpected payload does not belong in a traceback."""
+    with pytest.raises(UnexpectedResponseError) as caught:
+        UtilsMixin.decode_response(encode(["x" * 100] * 500), "querying")
+
+    assert len(str(caught.value)) < 500
+
+
+# ----------------------------------------------------- non-object error field
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("Parse error: unexpected character", id="bare-string"),
+        pytest.param(["a", "b"], id="list"),
+        pytest.param(-32000, id="integer"),
+    ],
+)
+def test_an_error_that_is_not_an_object_still_parses(raw: Any) -> None:
+    error = parse_rpc_error(raw)
+
+    assert isinstance(error, ServerError)
+    # The text the server sent has to survive - it is the only thing the
+    # caller has to go on.
+    assert str(raw) in str(error)
+
+
+def test_a_non_object_error_reaches_the_caller_through_check_response() -> None:
+    """The shape 2.x actually sends, through the method that actually reads it."""
+    response = {"id": "1", "error": "Serialization error: contained NUL byte"}
+
+    with pytest.raises(SurrealError) as caught:
+        UtilsMixin.check_response_for_error(response, "creating")
+
+    assert "contained NUL byte" in str(caught.value)
+
+
+def test_a_non_object_cause_does_not_break_the_chain() -> None:
+    error = parse_rpc_error({"kind": "Query", "message": "outer", "cause": "inner"})
+
+    assert isinstance(error.server_cause, ServerError)
+    assert "inner" in str(error.server_cause)
+
+
+def test_an_object_error_is_still_parsed_structurally() -> None:
+    """The guard must not swallow the structured path it sits in front of."""
+    error = parse_rpc_error({"kind": "NotFound", "message": "gone", "code": -32000})
+
+    assert error.kind == "NotFound"
+    assert error.code == -32000
+    assert str(error) == "gone"


### PR DESCRIPTION
Fixes the nine remaining pre-publication gate findings, plus one found while checking them. Each has a mutation its tests catch.

## §1 Three declared dependency floors are unusable

Two of them name versions at which `import surrealdb` raises:

```
$ pip install surrealdb pydantic-core==2.0.1   # satisfies the declared >=2.0.1
$ python -c "import surrealdb"
pydantic_core._pydantic_core.SchemaError: typed-dict.fields.params.type
  Field required
```

`cbor_ws` builds a `SchemaValidator` at module scope, and the `typed-dict-field` wrappers it uses arrive in 2.10.0. `websockets>=10.0` is the same class of error — `websockets.sync`, which the entire blocking transport is built on, does not exist before 11.0.

11.0 imports but deadlocks. Its message assembler blocks the reader thread until an unread frame is consumed, and `close()` joins that thread, so closing a connection with an undelivered live notification never returns. Bisected against the live-query teardown:

| websockets | result |
| --- | --- |
| 11.0 | deadlock (reader in `Assembler.put()`, main thread in `recv_events_thread.join()`) |
| 12.0 – 13.1 | passes, 10.26s — the full default close timeout, every teardown |
| 14.0+ | passes, 0.24s |

Floors are now `pydantic-core>=2.10.0` and `websockets>=14.0`. A third, `typing_extensions>=4.0.0`, predates `Buffer` (PEP 688, 4.6.0), which this package's own stubs import — `TYPE_CHECKING`-only so it still runs, but the SDK ships `py.typed` and a downstream checker cannot resolve the name.

**None of them had ever been exercised.** Every CI job runs `uv sync`, which installs the lockfile. A new `floors` job resolves `pyproject.toml` with `--resolution lowest-direct` — what a user with no pins of their own actually gets — and runs the suite against the built wheel at that result, with no `PYTHONPATH`. On the floors this PR replaces it fails with 32 collection errors.

## §2 HTTP returned data the caller did not ask for

`let()` bindings were written *over* the caller's per-query variables:

```python
db.let("limit", 99)
db.query("RETURN $limit", {"limit": 5})   # 99 on HTTP, 5 on a 3.x websocket
```

`query_raw` also merged into the dict the caller passed, so session bindings were left in an object the caller still held:

```
{'name': 'alice'} -> {'name': 'alice', 'secret': 'SESSION-SECRET'}
```

Both fixed. `query()` was never affected by the mutation — the builder copies — but `query_raw` is public and the copy is incidental, so both are pinned.

A 2.x websocket resolves the precedence the other way round, and the SDK sends an identical request either way:

| server | websocket | HTTP |
| --- | --- | --- |
| 2.0.5, 2.3.10 | `let()` wins | per-query wins |
| 3.2.3 | per-query wins | per-query wins |

Nothing to fix there without version detection, so the tests pin it per version and the README says so.

`unset()` on an unbound name also raised `KeyError` on HTTP alone — outside the `SurrealError` tree.

## §3 `live(table, diff=True)` never sent `diff`

`prep_live` encoded `[table]`, so the server stayed on its default. Accepted, typed and documented the whole time, silently delivering whole records instead of JSON Patch. The only observable difference is the shape of a notification nobody asserted on.

## §4 A naive `PreciseDatetime` was encoded as machine-local time

`astimezone` reads a naive value as local, while `encode` hands a naive `datetime` to cbor2 as UTC:

```
TZ=UTC              datetime -> 12:00:00Z   PreciseDatetime -> 12:00:00Z
TZ=America/New_York datetime -> 12:00:00Z   PreciseDatetime -> 17:00:00Z
```

Same wall clock, five hours apart, decided by the host rather than by anything the caller wrote. Every CI leg runs on UTC, which is exactly where the two agree; the new tests impose the zone with `TZ` + `tzset()`.

## §5 Three values still surfaced as a bare `AttributeError`

An RPC envelope that decodes to something other than a map; an `error` field that is a bare string, which is what 2.0.5 answers this with:

```python
db.create("person", {"a": "x\0y"})
# before: AttributeError: 'str' object has no attribute 'get'
# after:  InternalError: Serialization error: contained NUL byte
```

and a non-class passed as `into=`, which crashed inside the SDK's own error formatter while rendering `cls.__name__` for a different complaint. Now a `TypeError` raised before the query is sent.

## §6 Neither `connect()` was serialised

Measured on beta.4, eight concurrent callers on one connection:

```
blocking connect() x8 -> 8 sockets opened, 7 leaked
async  gather x8      -> 8 sockets opened, 7 leaked; 8 of 8 callers failed
                         ConnectionUnavailableError: WebSocket connection closed...
```

Each surplus async socket also started a reader over the shared future map, and the first to see its own socket close failed every pending future — so callers on the *surviving* socket were told the connection was gone. After: one socket, nothing leaked, no failures. The async lock is rebuilt when the loop changes, since a connection reused across two `asyncio.run` calls would otherwise trip on a lock bound to a dead loop.

## §7 An async live subscriber waited forever when the connection died

The reader failed pending RPC futures on its way out but never woke the live queues — subscribers wait on a queue, not a future, so `async for` never came back. It now raises `ConnectionUnavailableError`, as the blocking transport always has. Deliberately not a silent `return`: that is what `kill()` and `close()` produce, and a consumer that cannot tell them apart goes on believing it has seen every change to the table.

## §8 Every framework example called a method removed in 3.0

`db.merge(record, data)` in eleven files across fastapi, flask, quart, starlette, sanic, litestar, django, graphql, fastmcp, logfire and a notebook — a change this README's own migration table documents. `examples/embedded/basic_sync.py` also built a query builder it never executed, so it printed the builder.

Nothing imports the examples, so nothing noticed. A new test reads every `db.<method>()` in `examples/` and checks it against the real API; reverting the examples makes it name all eleven files.

## Verification

Against the built wheel installed into a clean venv — never `./src`, never PyPI:

| target | result |
| --- | --- |
| SurrealDB 3.2.3 | 1102 passed |
| SurrealDB 2.3.10 | 1075 passed |
| SurrealDB 2.0.5 | 1075 passed |
| no server reachable | 648 passed, 463 skipped |
| every declared floor | 1102 passed |

Plus 1148 passing with the embedded engine, and clean `ruff`, `mypy` (src and tests) and `pyright` at the existing baseline.
