### PR TITLE
Stop a read-modify-write from deleting every NULL field it touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,58 @@ with Surreal("ws://localhost:8000/rpc") as db:
   separate connection per live subscription (or the async client, which
   fans notifications out to per-subscriber queues).
 
+## `None`, `Null`, and empty values
+
+SurrealDB has two ways for a field to hold nothing, and they are different
+values:
+
+| SurrealQL | meaning | Python |
+| --------- | ------- | ------ |
+| `NONE`    | the field is not there | `None` |
+| `NULL`    | the field is there and is null | `surrealdb.Null` |
+
+An unset `option<T>` column is NONE, and a NONE field does not appear in a
+record at all when you read it. NULL is a value the field holds, and a column
+has to be declared to permit it — `option<T>` alone does not, and rejects NULL.
+
+```python
+from surrealdb import Null
+
+db.create(rec, {"age": None})    # age is NONE — what option<int> expects
+db.create(rec, {"age": Null})    # age is NULL — rejected by option<int>
+```
+
+This matters most when you read a record and write it back. A NULL field reads
+as `Null`, and sending `Null` back writes NULL again, so the round trip keeps
+the field:
+
+```python
+row = db.select(rec)             # {"nickname": Null}
+row["name"] = "new name"
+db.update(rec, row)              # nickname is still NULL
+```
+
+`Null` is falsy, like `None`, so `if not row["nickname"]` reads the way you
+would expect. It is deliberately **not** equal to `None` — the two are
+different values to the server, and treating them as one is what used to make
+the write-back above delete the field.
+
+> Before 3.0.0-beta.5 a NULL field decoded to `None`, which encoded back to
+> NONE — so an ordinary read-modify-write silently *removed* every NULL field
+> it touched. If you have code comparing a database value with `is None`,
+> check whether the column can be NULL.
+
+**Sets read back as lists.** SurrealDB's `set<T>` accepts any member type,
+including `set<object>` and `set<array>`, which a Python `set` cannot hold. A
+set therefore decodes to a `list` — the same shape SurrealDB 2.x and the
+server's own JSON endpoint return. Writing is unchanged: a Python `set` still
+goes out as a set, and the server deduplicates it.
+
+```python
+db.create(rec, {"tags": {"a", "b"}})   # stored as a set
+db.select(rec)["tags"]                 # ['a', 'b'] — a list
+```
+
 ## Error handling
 
 Every error the SDK raises derives from `SurrealError`, so a single
@@ -580,6 +632,8 @@ v3.0 is a breaking change. Highlights:
 | Sync `db.create(rec)[...]` (magic auto-exec)     | Sync `db.create(rec, data)` eager, or `db.create(rec).execute()` |
 | `db.select(RecordID(...))` -> `[record]`         | `db.select(RecordID(...))` -> `record` dict or `None`     |
 | `db.delete("my-table")` (silently inlined)       | `db.delete(Table("my-table"))` (raw string rejected)      |
+| A NULL field read as `None`                      | A NULL field reads as `Null` (`None` still means NONE)    |
+| `set<T>` read as a Python `set`                  | `set<T>` reads as a `list` (writing a `set` is unchanged) |
 
 > Bare-string resource targets are now strictly validated against the
 > safe-identifier pattern (`[A-Za-z_][A-Za-z0-9_]*`) so user-supplied

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -39,6 +39,7 @@ from surrealdb.connections.url import Url, UrlScheme
 from surrealdb.data.types.datetime import Datetime, PreciseDatetime
 from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
+from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import Range
 from surrealdb.data.types.record_id import RecordID, escape_identifier
 from surrealdb.data.types.table import Table
@@ -120,6 +121,8 @@ __all__ = [
     "RecordID",
     "Datetime",
     "PreciseDatetime",
+    "Null",
+    "NullType",
     "Tokens",
     "Value",
     "escape_identifier",

--- a/src/surrealdb/cbor/_decoder.py
+++ b/src/surrealdb/cbor/_decoder.py
@@ -60,6 +60,7 @@ class CBORDecoder:
         "_immutable",
         "_str_errors",
         "_stringref_namespace",
+        "null_value",
     )
 
     _fp: IO[bytes]  # pyright: ignore[reportUninitializedInstanceVariable]
@@ -104,6 +105,10 @@ class CBORDecoder:
         self._shareables: list[object] = []
         self._stringref_namespace: list[str | bytes] | None = None
         self._immutable = False
