### PR TITLE
Stop one bad request failing its neighbours, and reopen a dropped socket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,11 @@ dependencies = [
     # consumed, and `close()` joins that thread, so closing a connection with
     # an undelivered live notification never returns. 12.0 through 13.1 avoid
     # the deadlock but still pay the full 10s close timeout for it. 14.0 is the
-    # first release where closing such a connection is immediate.
-    "websockets>=14.0",
+    # first release where closing such a connection is immediate, and 14.1 the
+    # first to expose `ClientConnection.state` - which is how the blocking
+    # transport tells a live socket from one whose peer has gone away, so that
+    # `connect()` can replace it rather than returning on a dead connection.
+    "websockets>=14.1",
 ]
 
 [project.urls]

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -97,6 +97,10 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         # the loop that ends up running them.
         self._connect_lock: asyncio.Lock | None = None
         self._connect_lock_loop: AbstractEventLoop | None = None
+        # A protocol error the server could not correlate to a request, held
+        # until the request it belongs to hits its deadline - see
+        # `_deliver_uncorrelated`.
+        self._uncorrelated_error: SurrealError | None = None
 
     def _connect_guard(self) -> asyncio.Lock:
         """The lock serialising ``connect()``, bound to the running loop.
@@ -124,6 +128,43 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             if not fut.done():
                 fut.set_exception(error)
         self.qry.clear()
+
+    def _deliver_uncorrelated(self, error: SurrealError) -> None:
+        """Deliver an error the server could not tie to any request.
+
+        A protocol-level error arrives with no ``id`` because the server could
+        not parse the frame far enough to read one. Exactly *one* request is
+        affected - the one whose frame was rejected - and it is the one that
+        will never be answered. Every other request in flight is untouched and
+        gets its own reply as normal.
+
+        Failing every pending future, which is what this used to do, turned one
+        bad request into N failures: three unrelated queries on the same
+        connection all came back ``Parse error`` because a fourth, concurrent
+        one was malformed. The same three run alone succeeded.
+
+        With a single request in flight there is no ambiguity, so it is failed
+        straight away. With several, the error is held instead: the doomed
+        request is the one that never gets a reply, so it is the one that hits
+        its deadline, and :meth:`_send` reports this error there rather than a
+        bare timeout. That costs the doomed caller its timeout - which is
+        unavoidable, since nothing on the wire says which one it is - while
+        letting the others finish normally.
+        """
+        pending = [
+            (query_id, fut) for query_id, fut in self.qry.items() if not fut.done()
+        ]
+        if len(pending) == 1:
+            query_id, fut = pending[0]
+            fut.set_exception(error)
+            self.qry.pop(query_id, None)
+            return
+        self._uncorrelated_error = error
+
+    def _take_uncorrelated(self) -> SurrealError | None:
+        """Consume a held protocol error, if one is waiting."""
+        error, self._uncorrelated_error = self._uncorrelated_error, None
+        return error
 
     async def _recv_task(self) -> None:
         assert self.socket
@@ -160,7 +201,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                         try:
                             self.check_response_for_error(response, "_recv_task")
                         except SurrealError as exc:
-                            self._fail_pending(exc)
+                            self._deliver_uncorrelated(exc)
                 except Exception as exc:
                     self._fail_pending(
                         UnexpectedResponseError(
@@ -217,6 +258,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             try:
                 response = await asyncio.wait_for(fut, _RPC_RECV_TIMEOUT)
             except asyncio.TimeoutError as exc:
+                # The server may have rejected this request's frame outright,
+                # in which case it answered with an error carrying no `id` and
+                # no reply is ever coming. That error was held rather than
+                # failing every other request in flight; this is the request it
+                # belongs to, so report it instead of a bare deadline.
+                uncorrelated = self._take_uncorrelated()
+                if uncorrelated is not None:
+                    raise uncorrelated from exc
                 raise TransportTimeoutError(
                     f"timed out while {process} on {self.raw_url}: no reply "
                     f"within {_RPC_RECV_TIMEOUT}s"
@@ -1107,6 +1156,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             finally:
                 self.socket = None
                 self.recv_task = None
+                self._uncorrelated_error = None
 
     async def __aenter__(self) -> "AsyncWsSurrealConnection":
         """

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -15,6 +15,7 @@ from uuid import UUID
 import websockets
 import websockets.sync.client as ws_sync
 from websockets.exceptions import ConnectionClosed, WebSocketException
