### PR TITLE
Reject the durations SurrealDB rejects, and let a range be left open

### DIFF
--- a/src/surrealdb/data/types/duration.py
+++ b/src/surrealdb/data/types/duration.py
@@ -18,31 +18,53 @@ UNITS = {
 }
 
 
+_UNIT_PATTERN = r"ns|µs|us|ms|[smhdwy]"
+
+# One `<digits><unit>` part, used to add the parts up.
+_PART_RE = re.compile(rf"(\d+)({_UNIT_PATTERN})")
+
+# The whole string must be nothing but those parts. Anchored on purpose:
+# `findall` alone matched parts *anywhere* and ignored everything around them,
+# so a string the server rejects outright silently became a different duration -
+# "1.5s" parsed as the "5s" inside it, "-1s" lost its sign and came out
+# positive, and "1e3s" became three seconds. Each produced a wrong value rather
+# than an error, which is the worst of the three possible outcomes.
+_DURATION_RE = re.compile(rf"^(?:\d+(?:{_UNIT_PATTERN}))+$")
+
+
 @dataclass
 class Duration:
     elapsed: int = 0  # nanoseconds
 
     @staticmethod
     def parse(value: str | int, nanoseconds: int = 0) -> "Duration":
+        """Build a ``Duration`` from ``"1h30m"``-style text, or from seconds.
+
+        Accepts one or more ``<digits><unit>`` parts and nothing else, matching
+        what SurrealDB itself accepts for a duration literal. Fractional
+        ("1.5s"), signed ("-1s") and exponent ("1e3s") forms are rejected here
+        because the server rejects them too.
+
+        :raises InvalidDurationError: if *value* is not a duration the server
+            would accept.
+        """
         if isinstance(value, int):
+            if value < 0:
+                raise InvalidDurationError(
+                    f"Duration cannot be negative, got {value} seconds"
+                )
             return Duration(nanoseconds + value * UNITS["s"])
-        else:
-            # Support compound durations: "1h30m", "2d3h15m", etc.
-            pattern = r"(\d+)(ns|µs|us|ms|[smhdwy])"
-            matches = re.findall(pattern, value.lower())
 
-            if not matches:
-                raise InvalidDurationError(f"Invalid duration format: {value}")
+        # Support compound durations: "1h30m", "2d3h15m", etc.
+        text = value.lower()
+        if not _DURATION_RE.match(text):
+            raise InvalidDurationError(f"Invalid duration format: {value}")
 
-            total_ns = nanoseconds
-            for num_str, unit in matches:
-                num = int(num_str)
-                if unit not in UNITS:
-                    # this will never happen because the regex only matches valid units
-                    raise InvalidDurationError(f"Unknown duration unit: {unit}")
-                total_ns += num * UNITS[unit]
+        total_ns = nanoseconds
+        for num_str, unit in _PART_RE.findall(text):
+            total_ns += int(num_str) * UNITS[unit]
 
-            return Duration(total_ns)
+        return Duration(total_ns)
 
     def get_seconds_and_nano(self) -> tuple[int, int]:
         sec = floor(self.elapsed / UNITS["s"])

--- a/src/surrealdb/data/types/range.py
+++ b/src/surrealdb/data/types/range.py
@@ -5,6 +5,8 @@ Defines classes for representing bounded ranges, including inclusive and exclusi
 from dataclasses import dataclass
 from typing import Any
 
+from surrealdb.data.types.null import Null
+
 
 class Bound:
     """
@@ -122,12 +124,32 @@ class Range:
     Represents a range with a beginning and an end bound.
 
     Attributes:
-        begin: The starting bound of the range (inclusive or exclusive).
-        end: The ending bound of the range (inclusive or exclusive).
+        begin: The starting bound of the range (inclusive or exclusive), or
+            ``None`` / ``Null`` for an open start.
+        end: The ending bound of the range, or ``None`` / ``Null`` for an
+            open end.
     """
 