+        # What a plain CBOR null decodes to. `None` here, as CBOR says; the
+        # SurrealDB layer sets it to `Null`, because on that wire a null is
+        # SurrealDB's NULL and has to stay distinct from its NONE.
+        self.null_value: Any = None
 
     @property
     def immutable(self) -> bool:
@@ -612,7 +617,11 @@ class CBORDecoder:
     def decode_none(self) -> None:
         # Semantic tag 6
         value = self._decode()
-        if not isinstance(value, type(None)):
+        # The payload is a plain CBOR null, which `null_value` decides the
+        # Python spelling of - so compare against that rather than against
+        # `None`, or a decoder configured for a different null (SurrealDB's
+        # `Null`) rejects its own well-formed tag 6.
+        if value is not self.null_value:
             raise CBORDecodeValueError("invalid None value " + str(value))
 
         return self.set_shareable(None)
@@ -784,7 +793,7 @@ major_decoders: dict[int, Callable[[CBORDecoder, int], Any]] = {
 special_decoders: dict[int, Callable[[CBORDecoder], Any]] = {
     20: lambda self: False,
     21: lambda self: True,
-    22: lambda self: None,
+    22: lambda self: self.null_value,
     23: lambda self: undefined,
     24: CBORDecoder.decode_simple_value,
     25: CBORDecoder.decode_float16,

--- a/src/surrealdb/data/__init__.py
+++ b/src/surrealdb/data/__init__.py
@@ -8,10 +8,13 @@ from surrealdb.data.types.geometry import (
     GeometryPoint,
     GeometryPolygon,
 )
+from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.record_id import RecordID
 from surrealdb.data.types.table import Table
 
 __all__ = (
+    "Null",
+    "NullType",
     "GeometryPoint",
     "GeometryLine",
     "GeometryPolygon",

--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -8,7 +8,6 @@ from surrealdb.cbor import (
     CBORDecoder,
     CBOREncoder,
     CBORTag,
-    loads,
     shareable_encoder,
 )
 from surrealdb.data.types import constants
@@ -23,10 +22,14 @@ from surrealdb.data.types.geometry import (
     GeometryPoint,
     GeometryPolygon,
 )
+from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
 from surrealdb.data.types.record_id import RecordID
 from surrealdb.data.types.table import Table
 from surrealdb.errors import UnexpectedResponseError
+
+# Plain CBOR null: major type 7, subtype 22.
+_CBOR_NULL_SUBTYPE = 22
 
 
 @shareable_encoder
@@ -82,6 +85,13 @@ def default_encoder(encoder: CBOREncoder, obj: Any) -> None:
         # SurrealDB uses its own set tag (56); the bundled cbor2 encoder would
         # otherwise emit tag 258, which our decoder does not understand.
         tagged = CBORTag(constants.TAG_SET, list(obj))
+
+    elif isinstance(obj, NullType):
+        # Plain CBOR null, which SurrealDB reads as NULL. `None` is handled by
+        # the encoder's own `encode_none` and goes out as tag 6 (NONE) - see
+        # `surrealdb.data.types.null` for why the two are kept apart.
+        encoder.encode_length(7, _CBOR_NULL_SUBTYPE)
+        return
 
     else:
         # `BufferError` means a buffer operation failed; this is "you handed me
@@ -182,7 +192,17 @@ def tag_decoder(
         return decimal.Decimal(tag.value)
 
     elif tag.tag == constants.TAG_SET:
-        return set(tag.value) if isinstance(tag.value, list) else tag.value
+        # A list, not a Python `set`. SurrealDB's set holds any value - a
+        # `set<object>` or `set<array>` field is ordinary - while a Python set
+        # takes only hashable members, so `set(...)` raised `unhashable type:
+        # 'dict'` and took the whole response with it. Every `SELECT *` over
+        # such a table failed, and the field could not be read at all.
+        #
+        # A list is also what SurrealDB 2.x returns for a set, and what the
+        # server's own JSON endpoint returns, so this is the shape the rest of
+        # the ecosystem already uses. Encoding is unchanged: a Python `set`
+        # still goes out under the set tag.
+        return list(tag.value) if isinstance(tag.value, list) else tag.value
 
     else:
         # Unlike the encoder's unsupported-type case, this is not a caller
@@ -252,4 +272,14 @@ def encode(obj: Any) -> bytes:
 
 
 def decode(data: bytes) -> Any:
-    return loads(data, tag_hook=tag_decoder)
+    """Decode a SurrealDB CBOR payload.
+
+    Plain CBOR null becomes :data:`Null`, not ``None``: on this wire a null is
+    SurrealDB's NULL, which is a different value from its NONE. The public
+    ``surrealdb.cbor`` package is a general-purpose CBOR implementation and is
+    left alone - ``loads(b"\\xf6")`` there still returns ``None``.
+    """
+    with BytesIO(data) as fp:
+        decoder = CBORDecoder(fp, tag_hook=tag_decoder)
+        decoder.null_value = Null
+        return decoder.decode()

--- a/src/surrealdb/data/types/null.py
+++ b/src/surrealdb/data/types/null.py
@@ -1,0 +1,82 @@
+"""SurrealDB's ``NULL``, which Python's ``None`` cannot represent on its own.
+
+SurrealDB has two ways for a field to hold nothing, and they are not the same
+value:
+
+``NONE``
+    The field is not there. An unset ``option<T>`` column is NONE, and a NONE
+    field does not appear in a record at all when you read it.
+
+``NULL``
+    The field is there and its value is null. A column has to be declared to
+    permit it - ``option<T>`` alone does not, and rejects NULL.
+
+Python has one ``None``, so the SDK has to say which one it means. ``None``
+means NONE, because that is what ``option<T>`` columns take and they are the
+common case. ``Null`` means NULL.
+
+This distinction is not cosmetic: without it, reading a record and writing it
+back destroyed data. A NULL field read as ``None`` and sent back as NONE does
+not stay null - the field is *removed*, silently, on the most ordinary
+operation there is:
+
+    row = db.select(rec)      # {"nickname": Null}
+    row["name"] = "new name"
+    db.update(rec, row)       # nickname stays NULL, because Null went back
+
+Reading a NULL field gives ``Null``, so writing that record back sends NULL
+again and the round trip is lossless.
+"""
+
+from typing import Any, NoReturn
+
+
+class NullType:
+    """The type of :data:`Null`. There is only ever one instance.
+
+    Falsy, like ``None``, so ``if not row["nickname"]`` behaves the way it
+    reads. Deliberately *not* equal to ``None``: the whole point is that the
+    two are different values to SurrealDB, and quietly comparing equal would
+    put back exactly the confusion this type exists to remove.
+    """
+
+    _instance: "NullType | None" = None
+
+    def __new__(cls) -> "NullType":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "Null"
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return hash(NullType)
+
+    def __eq__(self, other: object) -> bool:
+        return other is self
+
+    def __ne__(self, other: object) -> bool:
+        return other is not self
+
+    # Copying and pickling have to preserve the singleton, or `Null` read back
+    # out of a deepcopy or a cache would compare unequal to the real one and
+    # `is Null` checks would start failing for no visible reason.
+    def __copy__(self) -> "NullType":
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "NullType":
+        return self
+
+    def __reduce__(self) -> tuple[type["NullType"], tuple[()]]:
+        return (NullType, ())
+
+    def __setattr__(self, name: str, value: Any) -> NoReturn:
+        raise AttributeError("Null is immutable")
+
+
+Null = NullType()
+"""SurrealDB's ``NULL``. See :class:`NullType`."""

--- a/src/surrealdb/types.py
+++ b/src/surrealdb/types.py
@@ -23,6 +23,7 @@ from surrealdb.data.types.geometry import (
     GeometryPoint,
     GeometryPolygon,
 )
+from surrealdb.data.types.null import NullType
 from surrealdb.data.types.range import Range
 from surrealdb.data.types.record_id import RecordID
 from surrealdb.data.types.table import Table
@@ -34,6 +35,9 @@ Value = (
     | float
     | bool
     | None
+    # SurrealDB's NULL, which is a different value from NONE (`None`) -
+    # see `surrealdb.data.types.null`.
+    | NullType
     | bytes
     | UUID
     | Decimal

--- a/tests/unit_tests/connections/test_null_round_trip.py
+++ b/tests/unit_tests/connections/test_null_round_trip.py
@@ -1,0 +1,253 @@
+"""Reading a record and writing it back does not delete its NULL fields.
+
+SurrealDB has two ways for a field to hold nothing. NONE means the field is not
+there - an unset ``option<T>`` column is NONE, and a NONE field does not appear
+in a record at all. NULL means the field is there and its value is null.
+
+Python has one ``None``, and the SDK used it for both: a NULL field decoded to
+``None``, and ``None`` encoded to NONE. That made the most ordinary operation
+there is destructive:
+
+    row = db.select(rec)      # {"nickname": None}   <- NULL in the table
+    row["name"] = "new name"
+    db.update(rec, row)       # nickname is now GONE, not NULL
+
+No error, no warning, and the field is not merely null afterwards - it is
+absent. A read-modify-write loop over a table with nullable columns stripped
+them one record at a time.
+
+``Null`` is now a distinct value: a NULL field decodes to ``Null``, and ``Null``
+encodes back to NULL, so the round trip is lossless. ``None`` still means NONE,
+which is what keeps ``option<T>`` columns working - they accept NONE and
+*reject* NULL, so mapping ``None`` to NULL instead would have broken every
+schema that uses one.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.null import Null
+from surrealdb.data.types.record_id import RecordID
+
+TABLE = "null_round_trip"
+OPTION_TABLE = "null_round_trip_opt"
+
+
+def _record(name: str) -> RecordID:
+    return RecordID(TABLE, name)
+
+
+@pytest.fixture(autouse=True)
+def _empty_tables(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
+    """Start every test from empty tables.
+
+    These tests ``create()`` fixed record ids, which is an error if the record
+    survives from an earlier run - and the whole suite shares one namespace.
+    Without this the file passes once and then fails with ``AlreadyExistsError``
+    on every run after, which looks exactly like the defect coming back.
+
+    ``REMOVE ... IF EXISTS`` rather than ``DELETE``: the schema defined below
+    has to go too, and ``DELETE`` on a table that does not exist yet raises.
+    """
+    blocking_ws_connection.query(
+        f"REMOVE TABLE IF EXISTS {TABLE}; REMOVE TABLE IF EXISTS {OPTION_TABLE};"
+    ).execute()
+
+
+# ------------------------------------------------- the read-modify-write path
+
+
+def test_blocking_ws_read_modify_write_keeps_a_null_field(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    record = _record("bws")
+    blocking_ws_connection.query(
+        f"CREATE {TABLE}:bws SET name = 'ada', nickname = NULL;"
+    ).execute()
+
+    row = blocking_ws_connection.select(record)
+    assert row["nickname"] is Null, "a NULL field must decode to Null, not None"
+
+    row["name"] = "ada l."
+    blocking_ws_connection.update(record, row)
+
+    after = blocking_ws_connection.select(record)
+    assert "nickname" in after, "the NULL field was deleted by writing the record back"
+    assert after["nickname"] is Null
+    assert (
+        blocking_ws_connection.query(f"RETURN {TABLE}:bws.nickname IS NULL;").first()
+        is True
+    )
+
+
+def test_blocking_http_read_modify_write_keeps_a_null_field(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    record = _record("bhttp")
+    blocking_http_connection.query(
+        f"CREATE {TABLE}:bhttp SET name = 'ada', nickname = NULL;"
+    ).execute()
+
+    row = blocking_http_connection.select(record)
+    row["name"] = "ada l."
+    blocking_http_connection.update(record, row)
+
+    after = blocking_http_connection.select(record)
+    assert "nickname" in after
+    assert after["nickname"] is Null
+
+
+async def test_async_ws_read_modify_write_keeps_a_null_field(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    record = _record("aws")
+    await async_ws_connection.query(
+        f"CREATE {TABLE}:aws SET name = 'ada', nickname = NULL;"
+    ).execute()
+
+    row = await async_ws_connection.select(record)
+    row["name"] = "ada l."
+    await async_ws_connection.update(record, row)
+
+    after = await async_ws_connection.select(record)
+    assert "nickname" in after
+    assert after["nickname"] is Null
+
+
+async def test_async_http_read_modify_write_keeps_a_null_field(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    record = _record("ahttp")
+    await async_http_connection.query(
+        f"CREATE {TABLE}:ahttp SET name = 'ada', nickname = NULL;"
+    ).execute()
+
+    row = await async_http_connection.select(record)
+    row["name"] = "ada l."
+    await async_http_connection.update(record, row)
+
+    after = await async_http_connection.select(record)
+    assert "nickname" in after
+    assert after["nickname"] is Null
+
+
+# ------------------------------------------------- writing each value directly
+
+
+def test_writing_null_stores_null(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    created = blocking_ws_connection.create(
+        _record("explicit_null"), {"name": "bob", "nickname": Null}
+    )
+
+    assert created["nickname"] is Null
+    assert (
+        blocking_ws_connection.query(
+            f"RETURN {TABLE}:explicit_null.nickname IS NULL;"
+        ).first()
+        is True
+    )
+
+
+def test_writing_none_stores_none(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """``None`` still means NONE, so the field is not set to anything.
+
+    Asserted against the server rather than against the returned record:
+    SurrealDB 2.x echoes a NONE key back in the record it returns while 3.x
+    omits it, and that difference says nothing about what was stored. What
+    matters is that the value is NONE and specifically *not* NULL.
+    """
+    blocking_ws_connection.create(
+        _record("explicit_none"), {"name": "bob", "nickname": None}
+    )
+
+    assert (
+        blocking_ws_connection.query(
+            f"RETURN {TABLE}:explicit_none.nickname IS NONE;"
+        ).first()
+        is True
+    )
+    assert (
+        blocking_ws_connection.query(
+            f"RETURN {TABLE}:explicit_none.nickname IS NULL;"
+        ).first()
+        is False
+    )
+
+
+def test_none_is_still_accepted_by_an_option_field(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The case that rules out simply making ``None`` mean NULL.
+
+    ``option<T>`` is how a SurrealDB schema spells a nullable column, and it
+    accepts NONE but *rejects* NULL. If ``None`` were encoded as NULL, every
+    ``create(rec, {"age": None})` against such a schema would start failing
+    with a coercion error.
+    """
+    blocking_ws_connection.query(
+        f"DEFINE TABLE {OPTION_TABLE} SCHEMAFULL; "
+        f"DEFINE FIELD age ON {OPTION_TABLE} TYPE option<int>;"
+    ).execute()
+
+    # No exception is the assertion: NULL here is a coercion error.
+    created = blocking_ws_connection.create(OPTION_TABLE, {"age": None})
+
+    assert created["id"] is not None
+    assert created.get("age") is None, "an option<int> set to NONE is not a value"
+
+
+def test_null_is_rejected_by_an_option_field(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The other half: the two values are genuinely different to the server."""
+    blocking_ws_connection.query(
+        f"DEFINE TABLE {OPTION_TABLE} SCHEMAFULL; "
+        f"DEFINE FIELD age ON {OPTION_TABLE} TYPE option<int>;"
+    ).execute()
+
+    with pytest.raises(Exception, match="(?i)coerce|expected"):
+        blocking_ws_connection.create(OPTION_TABLE, {"age": Null})
+
+
+def test_null_survives_nested_in_containers(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """Not just top-level fields: inside a list or an object too."""
+    payload: dict[str, Any] = {
+        "items": [1, Null, 3],
+        "nested": {"inner": Null},
+    }
+    created = blocking_ws_connection.create(_record("nested"), payload)
+
+    assert created["items"] == [1, Null, 3]
+    assert created["nested"] == {"inner": Null}
+
+
+@pytest.mark.parametrize(
+    ("label", "value"),
+    [
+        pytest.param("null", Null, id="null"),
+        pytest.param("zero", 0, id="zero"),
+        pytest.param("false", False, id="false"),
+        pytest.param("empty_string", "", id="empty-string"),
+        pytest.param("empty_list", [], id="empty-list"),
+        pytest.param("empty_object", {}, id="empty-object"),
+    ],
+)
+def test_falsy_values_are_all_preserved(
+    blocking_ws_connection: BlockingWsSurrealConnection, label: str, value: Any
+) -> None:
+    """``Null`` is not the only value that could be mistaken for "absent"."""
+    created = blocking_ws_connection.create(_record(f"falsy_{label}"), {"v": value})
+
+    assert "v" in created, f"{value!r} was dropped from the record"
+    assert created["v"] == value

--- a/tests/unit_tests/test_cbor_modules.py
+++ b/tests/unit_tests/test_cbor_modules.py
@@ -14,6 +14,7 @@ from surrealdb.cbor import (
 )
 from surrealdb.data import cbor
 from surrealdb.data.types import constants
+from surrealdb.data.types.null import Null
 
 
 def test_public_cbor_api_exports() -> None:
@@ -89,35 +90,81 @@ def test_set_encodes_with_surreal_set_tag() -> None:
     assert encoded[:3] != b"\xd9\x01\x02"
 
 
-def test_set_roundtrip() -> None:
-    """A Python set round-trips back to a set."""
-    original = {1, 2, 3}
-    decoded = cbor.decode(cbor.encode(original))
-    assert isinstance(decoded, set)
-    assert decoded == original
+def test_set_encodes_from_a_set_and_decodes_to_a_list() -> None:
+    """A Python set is sent as a set and comes back as a list.
+
+    Deliberately asymmetric. SurrealDB's set holds any value - `set<object>`
+    is an ordinary column - while a Python set takes only hashable members, so
+    decoding into one raised `unhashable type: 'dict'` and lost the whole
+    response. A list is also what SurrealDB 2.x and the server's JSON endpoint
+    return for a set.
+    """
+    decoded = cbor.decode(cbor.encode({1, 2, 3}))
+    assert isinstance(decoded, list)
+    assert sorted(decoded) == [1, 2, 3]
 
 
-def test_frozenset_roundtrip() -> None:
-    """A frozenset encodes via the set tag and decodes back to a set."""
+def test_frozenset_encodes_via_the_set_tag() -> None:
+    """A frozenset encodes via the set tag and decodes to a list."""
     encoded = cbor.encode(frozenset({4, 5, 6}))
     assert encoded[:2] == b"\xd8\x38"
     decoded = cbor.decode(encoded)
-    assert isinstance(decoded, set)
-    assert decoded == {4, 5, 6}
+    assert isinstance(decoded, list)
+    assert sorted(decoded) == [4, 5, 6]
 
 
 def test_nested_set_roundtrip() -> None:
-    """Sets nested inside containers also use the set tag and round-trip."""
-    original = {"nums": {7, 8, 9}}
-    decoded = cbor.decode(cbor.encode(original))
-    assert decoded == {"nums": {7, 8, 9}}
-    assert isinstance(decoded["nums"], set)
+    """Sets nested inside containers also use the set tag."""
+    decoded = cbor.decode(cbor.encode({"nums": {7, 8, 9}}))
+    assert isinstance(decoded["nums"], list)
+    assert sorted(decoded["nums"]) == [7, 8, 9]
 
 
-def test_none_still_encodes_as_tag_6() -> None:
-    """None is encoded natively as SurrealDB's NONE tag (6): 0xc6 0xf6."""
+def test_a_set_of_unhashable_values_decodes() -> None:
+    """The defect: a `set<object>` could not be read at all.
+
+    `set(...)` on the decoded members raised `unhashable type: 'dict'`, which
+    `decode_response` turned into an `UnexpectedResponseError` covering the
+    whole reply - so any `SELECT *` touching such a field failed, and the row
+    was unreadable in its native form.
+    """
+    raw = dumps(CBORTag(constants.TAG_SET, [{"k": "a"}, {"k": "b"}]))
+    assert cbor.decode(raw) == [{"k": "a"}, {"k": "b"}]
+
+    raw = dumps(CBORTag(constants.TAG_SET, [[1, 2], [3, 4]]))
+    assert cbor.decode(raw) == [[1, 2], [3, 4]]
+
+
+def test_none_encodes_as_the_none_tag() -> None:
+    """``None`` means SurrealDB's NONE: tag 6, 0xc6 0xf6."""
     assert cbor.encode(None) == b"\xc6\xf6"
     assert cbor.decode(cbor.encode(None)) is None
+
+
+def test_null_encodes_as_plain_cbor_null() -> None:
+    """``Null`` means SurrealDB's NULL: plain CBOR null, 0xf6."""
+    assert cbor.encode(Null) == b"\xf6"
+    assert cbor.decode(cbor.encode(Null)) is Null
+
+
+def test_null_and_none_stay_distinct_through_a_round_trip() -> None:
+    """The whole point: the two must not collapse into each other.
+
+    They did, and it cost data - a NULL field read as ``None`` went back as
+    NONE, which deletes the field rather than nulling it.
+    """
+    payload = {"a": Null, "b": None, "c": [Null, None], "d": {"e": Null}}
+    assert cbor.decode(cbor.encode(payload)) == payload
+
+
+def test_the_generic_cbor_package_still_decodes_null_as_none() -> None:
+    """``surrealdb.cbor`` is a general-purpose CBOR codec and stays standard.
+
+    Only the SurrealDB layer knows that a null on its wire means NULL; a
+    caller using the re-exported cbor2 API must still get plain ``None``.
+    """
+    assert loads(b"\xf6") is None
+    assert loads(dumps(None)) is None
 
 
 def test_decimal_still_encodes_as_tag_10() -> None:


### PR DESCRIPTION
The two data-loss findings from the beta.5 gate.

## §1 A read-modify-write silently deletes NULL fields

SurrealDB has two ways for a field to hold nothing, and they are different values. **NONE** means the field is not there — an unset `option<T>` column is NONE, and a NONE field does not appear in a record at all. **NULL** means the field is there and its value is null.

Python has one `None`, and the SDK used it for both. So:

```
1. read              : {'id': u:ada, 'name': 'ada', 'nickname': None}
   nickname IS NULL  : True
2. after write-back  : {'id': u:ada, 'name': 'ada l.'}      ← field gone
   nickname IS NONE  : True
```

No error, no warning, and afterwards the field is not merely null — it is absent. A read-modify-write loop over a table with nullable columns strips them one record at a time.

`Null` is now a distinct value: a NULL field decodes to `Null`, and `Null` encodes back to NULL.

```python
from surrealdb import Null

row = db.select(rec)          # {"nickname": Null}
row["name"] = "ada l."
db.update(rec, row)           # nickname is still NULL

db.create(rec, {"age": None}) # NONE — what option<int> expects
db.create(rec, {"x": Null})   # NULL — explicit
```

**`None` deliberately keeps meaning NONE.** The obvious fix is a one-byte change making `None` encode as NULL, and it is wrong: `option<T>` is how a SurrealDB schema spells a nullable column, and it accepts NONE but *rejects* NULL. I tried it first and the existing `test_none.py` caught it —

```
InternalError: Couldn't coerce value for field `nums`:
Expected `none | int` but found `NULL`
```

— so that mapping would break every schema using `option<T>`, which is the common case.

Nothing is lost by being unable to send NONE explicitly: no server sends it back to distinguish against either. Verified on 3.2.3 and 2.0.5 with a decoder tag hook — **neither emits CBOR tag 6 for any value in any position**. A NULL field arrives as plain null and a NONE field is absent from the record, so a decoded null can only have come from NULL.

Only the SurrealDB layer changes. `surrealdb.cbor` is a general-purpose CBOR codec and `loads(b"\xf6")` there still returns `None`; the decoder grew a `null_value` seam that the SurrealDB layer sets.

`Null` is falsy like `None`, is a pickle- and copy-stable singleton, and is deliberately **not** equal to `None` — treating the two as one is what caused this.

## §2 A `set<object>` field cannot be read at all

The set tag decoded into a Python `set`, which only takes hashable members:

```
RETURN <set>[1,2,3]   : {1, 2, 3}
RETURN <set>[{a:1}]   : UnexpectedResponseError: unhashable type: 'dict'
RETURN <set>[[1,2]]   : UnexpectedResponseError: unhashable type: 'list'
```

`decode_response` turned that into an error covering the whole reply, so any `SELECT *` touching such a field failed and the row was unreadable in its native form — while the server held the data perfectly well and returned it fine over `/sql`.

Sets now decode to a `list`, which is what SurrealDB 2.x and the server's own JSON endpoint already return. Encoding is unchanged: a Python `set` still goes out under the set tag and the server deduplicates it.

## Migration

Both rows are in the README's migration table, and there is a new `None`, `Null`, and empty values section. The behaviour change worth flagging to users: **code comparing a database value with `is None` should check whether the column can be NULL.**

## Verification

Against the built wheel installed into a clean venv — never `./src`, never PyPI:

| target | result |
| --- | --- |
| SurrealDB 3.2.3 | 1121 passed |
| SurrealDB 2.3.10 | 1094 passed |
| SurrealDB 2.0.5 | 1094 passed |
| no server reachable | 652 passed, 478 skipped |
| embedded engine | 1167 passed |

Three mutations — decoding null as `None`, encoding `Null` as NONE, and decoding the set tag back into a `set` — are each caught. Clean `ruff`, `mypy` (src and tests), and `pyright` at the existing baseline.

One test caught a genuine 2.x/3.x difference along the way: 2.0.5 echoes a NONE key back in the returned record while 3.x omits it. Both store NONE correctly, so the test now asserts what the server holds rather than what it echoes.