+from websockets.protocol import State
 from websockets.sync.client import ClientConnection
 
 from surrealdb.connections.builders import (
@@ -151,7 +152,17 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             self.port = target.port
 
         if self.socket is not None:
-            return
+            if self.socket.state is State.OPEN:
+                return
+            # The socket object is still here but the connection behind it is
+            # gone - the peer dropped it, or the server restarted. Returning
+            # early left the connection permanently wedged: every later request
+            # failed on the dead socket, and `connect()` - the documented way
+            # to reopen one - silently refused to, so there was no way back
+            # short of building a new connection. The async transport already
+            # noticed this through its reader task; the blocking one has no
+            # reader, so the socket's own state is what says so.
+            self.close()
 
         self.socket = self._connect_socket()
 

--- a/tests/unit_tests/connections/test_ws_request_isolation.py
+++ b/tests/unit_tests/connections/test_ws_request_isolation.py
@@ -1,0 +1,232 @@
+"""One bad request must not take unrelated ones down with it.
+
+A protocol-level error arrives with no ``id``: the server could not parse the
+frame far enough to read one. Exactly one request is affected - the one whose
+frame was rejected, which will never be answered - while every other request in
+flight still gets its own reply.
+
+The reader failed *every* pending future, so one malformed request turned into N
+failures. Measured before the fix: three ordinary queries plus one malformed one
+issued together, and all four came back ``ValidationError: Parse error``; the
+same three run alone succeeded.
+
+Nothing on the wire says which request was rejected, so with several in flight
+the error is held and reported to whichever request hits its deadline - the
+doomed one, since it is the only one that never gets a reply. With a single
+request in flight there is no ambiguity and it fails at once.
+"""
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.errors import SurrealError, TransportTimeoutError
+
+# A record id whose table name is not a string. The server cannot parse the
+# frame, so it answers with an error carrying no `id` - the shape this file is
+# about. Every non-string table name behaves the same way.
+UNPARSEABLE: Any = RecordID(1, "x")  # type: ignore[arg-type]
+
+
+async def test_a_bad_request_does_not_fail_its_neighbours(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    async def good(index: int) -> Any:
+        return (await connection.query(f"SLEEP 300ms; RETURN {index}").execute())[-1]
+
+    async def bad() -> Any:
+        # Sent after the good ones are already in flight.
+        await asyncio.sleep(0.05)
+        return await connection.query("RETURN $v", {"v": UNPARSEABLE}).execute()
+
+    results = await asyncio.gather(
+        good(1), good(2), good(3), bad(), return_exceptions=True
+    )
+
+    healthy, doomed = list(results[:3]), results[3]
+    assert healthy == [1, 2, 3], (
+        f"unrelated requests were failed by a malformed neighbour: {healthy}"
+    )
+    # Not merely "some SurrealError": a bare `TransportTimeoutError` is one too,
+    # and that is what comes out if the held error is dropped rather than
+    # delivered to the request that was actually rejected.
+    assert isinstance(doomed, SurrealError)
+    assert not isinstance(doomed, TransportTimeoutError), (
+        f"the doomed request reported a bare deadline instead of the server's "
+        f"explanation: {doomed}"
+    )
+    assert "timed out" not in str(doomed).lower()
+
+    await connection.close()
+
+
+async def test_the_only_request_in_flight_fails_immediately(
+    connection_params: dict[str, Any],
+) -> None:
+    """With nothing to confuse it for, the error needs no deadline."""
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    with pytest.raises(SurrealError):
+        # Two seconds is far below the 30s RPC deadline, so this only passes
+        # if the error was delivered straight to the waiting request.
+        await asyncio.wait_for(
+            connection.query("RETURN $v", {"v": UNPARSEABLE}).execute(), timeout=2.0
+        )
+
+    await connection.close()
+
+
+async def test_the_error_carries_the_servers_message_not_a_bare_timeout(
+    connection_params: dict[str, Any],
+) -> None:
+    """Holding the error must not lose it.
+
+    The doomed request waits for its deadline because nothing identifies it
+    sooner, but what it reports has to be the server's explanation rather than
+    "no reply within 30s", which says nothing about what was wrong.
+    """
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    with pytest.raises(SurrealError) as caught:
+        await connection.query("RETURN $v", {"v": UNPARSEABLE}).execute()
+
+    assert "timed out" not in str(caught.value).lower()
+    assert str(caught.value)
+
+    await connection.close()
+
+
+async def test_a_held_error_does_not_leak_into_a_later_request(
+    connection_params: dict[str, Any],
+) -> None:
+    """A protocol error belongs to one request, not to the connection."""
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+
+    with pytest.raises(SurrealError):
+        await connection.query("RETURN $v", {"v": UNPARSEABLE}).execute()
+
+    # The connection is fine, and nothing is left over to poison this.
+    assert await connection.query("RETURN 'after'").first() == "after"
+    assert connection._uncorrelated_error is None
+
+    await connection.close()
+
+
+async def test_close_clears_a_held_error(
+    connection_params: dict[str, Any],
+) -> None:
+    """A held error must not survive into the next socket."""
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    await connection.signin(connection_params["vars_params"])
+    await connection.use(
+        namespace=connection_params["namespace"],
+        database=connection_params["database_name"],
+    )
+    connection._uncorrelated_error = SurrealError("stale")
+
+    await connection.close()
+
+    assert connection._uncorrelated_error is None
+
+
+def test_a_blocking_connection_reopens_after_the_peer_drops_it(
+    connection_params: dict[str, Any],
+) -> None:
+    """``connect()`` must reopen a socket whose peer has gone away.
+
+    The socket object is still there after the peer drops the connection, so
+    ``connect()`` saw "already connected" and returned - leaving the connection
+    permanently wedged, with every later request failing on the dead socket and
+    the documented way to reopen one silently refusing to. The async transport
+    already noticed this through its reader task; the blocking one has no
+    reader, so the socket's own state is what says so.
+
+    Driven by closing the socket underneath the connection rather than by
+    restarting a server: same resulting state, no second server needed, and no
+    dependence on restart timing.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(f"""
+        from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+        connection = BlockingWsSurrealConnection({connection_params["ws_url"]!r})
+        connection.signin({connection_params["vars_params"]!r})
+        connection.use({connection_params["namespace"]!r}, {connection_params["database_name"]!r})
+        assert connection.query("RETURN 1").first() == 1
+
+        # The peer goes away underneath us: not `close()`, which the SDK knows
+        # about and which clears the reference.
+        connection.socket.close_socket()
+
+        connection.connect()
+        assert connection.socket is not None
+        connection.signin({connection_params["vars_params"]!r})
+        connection.use({connection_params["namespace"]!r}, {connection_params["database_name"]!r})
+        print(connection.query("RETURN 2").first(), flush=True)
+        connection.close()
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=90
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "2"
+
+
+def test_a_healthy_blocking_socket_is_not_replaced(
+    connection_params: dict[str, Any],
+) -> None:
+    """The liveness check must not tear down a working connection.
+
+    ``connect()`` on an open connection is a no-op, and it has to stay one:
+    reconnecting starts a fresh, anonymous server-side session, so replacing a
+    live socket would silently undo a completed ``signin()``.
+    """
+    from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    try:
+        connection.signin(connection_params["vars_params"])
+        connection.use(
+            namespace=connection_params["namespace"],
+            database=connection_params["database_name"],
+        )
+        socket = connection.socket
+
+        connection.connect()
+
+        assert connection.socket is socket, "a live socket was replaced"
+        # No signin() in between - the session has to still be there.
+        assert connection.query(f"RETURN {uuid.uuid4().int % 100}").first() is not None
+    finally:
+        connection.close()

--- a/tests/unit_tests/test_ws_connection_lifecycle.py
+++ b/tests/unit_tests/test_ws_connection_lifecycle.py
@@ -16,6 +16,7 @@ import gc
 from typing import Any
 
 import pytest
+from websockets.protocol import State
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
@@ -29,17 +30,25 @@ class _FakeSocket:
     ``close()`` is the graceful handshake-then-join teardown; ``close_socket()``
     is the one that just drops the socket. They are counted separately because
     which one runs matters: the graceful close deadlocks in a destructor.
+
+    ``state`` is modelled because ``connect()`` reads it to tell a live socket
+    from one whose peer has gone away - a real ``ClientConnection`` reports
+    ``State.CLOSED`` there once the connection is gone, while the object itself
+    stays put.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, state: State = State.OPEN) -> None:
         self.close_calls = 0
         self.close_socket_calls = 0
+        self.state = state
 
     def close(self) -> None:
         self.close_calls += 1
+        self.state = State.CLOSED
 
     def close_socket(self) -> None:
         self.close_socket_calls += 1
+        self.state = State.CLOSED
 
     def send(self, data: Any) -> None:
         pass
@@ -254,3 +263,45 @@ def test_del_survives_a_socket_that_raises_on_teardown() -> None:
     # Calling it directly rather than via `del`: an exception escaping __del__
     # is printed and ignored, so a GC-driven test would pass either way.
     connection.__del__()
+
+
+def test_connect_replaces_a_socket_whose_peer_has_gone(
+    connection: BlockingWsSurrealConnection,
+) -> None:
+    """A dead socket is not a connection, however present the object is.
+
+    When the peer drops the connection the ``ClientConnection`` object stays
+    put and only its ``state`` changes, so ``connect()`` saw "already
+    connected" and returned. That left the connection permanently wedged:
+    every later request failed on the dead socket, and the documented way to
+    reopen one silently refused to.
+    """
+    connection.connect()
+    first = connection.socket
+    assert isinstance(first, _FakeSocket)
+
+    first.state = State.CLOSED  # the peer went away
+
+    connection.connect()
+
+    assert connection.socket is not first, "the dead socket was kept"
+    assert isinstance(connection.socket, _FakeSocket)
+    assert connection.socket.state is State.OPEN
+
+
+def test_connect_keeps_a_socket_that_is_still_open(
+    connection: BlockingWsSurrealConnection,
+) -> None:
+    """The liveness check must not tear down a working connection.
+
+    Reconnecting starts a fresh, anonymous server-side session, so replacing a
+    live socket would silently undo a completed ``signin()``.
+    """
+    connection.connect()
+    first = connection.socket
+
+    connection.connect()
+
+    assert connection.socket is first
+    assert isinstance(first, _FakeSocket)
+    assert first.close_calls == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1632,7 +1632,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.25.0" },
     { name = "surrealdb-embedded", marker = "extra == 'embedded'", editable = "embedded" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6.0" },
-    { name = "websockets", specifier = ">=14.0" },
+    { name = "websockets", specifier = ">=14.1" },
 ]
 provides-extras = ["embedded", "pydantic"]
 


### PR DESCRIPTION
Two more gate majors, both websocket transport correctness.

## §1 A protocol error failed every request in flight

When the server cannot parse a frame it answers with an error carrying **no `id`** — it never got far enough to read one (JSON-RPC `-32700`). The reader treated that as connection-level and failed every pending future, so one malformed request took its neighbours down with it:

```
WITH one bad request:   all 4 -> ValidationError: Parse error
CONTROL, same 3 alone:  all 3 -> OK
```

Exactly one request is actually affected — the one whose frame was rejected, which is the one that will never be answered. Every other request in flight still gets its own reply.

So: with a **single** request in flight there is no ambiguity and it is failed at once. With **several**, the error is held — the doomed request is the one that reaches its deadline, and `_send` reports the server's real error there instead of a bare timeout. Measured after the fix:

```
several in flight:
   ('OK', 'g1')                    0.3s
   ('OK', 'g2')                    0.3s
   ('RAISED', 'ValidationError')  30.05s   <- the doomed one, with the real message
only one in flight:
   ('RAISED', 'ValidationError')   0.05s
```

Two of three now succeed where none did. The 30s is unavoidable — nothing on the wire says which request the server rejected, so the only way to identify it is that it is the one nothing answers. Trading a deadline for the doomed caller beats failing everyone.

## §2 A blocking connection stayed wedged after the peer dropped it

When the server goes away the `ClientConnection` object stays put and only its `state` changes:

```
before kill: state = State.OPEN    close_code = None
after  kill: state = State.CLOSED  close_code = ABNORMAL_CLOSURE
```

`connect()` checked only `socket is not None`, so it saw "already connected" and returned. Every later request failed on the dead socket, and `connect()` — the documented way to reopen one — silently refused to. There was no way back short of building a new connection.

The async transport already noticed this through its reader task; the blocking one has no reader, so the socket's own state is what says so.

## Notes

`RecordID(1, "x")` and friends (a non-string table name) are what reach the uncorrelatable-error path most easily. Tightening those constructors would remove the trigger, but it is a separate open question and the existing resilience tests deliberately use `RecordID(None, 1)` to provoke exactly this path — so that is left alone here.

## Verification

Run against **2.0.5, 2.3.10 and 3.2.3**: 1108 / 1108 / 1135 passing. Two mutations — restoring `_fail_pending` for uncorrelated errors, and ignoring the socket state — are each caught. Clean `ruff`, `mypy` (src and tests); `pyright` gains one `reportMissingImports` for `websockets.protocol`, the same locally-unresolvable class as the 35 existing `websockets.*` ones, which CI resolves.