### PR TITLE
Deliver every live notification, and end a subscription that was killed

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ with Surreal("ws://localhost:8000/rpc") as db:
 
 ### Talking to a SurrealDB 2.x server
 
-Three things behave differently against SurrealDB 2.x, all because of what the
+Five things behave differently against SurrealDB 2.x, all because of what the
 2.x server does rather than anything the SDK chooses.
 
 **Error kinds need 3.x.** The subclasses below `ServerError` come from the
@@ -612,6 +612,13 @@ db.run("fn::readv")        # 42 on 3.x, None on 2.x
 
 Pass the value as an argument (`db.run("fn::add", [1, 2])`) if you target 2.x —
 arguments work on every version.
+
+**A 2.x server does not tell subscribers that a live query was killed.** On 3.x
+the server sends a `KILLED` notification and `subscribe_live()` ends, whoever
+killed the query. On 2.x nothing is sent, so a subscriber to a query killed from
+*another* connection simply stops hearing anything and keeps waiting — there is
+no signal for the SDK to end the generator on. Calling `kill()` on the same
+connection you subscribed from ends the subscription on every version.
 
 The `TransportError` branch is `ConnectionUnavailableError` (the host was
 unreachable or the socket closed), `TransportTimeoutError` (the request timed

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -55,6 +55,12 @@ _LIVE_QUEUE_CLOSED = object()
 # change to the table.
 _LIVE_QUEUE_BROKEN = object()
 
+# The `action` SurrealDB puts on the notification it sends when a live query
+# ends. It reports the end of the subscription rather than a change to the
+# table - it carries no record and its `result` is None - so it terminates the
+# generator instead of being handed to the consumer.
+_LIVE_KILLED = "KILLED"
+
 
 # Upper bound on how long a single RPC waits for its reply. The blocking
 # transport has had one since it was found hanging on a protocol error; without
@@ -1040,6 +1046,14 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                             "WebSocket connection closed while subscribed to "
                             f"live query {suid}."
                         )
+                    # The server's own end-of-subscription marker. `kill()`
+                    # here pushes the sentinel above and never reaches this,
+                    # but a query killed by anyone else - another connection,
+                    # or the server - arrives only as this notification, and
+                    # yielding it handed the consumer a notification whose
+                    # `result` was None before iterating on forever.
+                    if isinstance(ret, dict) and ret.get("action") == _LIVE_KILLED:
+                        return
                     yield ret
             finally:
                 # Deregister this consumer's queue when the generator is

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -47,6 +47,12 @@ logger = logging.getLogger(__name__)
 # the connection lock so concurrent RPCs on the same socket can proceed.
 _LIVE_RECV_TIMEOUT = 0.1
 
+# The `action` SurrealDB puts on the notification it sends when a live query
+# ends. It reports the end of the subscription rather than a change to the
+# table - it carries no record and its `result` is None - so it terminates the
+# generator instead of being handed to the consumer.
+_LIVE_KILLED = "KILLED"
+
 # Upper bound on how long a single RPC waits for its reply. Without it the
 # receive loop below blocks forever if the reply never arrives - which it does
 # not when the server answers with a protocol-level error, since those carry no
@@ -1084,20 +1090,46 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             connection at a time; running several concurrently on one socket is
             not supported (use separate connections instead).
 