-    begin: Bound
-    end: Bound
+    begin: Any
+    end: Any
+
+    def __post_init__(self) -> None:
+        """Normalise an open bound spelled ``None`` to ``Null``.
+
+        An open bound is a null on the wire. ``None`` is the natural way to
+        spell "no bound" in Python, but it encodes as SurrealDB's NONE, which
+        the server refuses inside a range - so ``Range(BoundIncluded(1), None)``
+        was rejected with a parse error while the identical range *read back
+        from the server* (whose open bound decodes to ``Null``) sent fine. Same
+        value, two spellings, one of them unusable.
+
+        Normalising here rather than in the encoder also keeps equality honest:
+        a hand-built open range and one read back compare equal.
+        """
+        if self.begin is None:
+            self.begin = Null
+        if self.end is None:
+            self.end = Null
 
     def __eq__(self, other: object) -> bool:
         """

--- a/tests/unit_tests/connections/test_duration_and_range_wire.py
+++ b/tests/unit_tests/connections/test_duration_and_range_wire.py
@@ -1,0 +1,114 @@
+"""What the SDK accepts as a duration or an open range matches the server.
+
+Two defects, one shape: a value the SDK built happily and the server would not
+take, or the reverse.
+
+``Duration.parse`` used an unanchored pattern, so ``"1.5s"``, ``"-1s"`` and
+``"1e3s"`` - each rejected outright by SurrealDB - parsed into a different,
+wrong duration instead of raising. The server is asked here directly, so the
+accepted and rejected sets cannot drift from it.
+
+``Range`` with an open bound could be read from the server but not built by
+hand: an open bound is a null on the wire, and ``None`` - the natural Python
+spelling - encoded as NONE, which the server refuses inside a range. So a range
+read back sent fine while the identical range written by hand was rejected.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.duration import Duration
+from surrealdb.data.types.null import Null
+from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
+from surrealdb.errors import InvalidDurationError
+
+DURATIONS = ["1s", "0s", "1ns", "1us", "1µs", "500ms", "1h30m", "1s500ms", "1y"]
+NOT_DURATIONS = ["1.5s", "-1s", "1e3s", "0.5h", "1x", "1"]
+
+
+@pytest.mark.parametrize("text", DURATIONS)
+def test_the_sdk_and_the_server_agree_on_valid_durations(
+    blocking_ws_connection: BlockingWsSurrealConnection, text: str
+) -> None:
+    """Same string, same duration, parsed on each side."""
+    from_server = blocking_ws_connection.query(
+        "RETURN <duration>$text;", {"text": text}
+    ).first()
+
+    assert isinstance(from_server, Duration)
+    assert Duration.parse(text) == from_server
+
+
+@pytest.mark.parametrize("text", NOT_DURATIONS)
+def test_the_sdk_and_the_server_agree_on_invalid_durations(
+    blocking_ws_connection: BlockingWsSurrealConnection, text: str
+) -> None:
+    """If the server will not take it, neither does ``Duration.parse``.
+
+    The server half is asserted too: without it this test would keep passing if
+    SurrealDB started accepting one of these, and the SDK would be wrong in the
+    other direction.
+    """
+    with pytest.raises(Exception, match="(?i)cast|convert|invalid"):
+        blocking_ws_connection.query("RETURN <duration>$text;", {"text": text}).first()
+
+    with pytest.raises(InvalidDurationError):
+        Duration.parse(text)
+
+
+@pytest.mark.parametrize(
+    ("label", "built"),
+    [
+        pytest.param("open end, None", Range(BoundIncluded(1), None), id="end-none"),
+        pytest.param("open end, Null", Range(BoundIncluded(1), Null), id="end-null"),
+        pytest.param(
+            "open start, None", Range(None, BoundExcluded(5)), id="start-none"
+        ),
+        pytest.param(
+            "open start, Null", Range(Null, BoundExcluded(5)), id="start-null"
+        ),
+        pytest.param("open both", Range(None, None), id="both-open"),
+    ],
+)
+def test_a_hand_built_open_range_can_be_sent(
+    blocking_ws_connection: BlockingWsSurrealConnection, label: str, built: Range
+) -> None:
+    returned = blocking_ws_connection.query("RETURN $r;", {"r": built}).first()
+
+    assert returned == built, f"{label} did not survive the round trip"
+
+
+def test_a_range_read_from_the_server_can_be_sent_back(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The path that worked before, so the normalisation does not break it."""
+    for literal in ("1..", "..5", "1..5", "1>..=5"):
+        original = blocking_ws_connection.query(f"RETURN {literal};").first()
+        returned = blocking_ws_connection.query("RETURN $r;", {"r": original}).first()
+        assert returned == original, f"{literal} did not survive"
+
+
+def test_none_and_null_bounds_are_the_same_range() -> None:
+    """Equality has to agree, or a hand-built range never matches a read one."""
+    assert Range(BoundIncluded(1), None) == Range(BoundIncluded(1), Null)
+    assert Range(None, None) == Range(Null, Null)
+    assert hash(Range(BoundIncluded(1), None)) == hash(Range(BoundIncluded(1), Null))
+
+
+def test_an_open_range_still_renders_as_surrealql() -> None:
+    """``str()`` is used to build queries, so normalisation must not change it."""
+    assert str(Range(BoundIncluded(1), None)) == "1.."
+    assert str(Range(None, BoundExcluded(5))) == "..5"
+    assert str(Range(BoundIncluded(1), BoundIncluded(5))) == "1..=5"
+
+
+def test_a_range_of_record_ids_round_trips(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The shape ranges are actually used in: a record-id range on a table."""
+    payload: dict[str, Any] = {"r": Range(BoundIncluded(1), None)}
+    returned = blocking_ws_connection.query("RETURN $r;", payload).first()
+
+    assert returned == payload["r"]

--- a/tests/unit_tests/data_types/test_duration_parsing.py
+++ b/tests/unit_tests/data_types/test_duration_parsing.py
@@ -1,0 +1,84 @@
+"""``Duration.parse`` accepts what SurrealDB accepts, and nothing else.
+
+The pattern was applied with ``re.findall``, which matches ``<digits><unit>``
+parts *anywhere* in the string and silently ignores everything around them. So
+a string the server rejects outright became a different, valid-looking
+duration:
+
+======== ================= ==============================
+input    was parsed as     SurrealDB's own answer
+======== ================= ==============================
+``1.5s`` 5 seconds         rejected
+``-1s``  +1 second         rejected
+``1e3s`` 3 seconds         rejected
+======== ================= ==============================
+
+A wrong value is worse than an error here: nothing downstream can tell that
+``Duration.parse("1.5s")`` did not mean five seconds, and it was stored as
+five.
+
+The accepted forms are pinned against a live server in
+``test_duration_matches_the_server`` so this file cannot drift from what
+SurrealDB actually parses.
+"""
+
+import pytest
+
+from surrealdb.data.types.duration import Duration
+from surrealdb.errors import InvalidDurationError
+
+# Every one of these is rejected by SurrealDB's own `<duration>` cast.
+REJECTED = [
+    pytest.param("1.5s", id="fractional"),
+    pytest.param("0.5h", id="fractional-hours"),
+    pytest.param("-1s", id="negative"),
+    pytest.param("+1s", id="explicit-plus"),
+    pytest.param("1e3s", id="exponent"),
+    pytest.param("1E3s", id="exponent-upper"),
+    pytest.param("abc", id="not-a-duration"),
+    pytest.param("", id="empty"),
+    pytest.param("1s ", id="trailing-space"),
+    pytest.param(" 1s", id="leading-space"),
+    pytest.param("1s;DROP", id="trailing-junk"),
+    pytest.param("about 1s please", id="prose"),
+    pytest.param("1", id="no-unit"),
+    pytest.param("s", id="no-number"),
+    pytest.param("1x", id="unknown-unit"),
+]
+
+ACCEPTED = [
+    pytest.param("1s", 1_000_000_000, id="seconds"),
+    pytest.param("0s", 0, id="zero"),
+    pytest.param("1ns", 1, id="nanoseconds"),
+    pytest.param("1us", 1_000, id="microseconds-ascii"),
+    pytest.param("1µs", 1_000, id="microseconds-symbol"),
+    pytest.param("500ms", 500_000_000, id="milliseconds"),
+    pytest.param("1h30m", 5_400_000_000_000, id="compound"),
+    pytest.param("1s500ms", 1_500_000_000, id="compound-descending"),
+    pytest.param("1y", 31_536_000_000_000_000, id="years"),
+]
+
+
+@pytest.mark.parametrize("text", REJECTED)
+def test_a_string_the_server_rejects_is_rejected_here(text: str) -> None:
+    with pytest.raises(InvalidDurationError):
+        Duration.parse(text)
+
+
+@pytest.mark.parametrize(("text", "nanoseconds"), ACCEPTED)
+def test_a_string_the_server_accepts_parses_to_the_right_value(
+    text: str, nanoseconds: int
+) -> None:
+    assert Duration.parse(text).elapsed == nanoseconds
+
+
+def test_a_negative_number_of_seconds_is_rejected() -> None:
+    """The integer path had the same hole: durations are unsigned."""
+    with pytest.raises(InvalidDurationError):
+        Duration.parse(-1)
+
+
+def test_the_nanoseconds_argument_still_adds() -> None:
+    """Unchanged behaviour: the offset is added to the parsed value."""
+    assert Duration.parse("1s", nanoseconds=7).elapsed == 1_000_000_007
+    assert Duration.parse(2, nanoseconds=7).elapsed == 2_000_000_007


### PR DESCRIPTION
Two of the remaining gate majors, both in `surrealdb.data.types`.

## §1 `Duration.parse` silently returned the wrong duration

The pattern was applied with `re.findall`, which matches `<digits><unit>` parts *anywhere* in the string and ignores everything around them. Strings SurrealDB refuses outright parsed into a different, valid-looking duration:

| input | SDK parsed it as | SurrealDB's own `<duration>` cast |
| --- | --- | --- |
| `1.5s` | 5 seconds | rejected |
| `-1s` | +1 second (sign dropped) | rejected |
| `1e3s` | 3 seconds | rejected |

A wrong value is the worst of the three possible outcomes here — nothing downstream can tell that `Duration.parse("1.5s")` did not mean five seconds, and five is what got stored.

The pattern is now anchored to the whole string. The integer path had the same hole and now rejects a negative number of seconds.

The accepted and rejected sets are asserted **against a live server** — each string is cast by SurrealDB and by the SDK in the same test — so this cannot drift from what the server actually parses.

## §2 An open `Range` could be read but never written

An open bound is a null on the wire. `None` is the natural Python spelling, and it encoded as SurrealDB's NONE, which the server refuses inside a range:

```python
Range(BoundIncluded(1), None)   # ValidationError: Parse error
Range(BoundIncluded(1), Null)   # fine
```

So a range read back from the server sent fine, while the identical range written by hand was rejected. `Range` now normalises a `None` bound to `Null` on construction.

Normalising in the type rather than in the encoder also keeps equality honest — a hand-built open range and one read from the server compare equal, and hash the same:

```python
Range(BoundIncluded(1), None) == Range(BoundIncluded(1), Null)   # True
```

The read side of this was already fixed as a side effect of the `Null` work in the previous PR; this closes the write side.

## Verification

1217 passing locally including the embedded engine. Three mutations — unanchoring the duration pattern, allowing a negative number of seconds, and dropping the range normalisation — are each caught. Clean `ruff`, `mypy` (src and tests), and `pyright` at the existing baseline.