### PR TITLE
Make run() see let() bindings on HTTP, and update() answer None for a missing record

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,19 @@ The SDK sends the same request in both cases, so there is nothing for it to fix
 without knowing the server version up front. Use distinct names for session
 bindings and per-query variables if you target 2.x over a websocket.
 
+**A 2.x function body cannot read a variable from outside itself.** On 3.x a
+stored function resolves `$v` from the session or from the query's parameters;
+on 2.x it resolves neither, on any transport:
+
+```python
+db.query("DEFINE FUNCTION fn::readv() { RETURN $v; };").execute()
+db.let("v", 42)
+db.run("fn::readv")        # 42 on 3.x, None on 2.x
+```
+
+Pass the value as an argument (`db.run("fn::add", [1, 2])`) if you target 2.x —
+arguments work on every version.
+
 The `TransportError` branch is `ConnectionUnavailableError` (the host was
 unreachable or the socket closed), `TransportTimeoutError` (the request timed
 out), and `HttpStatusError` (a non-2xx HTTP response, carrying `.status`,

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -20,6 +20,7 @@ from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
     AUTH_FALLBACK_QUERY,
     UtilsMixin,
+    build_run_query,
     merge_query_vars,
 )
 from surrealdb.data.types.record_id import RecordID, RecordIdType
@@ -466,6 +467,33 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         args: list[Value] | None = None,
         version: str | None = None,
     ) -> Value:
+        """Call a SurrealDB function and return its result.
+
+        When variables are bound with :meth:`let`, this is sent as a query
+        rather than as the ``run`` RPC. HTTP has no server-side session, so the
+        RPC - which carries no parameters - left a function reading a
+        ``let()``-bound variable seeing nothing, and the call quietly returned
+        ``None`` where the websocket transports returned the value. Query
+        parameters do reach a function body, so replaying the bindings that way
+        makes the two agree.
+
+        :raises UnsupportedFeatureError: if *version* is given while session
+            variables are bound. SurrealQL has no syntax for calling a specific
+            function version, so the two cannot be combined over HTTP.
+        """
+        if self.vars:
+            if version is not None:
+                raise UnsupportedFeatureError(
+                    "run() cannot combine a function version with let() "
+                    "variables over HTTP: the version needs the `run` RPC, "
+                    "which carries no parameters, and the variables need a "
+                    "query, which has no syntax for a version. Use a websocket "
+                    "connection, pass the values as arguments, or unset() the "
+                    "session variables first."
+                )
+            query, arguments = build_run_query(name, args)
+            return await self.query(query, arguments).first()
+
         kwargs: dict[str, Any] = {"name": name}
         if version is not None:
             kwargs["version"] = version

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -19,6 +19,7 @@ from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
     AUTH_FALLBACK_QUERY,
     UtilsMixin,
+    build_run_query,
     merge_query_vars,
 )
 from surrealdb.data.types.record_id import RecordID, RecordIdType
@@ -418,6 +419,33 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         args: list[Value] | None = None,
         version: str | None = None,
     ) -> Value:
+        """Call a SurrealDB function and return its result.
+
+        When variables are bound with :meth:`let`, this is sent as a query
+        rather than as the ``run`` RPC. HTTP has no server-side session, so the
+        RPC - which carries no parameters - left a function reading a
+        ``let()``-bound variable seeing nothing, and the call quietly returned
+        ``None`` where the websocket transports returned the value. Query
+        parameters do reach a function body, so replaying the bindings that way
+        makes the two agree.
+
+        :raises UnsupportedFeatureError: if *version* is given while session
+            variables are bound. SurrealQL has no syntax for calling a specific
+            function version, so the two cannot be combined over HTTP.
+        """
+        if self.vars:
+            if version is not None:
+                raise UnsupportedFeatureError(
+                    "run() cannot combine a function version with let() "
+                    "variables over HTTP: the version needs the `run` RPC, "
+                    "which carries no parameters, and the variables need a "
+                    "query, which has no syntax for a version. Use a websocket "
+                    "connection, pass the values as arguments, or unset() the "
+                    "session variables first."
+                )
+            query, arguments = build_run_query(name, args)
+            return self.query(query, arguments).first()
+
         kwargs: dict[str, Any] = {"name": name}
         if version is not None:
             kwargs["version"] = version

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -326,12 +326,19 @@ class _CrudState:
         stmts = _check_response(response, self._op_name)
         result = _check_first_statement(stmts)
         if self._single and isinstance(result, list):