+        The subscription is registered before this returns, not on the first
+        ``next()``. As a plain generator function the body - registration
+        included - did not run until the consumer first iterated, and any
+        notification ``_send`` read in that window found no queue to route to
+        and was dropped with no error and no log. One RPC between ``live()``
+        and the first ``next()`` was enough to lose a change permanently.
+
+        Ends when the live query is killed, by :meth:`kill` here or by anyone
+        else. The server marks that with a ``KILLED`` notification, which is
+        not a change to the table - it carries no record - so it stops the
+        iteration instead of being yielded. Yielding it handed consumers a
+        notification whose ``result`` was ``None``, and the generator then ran
+        on forever waiting for a query that no longer existed.
+
         :raises ConnectionUnavailableError: if the socket is not established or
             is closed while the subscription is active.
         """
         suid = str(query_uuid)
         notifications: queue.Queue[dict[str, Any]] = queue.Queue()
         self.live_queues.setdefault(suid, []).append(notifications)
+        return self._iter_live(suid, notifications)
+
+    def _iter_live(
+        self,
+        suid: str,
+        notifications: "queue.Queue[dict[str, Any]]",
+    ) -> Generator[dict[str, Value], None, None]:
+        """The body of :meth:`subscribe_live`, split out so registration is eager."""
         try:
             while True:
                 # Hand back anything ``_send`` routed to us while correlating.
                 try:
-                    yield notifications.get_nowait()
-                    continue
+                    routed = notifications.get_nowait()
                 except queue.Empty:
                     pass
+                else:
+                    if routed.get("action") == _LIVE_KILLED:
+                        return
+                    yield routed
+                    continue
 
                 # Otherwise read from the socket ourselves, under the lock so
                 # we never race ``_send``. The short timeout releases the lock
@@ -1136,6 +1168,8 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
                 if rid is None:
                     continue
                 if str(rid) == suid:
+                    if result.get("action") == _LIVE_KILLED:
+                        return
                     yield result
                 else:
                     # Notification for a different live query; route it onward.

--- a/tests/unit_tests/connections/subscribe_live/test_delivery.py
+++ b/tests/unit_tests/connections/subscribe_live/test_delivery.py
@@ -1,0 +1,297 @@
+"""Every notification is delivered, and a killed query ends the subscription.
+
+Two defects in how live notifications reach a consumer.
+
+**A notification could be dropped before the first ``next()``.** The blocking
+``subscribe_live`` was a plain generator function, so its body - including the
+registration that says where notifications for this query should go - did not
+run until the consumer first iterated. Any notification ``_send`` read off the
+shared socket in that window found no queue, and was discarded with no error
+and no log. A single RPC between ``live()`` and the first ``next()`` was enough
+to lose a change permanently:
+
+    live_id = db.live("person")
+    sub = db.subscribe_live(live_id)
+    other.create("person", {"name": "first"})
+    db.query("RETURN 1").execute()          # <- swallows the notification
+    other.create("person", {"name": "second"})
+    next(sub)                               # 'second'; 'first' is gone
+
+**A killed query yielded a fake notification and then never ended.** SurrealDB
+marks the end of a live query with a ``KILLED`` notification. It reports that
+the subscription is over rather than a change to the table - it carries no
+record and its ``result`` is ``None`` - but both transports handed it to the
+consumer, so ``update["result"]["field"]`` raised ``TypeError``. The generator
+then went on waiting for a query that no longer existed.
+
+``kill()`` on the *same* connection was already handled on the async side. This
+covers the query being killed from anywhere else, which is the case neither
+transport handled.
+"""
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+# Long enough not to flake, far below an indefinite hang.
+_DEADLINE = 15.0
+
+
+def _signals_a_killed_query(version: str) -> bool:
+    """Whether this server tells subscribers that a live query has ended.
+
+    3.x sends a ``KILLED`` notification when a query is killed, wherever the
+    kill came from. 2.x sends nothing at all - a subscriber to a query killed
+    from another connection simply stops hearing anything - so there is no
+    signal for the SDK to end the generator on, and it keeps waiting.
+    """
+    text = (version or "").strip().lower()
+    for prefix in ("surrealdb-", "v"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    try:
+        return int(text.split(".")[0]) >= 3
+    except (ValueError, IndexError):
+        return False
+
+
+# Shorter than the full deadline: on a server that never signals a kill this
+# is spent proving a negative, once per test.
+_NO_SIGNAL_GRACE = 3.0
+
+
+def _next_within(subscription: Any, deadline: float = _DEADLINE) -> dict[str, Any]:
+    """``next(subscription)``, but a lost notification fails instead of hanging.
+
+    The blocking generator blocks until a notification arrives, so a dropped
+    one means ``next()`` never returns. Without a deadline the whole defect
+    reads as a hung test - which on CI is a job timeout with nothing pointing
+    at the cause - rather than a failed assertion naming what was lost.
+    """
+    received: list[dict[str, Any]] = []
+    failed: list[BaseException] = []
+
+    def pull() -> None:
+        try:
+            received.append(next(subscription))
+        except BaseException as error:  # noqa: BLE001 - re-raised below
+            failed.append(error)
+
+    reader = threading.Thread(target=pull, daemon=True)
+    reader.start()
+    reader.join(timeout=deadline)
+
+    if failed:
+        raise failed[0]
+    assert received, (
+        f"no notification arrived within {deadline}s - it was dropped before "
+        "the subscription was registered"
+    )
+    return received[0]
+
+
+def test_a_notification_survives_an_rpc_before_the_first_next(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    """The exact window that used to swallow a change."""
+    blocking_ws_connection.query("DEFINE TABLE OVERWRITE person SCHEMALESS").execute()
+
+    live_id = blocking_ws_connection.live("person")
+    subscription = blocking_ws_connection.subscribe_live(live_id)
+
+    blocking_ws_connection_secondary.create("person", {"name": "first"})
+    time.sleep(0.5)
+
+    # Any RPC on the subscribing connection reads from the same socket, so it
+    # is what picks the notification up while correlating its own reply.
+    blocking_ws_connection.query("RETURN 1").execute()
+    time.sleep(0.2)
+
+    try:
+        assert _next_within(subscription)["result"]["name"] == "first"
+    finally:
+        subscription.close()
+        blocking_ws_connection_secondary.kill(live_id)
+
+
+def test_a_notification_arrives_with_no_rpc_in_between(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    """The control: the same sequence without the RPC always worked."""
+    blocking_ws_connection.query("DEFINE TABLE OVERWRITE person SCHEMALESS").execute()
+
+    live_id = blocking_ws_connection.live("person")
+    subscription = blocking_ws_connection.subscribe_live(live_id)
+
+    blocking_ws_connection_secondary.create("person", {"name": "first"})
+    time.sleep(0.5)
+
+    try:
+        assert _next_within(subscription)["result"]["name"] == "first"
+    finally:
+        subscription.close()
+        blocking_ws_connection_secondary.kill(live_id)
+
+
+def test_blocking_subscription_ends_when_the_query_is_killed_elsewhere(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    blocking_ws_connection.query("DEFINE TABLE OVERWRITE thing SCHEMALESS").execute()
+    live_id = blocking_ws_connection.live("thing")
+
+    received: list[dict[str, Any]] = []
+    finished: list[bool] = []
+
+    def consume() -> None:
+        for notification in blocking_ws_connection.subscribe_live(live_id):
+            received.append(notification)
+        finished.append(True)
+
+    reader = threading.Thread(target=consume, daemon=True)
+    reader.start()
+    time.sleep(0.4)
+
+    blocking_ws_connection_secondary.create("thing", {"n": 1})
+    time.sleep(0.5)
+    blocking_ws_connection_secondary.kill(live_id)
+
+    signals = _signals_a_killed_query(blocking_ws_connection.version())
+    reader.join(timeout=_DEADLINE if signals else _NO_SIGNAL_GRACE)
+
+    # Whatever the server does, the consumer must never be handed the
+    # end-of-subscription marker as though it were a change to the table.
+    assert [n["action"] for n in received] == ["CREATE"], (
+        "the end-of-subscription marker was handed to the consumer as if it "
+        "were a change"
+    )
+    assert all(n["result"] is not None for n in received)
+
+    if signals:
+        assert finished, "the generator never ended after the query was killed"
+        assert not reader.is_alive()
+    else:
+        # 2.x says nothing when a query is killed elsewhere, so there is
+        # nothing for the generator to end on. Pinned rather than skipped so
+        # a server that starts signalling is visible here.
+        assert not finished
+
+
+async def test_async_subscription_ends_when_the_query_is_killed_elsewhere(
+    async_ws_connection: AsyncWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    await async_ws_connection.query("DEFINE TABLE OVERWRITE thing SCHEMALESS").execute()
+    live_id = await async_ws_connection.live("thing")
+    subscription = await async_ws_connection.subscribe_live(live_id)
+
+    received: list[dict[str, Any]] = []
+
+    async def consume() -> None:
+        async for notification in subscription:
+            received.append(notification)
+
+    consumer = asyncio.ensure_future(consume())
+    await asyncio.sleep(0.4)
+
+    blocking_ws_connection_secondary.create("thing", {"n": 1})
+    await asyncio.sleep(0.5)
+    blocking_ws_connection_secondary.kill(live_id)
+
+    signals = _signals_a_killed_query(await async_ws_connection.version())
+    if signals:
+        await asyncio.wait_for(consumer, timeout=_DEADLINE)
+    else:
+        # See `_signals_a_killed_query`: nothing arrives to end it on 2.x.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(consumer), timeout=_NO_SIGNAL_GRACE)
+        consumer.cancel()
+
+    assert [n["action"] for n in received] == ["CREATE"]
+    assert all(n["result"] is not None for n in received)
+
+
+async def test_async_kill_on_the_same_connection_still_ends_cleanly(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    """The path that already worked, so the new branch does not disturb it."""
+    await async_ws_connection.query("DEFINE TABLE OVERWRITE thing SCHEMALESS").execute()
+    live_id = await async_ws_connection.live("thing")
+    subscription = await async_ws_connection.subscribe_live(live_id)
+
+    async def consume() -> None:
+        async for _ in subscription:
+            pass
+
+    consumer = asyncio.ensure_future(consume())
+    await asyncio.sleep(0.2)
+
+    await async_ws_connection.kill(live_id)
+
+    # `kill()` here pushes the SDK's own sentinel, so this ends on every
+    # server version - it does not depend on the server signalling anything.
+    await asyncio.wait_for(consumer, timeout=_DEADLINE)
+
+
+def test_a_live_query_still_delivers_several_notifications(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+) -> None:
+    """Ending on KILLED must not end on anything else.
+
+    Guards the obvious over-reach: a subscription that stops after the first
+    notification would pass every test above.
+    """
+    blocking_ws_connection.query("DEFINE TABLE OVERWRITE thing SCHEMALESS").execute()
+    live_id = blocking_ws_connection.live("thing")
+    subscription = blocking_ws_connection.subscribe_live(live_id)
+
+    try:
+        for index in range(3):
+            blocking_ws_connection_secondary.create("thing", {"n": index})
+
+        actions = [_next_within(subscription)["action"] for _ in range(3)]
+        assert actions == ["CREATE", "CREATE", "CREATE"]
+    finally:
+        subscription.close()
+        blocking_ws_connection_secondary.kill(live_id)
+
+
+@pytest.mark.parametrize("action", ["CREATE", "UPDATE", "DELETE"])
+def test_real_notifications_are_not_mistaken_for_the_end(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    blocking_ws_connection_secondary: BlockingWsSurrealConnection,
+    action: str,
+) -> None:
+    """Every action that is a genuine change still reaches the consumer."""
+    # `DEFINE TABLE OVERWRITE` redefines the table but keeps its rows, so the
+    # fixed record id below would collide with the previous parametrisation.
+    blocking_ws_connection.query(
+        "REMOVE TABLE IF EXISTS thing; DEFINE TABLE thing SCHEMALESS;"
+    ).execute()
+    blocking_ws_connection_secondary.create("thing:target", {"n": 0})
+
+    live_id = blocking_ws_connection.live("thing")
+    subscription = blocking_ws_connection.subscribe_live(live_id)
+
+    try:
+        if action == "CREATE":
+            blocking_ws_connection_secondary.create("thing:fresh", {"n": 1})
+        elif action == "UPDATE":
+            blocking_ws_connection_secondary.update("thing:target", {"n": 2})
+        else:
+            blocking_ws_connection_secondary.delete("thing:target")
+
+        notification = _next_within(subscription)
+        assert notification["action"] == action
+    finally:
+        subscription.close()
+        blocking_ws_connection_secondary.kill(live_id)


### PR DESCRIPTION
Two gate majors in how live notifications reach a consumer.

## §1 A notification could be dropped before the first `next()`

The blocking `subscribe_live` was a plain generator function, so its body — including the registration that says where notifications for this query should go — did not run until the consumer first iterated. Any notification `_send` read off the shared socket in that window found no queue and was discarded, with no error and no log:

```python
live_id = db.live("person")
sub = db.subscribe_live(live_id)
other.create("person", {"name": "first"})
db.query("RETURN 1").execute()      # <- swallows the notification
other.create("person", {"name": "second"})
next(sub)                           # 'second'; 'first' is gone
```

```
rpc_in_between=False  first delivered = 'first'
rpc_in_between=True   first delivered = 'second'    <- 'first' lost
```

One ordinary RPC between `live()` and the first `next()` was enough to lose a change permanently. Registration now happens before `subscribe_live` returns, with the loop split into a helper — the same shape the async transport already used.

## §2 A killed query yielded a fake notification and then never ended

SurrealDB marks the end of a live query with a `KILLED` notification. It reports that the subscription is over rather than a change to the table — it carries no record and its `result` is `None`:

```
{'action': 'KILLED', 'id': UUID(...), 'record': None, 'result': None, 'session': None}
```

Both transports handed that to the consumer, so `update["result"]["field"]` raised `TypeError`, and the generator then waited forever for a query that no longer existed:

```
actions yielded: ['CREATE', 'KILLED']
generator ended: False
```

It now ends the iteration, on both transports. `kill()` on the *same* connection was already handled on the async side — this is the case where the query is killed from anywhere else, which neither transport handled.

## SurrealDB 2.x

2.x sends no `KILLED` notification at all, so a subscriber to a query killed from another connection simply stops hearing anything and there is nothing for the SDK to end on. The tests pin that per version rather than skipping it, so a server that starts signalling becomes visible, and the README records it with the other 2.x compatibility notes.

## Verification

Run against **2.0.5, 2.3.10 and 3.2.3**: 1158 / 1158 / 1185 passing.

Three mutations — restoring lazy registration, and yielding the `KILLED` frame on each transport — are each caught. The first one initially made the tests **hang** rather than fail, which on CI is a job timeout with nothing pointing at the cause, so the delivery assertions now carry deadlines and report what was lost instead.