### PR TITLE
Refresh the lockfile the dependency-floor change left stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
         with:
           python-version: "3.13"
 
+      # `uv sync` resolves and installs without complaining that the lockfile
+      # disagrees with pyproject.toml, so a dependency change that skipped
+      # `uv lock` went green everywhere and only surfaced at release time, when
+      # the release PR refreshes the lock and picks up someone else's edit.
+      - name: Assert uv.lock is up to date with pyproject.toml
+        run: uv lock --check
+
       - name: Build wheel
         run: uv build --wheel
 

--- a/uv.lock
+++ b/uv.lock
@@ -1628,11 +1628,11 @@ test = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.12.0" },
-    { name = "pydantic-core", specifier = ">=2.0.1" },
+    { name = "pydantic-core", specifier = ">=2.10.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "surrealdb-embedded", marker = "extra == 'embedded'", editable = "embedded" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0.0" },
-    { name = "websockets", specifier = ">=10.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["embedded", "pydantic"]
 


### PR DESCRIPTION
Follow-up to the dependency-floor PR: it raised three specifiers in `pyproject.toml` and did not run `uv lock`, so the lockfile still records the versions it replaced.

```
$ uv lock --check
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

```diff
-    { name = "pydantic-core", specifier = ">=2.0.1" },
+    { name = "pydantic-core", specifier = ">=2.10.0" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.0.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0" },
-    { name = "websockets", specifier = ">=10.0" },
+    { name = "websockets", specifier = ">=14.0" },
```

Two of the stale entries name versions at which `import surrealdb` raises — the same ones that PR was fixing.

**Nothing caught it because no job runs `uv lock --check`.** `uv sync` resolves and installs happily against a lockfile that disagrees with the project, so all 40 checks went green. It would have surfaced at release time, where step 2 of the release process refreshes both lockfiles — quietly folding an unrelated dependency change into a commit titled `Release 3.0.0-beta.5`.

So this also adds the check, in the packaging job alongside the other "is the distributed artifact actually right" assertions. It fails on the lockfile this PR replaces and passes on the refreshed one.

`embedded/Cargo.lock` was already current — checked, no change needed.