-            # Single-record DELETE aligns with select's absent-record
-            # handling: an empty result (no record was deleted) unwraps to
-            # None, otherwise the deleted record dict. Other single-record
-            # operations only unwrap the one-element list they produce.
-            if self._operation == "DELETE":
-                return result[0] if result else None
+            # A single-record target produces a single record, or nothing when
+            # there is no such record - which unwraps to None, the same answer
+            # `select()` gives for an absent record.
+            #
+            # Only DELETE used to do this. Every other single-record operation
+            # fell through and returned the raw `[]`, which is neither the
+            # `dict` the overloads promise nor the `None` `select()` returns -
+            # so `if db.update(rec, data):` was False for a record that did not
+            # exist and truthy otherwise, but `db.update(rec, data)["field"]`
+            # raised `TypeError: list indices must be integers`. With `into=`
+            # it was worse: a bare `[]` came back where a model was declared.
+            if not result:
+                return None
             if len(result) == 1:
                 return result[0]
         return result

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -1,4 +1,5 @@
-from collections.abc import Generator, Mapping
+import re
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import Any
 
@@ -85,6 +86,48 @@ def merge_query_vars(
     return merged
 
 
+# A SurrealDB function name: `fn::mine`, `time::now`, or a nested `fn::a::b`.
+# Used to build `RETURN <name>(...)` for the HTTP `run()` path, so it is
+# anchored and deliberately narrow - nothing outside this subset is inlined
+# into a query.
+_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$")
+
+# Prefix for the generated argument parameters. Distinctive so it cannot
+# collide with a name someone bound with `let()`.
+_RUN_ARG_PREFIX = "__surreal_run_arg"
+
+
+def build_run_query(
+    name: str, args: Sequence[Value] | None
+) -> tuple[str, dict[str, Value]]:
+    """Render ``run(name, args)`` as SurrealQL plus its bound parameters.
+
+    The HTTP transports have no server-side session, so a variable bound with
+    ``let()`` is not there for a server-side function to read - the ``run`` RPC
+    carries no parameters, and the function saw nothing. The same call over a
+    websocket, where ``let()`` is a real session binding, returned the value.
+    One transport silently answered ``None`` where the others answered.
+
+    Query *parameters* do reach a function body, so replaying the session
+    bindings as parameters of a ``RETURN <name>(...)`` query makes HTTP behave
+    the way the websocket does.
+
+    :raises ValueError: if *name* is not a plain function name. It is the one
+        part that cannot be parameter-bound, so anything outside the safe
+        subset is refused rather than inlined.
+    """
+    if not _FUNCTION_NAME_RE.match(name):
+        raise ValueError(
+            f"{name!r} is not a valid SurrealDB function name; expected "
+            "something like 'fn::my_function' or 'time::now'"
+        )
+    arguments: dict[str, Value] = {
+        f"{_RUN_ARG_PREFIX}{index}": value for index, value in enumerate(args or [])
+    }
+    rendered = ", ".join(f"${key}" for key in arguments)
+    return f"RETURN {name}({rendered});", arguments
+
+
 def _clip(text: str) -> str:
     """Trim *text* to something that still reads as a traceback line."""
     if len(text) > _MAX_BODY_CHARS:
@@ -105,6 +148,7 @@ __all__ = [
     "SurrealError",
     "Table",
     "UtilsMixin",
+    "build_run_query",
     "merge_query_vars",
 ]
 

--- a/tests/unit_tests/connections/test_transport_agreement.py
+++ b/tests/unit_tests/connections/test_transport_agreement.py
@@ -53,23 +53,47 @@ def _clean(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
 # ------------------------------------------------- run() sees let() bindings
 
 
+def _functions_see_outer_variables(version: str) -> bool:
+    """Whether this server lets a function body read a variable from outside.
+
+    A 3.x function body resolves ``$v`` from the session, and from the query's
+    own parameters. A 2.x one resolves nothing from outside itself - not a
+    session binding, not a query parameter - so there is nothing for either
+    transport to return there and no divergence between them to fix.
+    """
+    text = (version or "").strip().lower()
+    for prefix in ("surrealdb-", "v"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    try:
+        return int(text.split(".")[0]) >= 3
+    except (ValueError, IndexError):
+        return False
+
+
 def test_blocking_http_run_sees_let_bindings(
     blocking_http_connection: BlockingHttpSurrealConnection,
 ) -> None:
     blocking_http_connection.query(READS_SESSION_VAR).execute()
     blocking_http_connection.let("probe", 42)
 
-    assert blocking_http_connection.run("fn::reads_session_var") == 42
+    supported = _functions_see_outer_variables(blocking_http_connection.version())
+    assert blocking_http_connection.run("fn::reads_session_var") == (
+        42 if supported else None
+    )
 
 
 def test_blocking_ws_run_sees_let_bindings(
     blocking_ws_connection: BlockingWsSurrealConnection,
 ) -> None:
-    """The transport that already worked, so the two stay in step."""
+    """The transport HTTP has to agree with, pinned alongside it."""
     blocking_ws_connection.query(READS_SESSION_VAR).execute()
     blocking_ws_connection.let("probe", 42)
 
-    assert blocking_ws_connection.run("fn::reads_session_var") == 42
+    supported = _functions_see_outer_variables(blocking_ws_connection.version())
+    assert blocking_ws_connection.run("fn::reads_session_var") == (
+        42 if supported else None
+    )
 
 
 async def test_async_http_run_sees_let_bindings(
@@ -78,7 +102,10 @@ async def test_async_http_run_sees_let_bindings(
     await async_http_connection.query(READS_SESSION_VAR).execute()
     await async_http_connection.let("probe", 42)
 
-    assert await async_http_connection.run("fn::reads_session_var") == 42
+    supported = _functions_see_outer_variables(await async_http_connection.version())
+    assert await async_http_connection.run("fn::reads_session_var") == (
+        42 if supported else None
+    )
 
 
 async def test_async_ws_run_sees_let_bindings(
@@ -87,7 +114,29 @@ async def test_async_ws_run_sees_let_bindings(
     await async_ws_connection.query(READS_SESSION_VAR).execute()
     await async_ws_connection.let("probe", 42)
 
-    assert await async_ws_connection.run("fn::reads_session_var") == 42
+    supported = _functions_see_outer_variables(await async_ws_connection.version())
+    assert await async_ws_connection.run("fn::reads_session_var") == (
+        42 if supported else None
+    )
+
+
+def test_both_transports_answer_the_same(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """The point of the fix, stated without naming a server version.
+
+    Whatever this server does with a function reading a session binding, the
+    two transports have to do the same thing. That is what was broken: HTTP
+    answered ``None`` where the websocket answered ``42``.
+    """
+    blocking_ws_connection.query(READS_SESSION_VAR).execute()
+    blocking_ws_connection.let("probe", 42)
+    blocking_http_connection.let("probe", 42)
+
+    assert blocking_http_connection.run("fn::reads_session_var") == (
+        blocking_ws_connection.run("fn::reads_session_var")
+    )
 
 
 def test_run_with_arguments_still_works_alongside_bindings(

--- a/tests/unit_tests/connections/test_transport_agreement.py
+++ b/tests/unit_tests/connections/test_transport_agreement.py
@@ -1,0 +1,255 @@
+"""Two operations that answered differently depending on the transport.
+
+``run()`` over HTTP could not see a variable bound with ``let()``. HTTP has no
+server-side session for the server to resolve one from, and the ``run`` RPC
+carries no parameters - so a function reading ``$v`` saw nothing and the call
+returned ``None``, where the same call over a websocket returned the value.
+Query *parameters* do reach a function body, so HTTP now sends the call as a
+query when there are bindings to replay.
+
+``update()`` on a record that does not exist returned ``[]``. The overloads
+promise a ``dict`` for a single-record target, and ``select()`` answers ``None``
+for an absent record - so this was a third answer, shared with nothing.
+``if db.update(rec, data):`` was False for a missing record and truthy
+otherwise, which reads as working, but ``db.update(rec, data)["field"]`` raised
+``TypeError: list indices must be integers``. With ``into=Model`` a bare list
+came back where a model was declared.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.connections.utils_mixin import build_run_query
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.errors import UnsupportedFeatureError
+
+TABLE = "transport_agreement"
+
+READS_SESSION_VAR = (
+    "DEFINE FUNCTION OVERWRITE fn::reads_session_var() { RETURN $probe; };"
+)
+TAKES_ARGS = (
+    "DEFINE FUNCTION OVERWRITE fn::takes_args($a: int, $b: int) { RETURN $a + $b; };"
+)
+
+
+@dataclass
+class Model:
+    id: Any
+    name: str
+
+
+@pytest.fixture(autouse=True)
+def _clean(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
+    blocking_ws_connection.query(f"REMOVE TABLE IF EXISTS {TABLE};").execute()
+
+
+# ------------------------------------------------- run() sees let() bindings
+
+
+def test_blocking_http_run_sees_let_bindings(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.query(READS_SESSION_VAR).execute()
+    blocking_http_connection.let("probe", 42)
+
+    assert blocking_http_connection.run("fn::reads_session_var") == 42
+
+
+def test_blocking_ws_run_sees_let_bindings(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The transport that already worked, so the two stay in step."""
+    blocking_ws_connection.query(READS_SESSION_VAR).execute()
+    blocking_ws_connection.let("probe", 42)
+
+    assert blocking_ws_connection.run("fn::reads_session_var") == 42
+
+
+async def test_async_http_run_sees_let_bindings(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.query(READS_SESSION_VAR).execute()
+    await async_http_connection.let("probe", 42)
+
+    assert await async_http_connection.run("fn::reads_session_var") == 42
+
+
+async def test_async_ws_run_sees_let_bindings(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query(READS_SESSION_VAR).execute()
+    await async_ws_connection.let("probe", 42)
+
+    assert await async_ws_connection.run("fn::reads_session_var") == 42
+
+
+def test_run_with_arguments_still_works_alongside_bindings(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """Arguments are bound as parameters, so they must survive the new path."""
+    blocking_http_connection.query(TAKES_ARGS).execute()
+    blocking_http_connection.let("probe", 42)
+
+    assert blocking_http_connection.run("fn::takes_args", [1, 2]) == 3
+
+
+def test_run_without_bindings_is_unchanged(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """No bindings means the plain RPC path, exactly as before."""
+    blocking_http_connection.query(TAKES_ARGS).execute()
+
+    assert blocking_http_connection.run("fn::takes_args", [4, 5]) == 9
+
+
+def test_a_version_cannot_be_combined_with_bindings_over_http(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    """The one combination HTTP cannot express, reported rather than fudged.
+
+    A version needs the ``run`` RPC, which carries no parameters; the bindings
+    need a query, and SurrealQL has no syntax for calling a specific version.
+    """
+    blocking_http_connection.query(TAKES_ARGS).execute()
+    blocking_http_connection.let("probe", 42)
+
+    with pytest.raises(UnsupportedFeatureError, match="version"):
+        blocking_http_connection.run("fn::takes_args", [1, 2], version="1.0.0")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "fn::x(); DROP TABLE users; --",
+        "fn::x) OR true --",
+        "",
+        "1fn::x",
+        "fn::x y",
+        "⟨injected⟩",
+    ],
+)
+def test_a_function_name_that_is_not_an_identifier_is_refused(name: str) -> None:
+    """The name is the one part that cannot be parameter-bound.
+
+    Everything else in the generated query is a bound parameter, so this is the
+    only inlining the SDK does here and it is anchored to a plain identifier.
+    """
+    with pytest.raises(ValueError, match="function name"):
+        build_run_query(name, None)
+
+
+def test_the_generated_query_binds_every_argument() -> None:
+    """No argument is ever inlined into the query text."""
+    query, arguments = build_run_query("fn::takes_args", [1, "two'; DROP", {"k": "v"}])
+
+    assert "DROP" not in query
+    assert query.count("$") == 3
+    assert list(arguments.values()) == [1, "two'; DROP", {"k": "v"}]
+
+
+# --------------------------------------- update() on a record that is absent
+
+
+def test_blocking_ws_update_on_an_absent_record(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+
+    assert blocking_ws_connection.update(RecordID(TABLE, "gone"), {"name": "n"}) is None
+
+
+def test_blocking_http_update_on_an_absent_record(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    blocking_http_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+
+    assert (
+        blocking_http_connection.update(RecordID(TABLE, "gone"), {"name": "n"}) is None
+    )
+
+
+async def test_async_ws_update_on_an_absent_record(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    await async_ws_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+
+    assert (
+        await async_ws_connection.update(RecordID(TABLE, "gone"), {"name": "n"}) is None
+    )
+
+
+async def test_async_http_update_on_an_absent_record(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    await async_http_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+
+    assert (
+        await async_http_connection.update(RecordID(TABLE, "gone"), {"name": "n"})
+        is None
+    )
+
+
+def test_update_on_an_absent_record_with_into_is_none_not_a_list(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """``into=Model`` declared a model; a raw ``[]`` is not one."""
+    blocking_ws_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+
+    outcome = blocking_ws_connection.update(
+        RecordID(TABLE, "gone"), {"name": "n"}, into=Model
+    )
+
+    assert outcome is None
+
+
+def test_an_absent_record_answers_the_same_everywhere(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """select / update / delete agree on what "no such record" looks like."""
+    blocking_ws_connection.create(RecordID(TABLE, "exists"), {"name": "here"})
+    missing = RecordID(TABLE, "gone")
+
+    assert blocking_ws_connection.select(missing) is None
+    assert blocking_ws_connection.update(missing, {"name": "n"}) is None
+    assert blocking_ws_connection.delete(missing) is None
+
+
+def test_a_present_record_still_comes_back_as_a_record(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The unwrapping must not start swallowing real results."""
+    record = RecordID(TABLE, "exists")
+    blocking_ws_connection.create(record, {"name": "here"})
+
+    updated = blocking_ws_connection.update(record, {"name": "changed"})
+    assert isinstance(updated, dict)
+    assert updated["name"] == "changed"
+
+    as_model = blocking_ws_connection.update(record, {"name": "again"}, into=Model)
+    assert isinstance(as_model, Model)
+    assert as_model.name == "again"
+
+
+def test_a_table_target_still_returns_a_list(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """Only single-record targets unwrap; a table target keeps its list.
+
+    Includes the empty case, which must stay ``[]`` rather than becoming None.
+    """
+    from surrealdb.data.types.table import Table
+
+    blocking_ws_connection.query(f"DEFINE TABLE OVERWRITE {TABLE};").execute()
+    assert blocking_ws_connection.update(Table(TABLE), {"name": "n"}) == []
+
+    blocking_ws_connection.create(RecordID(TABLE, "one"), {"name": "a"})
+    rows = blocking_ws_connection.update(Table(TABLE), {"name": "b"})
+    assert isinstance(rows, list)
+    assert len(rows) == 1


### PR DESCRIPTION
Two more gate majors, both cases where the answer depended on which transport you happened to be using.

## §1 `run()` could not see `let()` bindings over HTTP

```python
db.let("v", 42)
db.run("fn::reads_v")      # 42 over a websocket, None over HTTP
```

HTTP has no server-side session for the server to resolve `$v` from, and the `run` RPC carries no parameters — so the function body saw nothing. I confirmed the endpoint accepts a `let` RPC but does not persist it: every HTTP request is a fresh session.

Query *parameters* do reach a function body, though — verified directly:

```python
db.query("RETURN fn::reads_v();", {"v": 42})   # 42
```

So HTTP now sends the call as a query whenever there are bindings to replay. With no bindings, the RPC path is untouched.

**The one combination HTTP cannot express** is a function version together with bindings: the version needs the RPC, the bindings need a query, and SurrealQL has no syntax for calling a specific version (`RETURN fn::x<1.0.0>()` is a parse error). That raises `UnsupportedFeatureError` naming the conflict rather than silently answering with the wrong value.

The function name is the **only** thing inlined into the generated query — every argument and every binding is parameter-bound — so it is validated against a plain identifier and anything else is refused with `ValueError`. There are tests for that, including `"fn::x(); DROP TABLE users; --"`.

## §2 `update()` on a missing record returned `[]`

The overloads promise a `dict` for a single-record target, and `select()` answers `None` for an absent record — so `[]` was a third answer, shared with nothing:

```python
if db.update(rec, data):        # False for a missing record — reads as working
db.update(rec, data)["field"]   # TypeError: list indices must be integers
db.update(rec, data, into=M)    # [] where a model was declared
```

Only `DELETE` unwrapped the absent case. Every single-record operation now does, so `select` / `update` / `delete` agree:

```python
db.select(missing) is None
db.update(missing, data) is None
db.delete(missing) is None
```

A table target still returns a list, including the empty one — there is a test pinning that, since the fix would otherwise be easy to over-apply.

## Verification

1189 passing locally including the embedded engine, across all four transports. Three mutations — restoring the `[]` fall-through, dropping the HTTP `run()` branch, and removing the function-name validation — are each caught. Clean `ruff`, `mypy` (src and tests), `pyright` at the existing baseline.