### PR TITLE
Await subscribe_live in the six live-query examples

### DIFF
--- a/examples/fastapi/routes/websocket.py
+++ b/examples/fastapi/routes/websocket.py
@@ -43,7 +43,10 @@ async def users_live_query(websocket: WebSocket) -> None:
         async def process_live_results() -> None:
             """Process live query results and send to client."""
             try:
-                async for result in db.subscribe_live(live_query_id):
+                # `subscribe_live` is a coroutine returning an async generator, so it
+                # has to be awaited before it can be iterated.
+                subscription = await db.subscribe_live(live_query_id)
+                async for result in subscription:
                     await websocket.send_json(
                         {
                             "type": "update",

--- a/examples/graphql/schema/subscriptions.py
+++ b/examples/graphql/schema/subscriptions.py
@@ -28,7 +28,10 @@ class Subscription:
             live_query_id = await db.live("users")
 
             # Stream updates to subscribers
-            async for result in db.subscribe_live(live_query_id):
+            # `subscribe_live` is a coroutine returning an async generator, so it
+            # has to be awaited before it can be iterated.
+            subscription = await db.subscribe_live(live_query_id)
+            async for result in subscription:
                 # Parse the live query result
                 if isinstance(result, dict) and "result" in result:
                     user_data = result["result"]

--- a/examples/litestar/controllers/websocket.py
+++ b/examples/litestar/controllers/websocket.py
@@ -58,7 +58,10 @@ class WebSocketController(Controller):
             async def process_live_results():
                 """Process live query results and send to client."""
                 try:
-                    async for result in db.subscribe_live(live_query_id):
+                    # `subscribe_live` is a coroutine returning an async generator, so it
+                    # has to be awaited before it can be iterated.
+                    subscription = await db.subscribe_live(live_query_id)
+                    async for result in subscription:
                         await socket.send_json(
                             {
                                 "type": "update",

--- a/examples/quart/routes/websocket.py
+++ b/examples/quart/routes/websocket.py
@@ -45,7 +45,10 @@ async def users_live_query():
         async def process_live_results():
             """Process live query results and send to client."""
             try:
-                async for result in db.subscribe_live(live_query_id):
+                # `subscribe_live` is a coroutine returning an async generator, so it
+                # has to be awaited before it can be iterated.
+                subscription = await db.subscribe_live(live_query_id)
+                async for result in subscription:
                     await websocket.send(
                         json.dumps(
                             {

--- a/examples/sanic/blueprints/websocket.py
+++ b/examples/sanic/blueprints/websocket.py
@@ -44,7 +44,10 @@ async def users_live_query(request, ws):
         async def process_live_results():
             """Process live query results and send to client."""
             try:
-                async for result in db.subscribe_live(live_query_id):
+                # `subscribe_live` is a coroutine returning an async generator, so it
+                # has to be awaited before it can be iterated.
+                subscription = await db.subscribe_live(live_query_id)
+                async for result in subscription:
                     await ws.send(
                         json.dumps(
                             {

--- a/examples/starlette/routes/websocket.py
+++ b/examples/starlette/routes/websocket.py
@@ -41,7 +41,10 @@ async def users_live_query(websocket: WebSocket):
         async def process_live_results():
             """Process live query results and send to client."""
             try:
-                async for result in db.subscribe_live(live_query_id):
+                # `subscribe_live` is a coroutine returning an async generator, so it
+                # has to be awaited before it can be iterated.
+                subscription = await db.subscribe_live(live_query_id)
+                async for result in subscription:
                     await websocket.send_json(
                         {
                             "type": "update",

--- a/tests/unit_tests/test_examples_use_the_real_api.py
+++ b/tests/unit_tests/test_examples_use_the_real_api.py
@@ -15,6 +15,7 @@ Notebooks are included: the same call was in one of those too.
 """
 
 import ast
+import inspect
 import json
 import pathlib
 import re
@@ -109,3 +110,55 @@ def test_every_example_parses() -> None:
             broken.append(f"{path.name}: {error}")
 
     assert not broken, "examples that do not parse: " + "; ".join(broken)
+
+
+def _coroutine_methods() -> set[str]:
+    """Public methods that are coroutines on any async connection class."""
+    return {
+        name
+        for cls in _CONNECTIONS
+        for name, member in vars(cls).items()
+        if not name.startswith("_") and inspect.iscoroutinefunction(member)
+    }
+
+
+def test_no_example_iterates_a_coroutine() -> None:
+    """``async for`` over an un-awaited coroutine raises ``TypeError``.
+
+    ``subscribe_live`` is a coroutine that *returns* an async generator, so it
+    has to be awaited before it can be iterated. Six framework examples wrote
+
+        async for result in db.subscribe_live(live_query_id):
+
+    which raises ``TypeError: 'async for' requires an object with __aiter__
+    method, got coroutine`` the moment the endpoint is hit - so every
+    live-query WebSocket example never delivered a single update.
+
+    The existing check above only asks whether the method exists, which this
+    passes: `subscribe_live` is real, it is just being used wrongly. Iterating
+    a coroutine is wrong for any connection type, so this needs no guess about
+    which one an example holds.
+    """
+    coroutines = _coroutine_methods()
+    offenders: list[str] = []
+
+    for path, text in _sources():
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue  # reported by the parse test above
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFor):
+                continue
+            call = node.iter
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            if not isinstance(func, ast.Attribute) or func.attr not in coroutines:
+                continue
+            offenders.append(
+                f"{path.relative_to(_EXAMPLES.parent)}:{node.lineno} "
+                f"iterates db.{func.attr}() without awaiting it"
+            )
+
+    assert not offenders, "examples iterating a coroutine: " + "; ".join(offenders)


### PR DESCRIPTION
The last of the gate majors.

## The defect

`subscribe_live` is a coroutine that *returns* an async generator, so it has to be awaited before it can be iterated. Six framework examples wrote:

```python
async for result in db.subscribe_live(live_query_id):
```

```
TypeError: 'async for' requires an object with __aiter__ method, got coroutine
```

Every live-query WebSocket example — fastapi, quart, starlette, sanic, litestar, graphql — raised that the moment the endpoint was hit, and never delivered a single update.

## Why the existing check missed it

The examples check added with the `merge()` migration only asks whether a method **exists**, and this passes: `subscribe_live` is real, it was just being used wrongly.

It now also refuses an `async for` over any method that is a coroutine on a connection class. Iterating a coroutine is wrong whichever connection an example holds, so the check needs no guess about which one that is — no heuristics about `Surreal` vs `AsyncSurreal`.

Reverting the examples makes it name all six:

```
examples/fastapi/routes/websocket.py:46 iterates db.subscribe_live() without awaiting it
examples/graphql/schema/subscriptions.py:31 iterates db.subscribe_live() without awaiting it
examples/litestar/controllers/websocket.py:61 iterates db.subscribe_live() without awaiting it
examples/quart/routes/websocket.py:48 iterates db.subscribe_live() without awaiting it
examples/sanic/blueprints/websocket.py:47 iterates db.subscribe_live() without awaiting it
examples/starlette/routes/websocket.py:44 iterates db.subscribe_live() without awaiting it
```

## Verification

1218 passing locally including the embedded engine. Clean `ruff` and `mypy`.