### PR TITLE
Fix the twelve regressions the second gate found in the nine fix PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,16 +514,32 @@ the write-back above delete the field.
 > it touched. If you have code comparing a database value with `is None`,
 > check whether the column can be NULL.
 
-**Sets read back as lists.** SurrealDB's `set<T>` accepts any member type,
-including `set<object>` and `set<array>`, which a Python `set` cannot hold. A
-set therefore decodes to a `list` — the same shape SurrealDB 2.x and the
-server's own JSON endpoint return. Writing is unchanged: a Python `set` still
-goes out as a set, and the server deduplicates it.
+**Sets read back as `SurrealSet`.** SurrealDB's `set<T>` is a deduplicated
+sequence that accepts any member type, including `set<object>` and `set<array>`
+— which a Python `set` cannot hold, because its members must be hashable.
+
+`SurrealSet` is a `list` subclass, so it indexes and compares like the sequence
+it is, and it encodes back under the set tag, so writing a record back keeps the
+field a set:
 
 ```python
-db.create(rec, {"tags": {"a", "b"}})   # stored as a set
-db.select(rec)["tags"]                 # ['a', 'b'] — a list
+row = db.select(rec)                   # {"tags": SurrealSet(['a', 'b'])}
+row["name"] = "new name"
+db.update(rec, row)                    # tags is still a set
+
+db.select(rec)["tags"] == ["a", "b"]   # True — it is a list
 ```
+
+Writing a plain Python `set` still works and is still sent as a set. The order
+is whatever the server sent: SurrealDB normalises a set, so `<set>[3,1,2]` comes
+back as `[1, 2, 3]`.
+
+> Decoding a set to a plain `list` — as 3.0.0-beta.5 briefly did — loses the
+> type on the way back: a schemafull `set<T>` field rejects the array outright,
+> and a schemaless one silently becomes an array and stops deduplicating.
+>
+> Sets need SurrealDB 3.x. 2.x has no CBOR set representation at all — see
+> [Talking to a SurrealDB 2.x server](#talking-to-a-surrealdb-2x-server).
 
 ## Error handling
 
@@ -653,7 +669,7 @@ v3.0 is a breaking change. Highlights:
 | `db.select(RecordID(...))` -> `[record]`         | `db.select(RecordID(...))` -> `record` dict or `None`     |
 | `db.delete("my-table")` (silently inlined)       | `db.delete(Table("my-table"))` (raw string rejected)      |
 | A NULL field read as `None`                      | A NULL field reads as `Null` (`None` still means NONE)    |
-| `set<T>` read as a Python `set`                  | `set<T>` reads as a `list` (writing a `set` is unchanged) |
+| `set<T>` read as a Python `set`                  | `set<T>` reads as a `SurrealSet` (writing a `set` is unchanged) |
 
 > Bare-string resource targets are now strictly validated against the
 > safe-identifier pattern (`[A-Za-z_][A-Za-z0-9_]*`) so user-supplied

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -41,6 +41,7 @@ from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import Range
+from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.record_id import RecordID, escape_identifier
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
@@ -123,6 +124,7 @@ __all__ = [
     "PreciseDatetime",
     "Null",
     "NullType",
+    "SurrealSet",
     "Tokens",
     "Value",
     "escape_identifier",

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -5,6 +5,7 @@ A basic async connection to a SurrealDB instance.
 import asyncio
 import logging
 import uuid
+import weakref
 from asyncio import AbstractEventLoop, Future, Queue, Task
 from collections.abc import AsyncGenerator
 from types import TracebackType
@@ -68,6 +69,21 @@ _LIVE_KILLED = "KILLED"
 _RPC_RECV_TIMEOUT = 30.0
 
 
+def _release_live_queue(
+    live_queues: dict[str, list["Queue[Any]"]],
+    suid: str,
+    result_queue: "Queue[Any]",
+) -> None:
+    """Deregister one subscriber's queue. Safe to call twice."""
+    queues = live_queues.get(suid)
+    if queues is None:
+        return
+    if result_queue in queues:
+        queues.remove(result_queue)
+    if not queues:
+        live_queues.pop(suid, None)
+
+
 class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
     """
     A single async connection to a SurrealDB instance. To be used once and discarded.
@@ -105,8 +121,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self._connect_lock_loop: AbstractEventLoop | None = None
         # A protocol error the server could not correlate to a request, held
         # until the request it belongs to hits its deadline - see
-        # `_deliver_uncorrelated`.
+        # `_deliver_uncorrelated`. `_uncorrelated_for` is the set of request ids
+        # that were in flight when it arrived: the rejected frame belongs to one
+        # of those and to nothing else.
         self._uncorrelated_error: SurrealError | None = None
+        self._uncorrelated_for: set[str] = set()
 
     def _connect_guard(self) -> asyncio.Lock:
         """The lock serialising ``connect()``, bound to the running loop.
@@ -166,11 +185,41 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             self.qry.pop(query_id, None)
             return
         self._uncorrelated_error = error
+        self._uncorrelated_for = {query_id for query_id, _ in pending}
 
-    def _take_uncorrelated(self) -> SurrealError | None:
-        """Consume a held protocol error, if one is waiting."""
-        error, self._uncorrelated_error = self._uncorrelated_error, None
+    def _take_uncorrelated(self, query_id: str) -> SurrealError | None:
+        """Consume a held protocol error if it can belong to *query_id*.
+
+        Only a request that was already in flight when the error arrived can be
+        the one whose frame the server rejected; anything started afterwards has
+        its own reply coming. Handing the error to whichever request happened to
+        time out next told a caller its own perfectly valid query had a parse
+        error - a request that was not even sent when the failure happened.
+        """
+        if self._uncorrelated_error is None or query_id not in self._uncorrelated_for:
+            return None
+        error = self._uncorrelated_error
+        self._forget_uncorrelated()
         return error
+
+    def _forget_uncorrelated(self) -> None:
+        """Drop a held error once it can no longer belong to anyone."""
+        self._uncorrelated_error = None
+        self._uncorrelated_for = set()
+
+    def _prune_uncorrelated(self) -> None:
+        """Forget a held error whose candidates have all gone away.
+
+        A caller that abandons its request - an application-level timeout, a
+        cancelled task - never reaches the deadline that would have collected
+        the error, so without this it would sit there waiting to ambush an
+        unrelated request much later.
+        """
+        if self._uncorrelated_error is None:
+            return
+        self._uncorrelated_for &= self.qry.keys()
+        if not self._uncorrelated_for:
+            self._forget_uncorrelated()
 
     async def _recv_task(self) -> None:
         assert self.socket
@@ -269,7 +318,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                 # no reply is ever coming. That error was held rather than
                 # failing every other request in flight; this is the request it
                 # belongs to, so report it instead of a bare deadline.
-                uncorrelated = self._take_uncorrelated()
+                uncorrelated = self._take_uncorrelated(query_id)
                 if uncorrelated is not None:
                     raise uncorrelated from exc
                 raise TransportTimeoutError(
@@ -280,6 +329,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             # ``_recv_task`` clears ``self.qry`` when the socket closes, so the
             # key may already be gone; ``pop`` avoids a spurious ``KeyError``.
             self.qry.pop(query_id, None)
+            self._prune_uncorrelated()
 
         if bypass is False:
             self.check_response_for_error(response, process)
@@ -1062,7 +1112,19 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                 if queues is not None and result_queue in queues:
                     queues.remove(result_queue)
 
-        return _iter()
+        subscription = _iter()
+        # Registration happens above, before anything is iterated, so release
+        # has to be reachable without iterating. A generator that is never
+        # started does not run its `finally` on close or GC, so a subscription
+        # set up and then abandoned stayed registered for the life of the
+        # connection while notifications kept filling a queue nobody drains.
+        #
+        # Closing over `live_queues` rather than `self`, so the finalizer does
+        # not keep the connection alive for as long as the generator.
+        weakref.finalize(
+            subscription, _release_live_queue, self.live_queues, suid, result_queue
+        )
+        return subscription
 
     async def kill(
         self,
@@ -1170,7 +1232,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
             finally:
                 self.socket = None
                 self.recv_task = None
-                self._uncorrelated_error = None
+
+        # Unconditionally, not only when there was a socket to close: a new
+        # socket is a new conversation, and nothing about the old one may be
+        # waiting to be delivered into it.
+        self._forget_uncorrelated()
 
     async def __aenter__(self) -> "AsyncWsSurrealConnection":
         """

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -7,6 +7,7 @@ import queue
 import threading
 import time
 import uuid
+import weakref
 from collections.abc import Generator
 from types import TracebackType
 from typing import Any, overload
@@ -53,12 +54,31 @@ _LIVE_RECV_TIMEOUT = 0.1
 # generator instead of being handed to the consumer.
 _LIVE_KILLED = "KILLED"
 
+# Pushed into a subscriber's queue by `kill()` on this connection, so the
+# generator ends without waiting for a server notification. 2.x never sends one.
+_LIVE_KILLED_SENTINEL: dict[str, Any] = {"action": _LIVE_KILLED, "id": None}
+
 # Upper bound on how long a single RPC waits for its reply. Without it the
 # receive loop below blocks forever if the reply never arrives - which it does
 # not when the server answers with a protocol-level error, since those carry no
 # `id` to correlate. Matches the 30s total the HTTP transports give aiohttp and
 # requests.
 _RPC_RECV_TIMEOUT = 30.0
+
+
+def _release_live_queue(
+    live_queues: dict[str, list["queue.Queue[dict[str, Any]]"]],
+    suid: str,
+    notifications: "queue.Queue[dict[str, Any]]",
+) -> None:
+    """Deregister one subscriber's queue. Safe to call twice."""
+    queues = live_queues.get(suid)
+    if queues is None:
+        return
+    if notifications in queues:
+        queues.remove(notifications)
+    if not queues:
+        live_queues.pop(suid, None)
 
 
 class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
@@ -1065,13 +1085,26 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         query_uuid: str | UUID,
         session_id: UUID | None = None,
     ) -> None:
-        """Kill a running live query by its UUID."""
+        """Kill a running live query by its UUID.
+
+        Any ``subscribe_live`` generator on this connection for that query ends
+        as a result, on every server version. 3.x announces the kill with a
+        ``KILLED`` notification and the generator stops on that, but 2.x sends
+        nothing at all - so waiting for the server left the caller's own
+        subscription blocked forever on a query it had just killed itself. The
+        sentinel below is pushed locally, which is what the async transport has
+        always done.
+        """
         kwargs: dict[str, Any] = {"uuid": query_uuid}
         if session_id is not None:
             kwargs["session"] = session_id
         message = RequestMessage(RequestMethod.KILL, **kwargs)
         self.id = message.id
         self._send(message, "kill")
+
+        suid = str(query_uuid)
+        for notifications in self.live_queues.get(suid, []):
+            notifications.put(_LIVE_KILLED_SENTINEL)
 
     def subscribe_live(
         self,
@@ -1110,7 +1143,21 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         suid = str(query_uuid)
         notifications: queue.Queue[dict[str, Any]] = queue.Queue()
         self.live_queues.setdefault(suid, []).append(notifications)
-        return self._iter_live(suid, notifications)
+        subscription = self._iter_live(suid, notifications)
+        # Registration is eager, so release has to be reachable without ever
+        # iterating. A generator that is never started does not run its
+        # `finally` on close or GC, so a subscription that was set up and then
+        # abandoned - on an early error, a conditional consumer, a retry loop -
+        # stayed registered for the life of the connection while notifications
+        # kept being routed into a queue nobody would ever drain.
+        #
+        # The finalizer deliberately closes over `live_queues` rather than
+        # `self`: a bound method here would keep the whole connection alive for
+        # as long as the generator, trading one leak for another.
+        weakref.finalize(
+            subscription, _release_live_queue, self.live_queues, suid, notifications
+        )
+        return subscription
 
     def _iter_live(
         self,

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -86,11 +86,12 @@ def merge_query_vars(
     return merged
 
 
-# A SurrealDB function name: `fn::mine`, `time::now`, or a nested `fn::a::b`.
-# Used to build `RETURN <name>(...)` for the HTTP `run()` path, so it is
-# anchored and deliberately narrow - nothing outside this subset is inlined
-# into a query.
-_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$")
+# One segment of a function name that needs no quoting: `fn`, `time`, `now`.
+_PLAIN_SEGMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+# Characters that cannot appear inside a backtick-quoted segment without
+# ending the quoting, so a name containing one cannot be rendered safely.
+_UNQUOTABLE = ("`", "\n", "\r")
 
 # Prefix for the generated argument parameters. Distinctive so it cannot
 # collide with a name someone bound with `let()`.
@@ -112,20 +113,58 @@ def build_run_query(
     bindings as parameters of a ``RETURN <name>(...)`` query makes HTTP behave
     the way the websocket does.
 
-    :raises ValueError: if *name* is not a plain function name. It is the one
-        part that cannot be parameter-bound, so anything outside the safe
-        subset is refused rather than inlined.
+    :raises ValueError: if *name* cannot be rendered as SurrealQL. The name is
+        the one part that cannot be parameter-bound, so a segment containing a
+        backtick or a newline - which would end the quoting - is refused rather
+        than inlined.
+    :raises TypeError: if *args* is not a list or tuple. ``enumerate`` accepts
+        any iterable, so a bare string used to be spread into one argument per
+        character: ``run("fn::f", "ab")`` called ``f("a", "b")``. The server
+        rejects a non-array ``args`` too ("Expected args to be array"), so this
+        refuses the same input, just earlier and by name.
     """
-    if not _FUNCTION_NAME_RE.match(name):
-        raise ValueError(
-            f"{name!r} is not a valid SurrealDB function name; expected "
-            "something like 'fn::my_function' or 'time::now'"
+    if args is not None and not isinstance(args, (list, tuple)):
+        raise TypeError(
+            f"run() args must be a list or tuple of values, got {type(args).__name__}"
         )
     arguments: dict[str, Value] = {
         f"{_RUN_ARG_PREFIX}{index}": value for index, value in enumerate(args or [])
     }
     rendered = ", ".join(f"${key}" for key in arguments)
-    return f"RETURN {name}({rendered});", arguments
+    return f"RETURN {_render_function_name(name)}({rendered});", arguments
+
+
+def _render_function_name(name: str) -> str:
+    """Render a function name as SurrealQL, quoting segments that need it.
+
+    SurrealDB accepts a backtick-quoted identifier in a function name, so
+    ``fn::`my-fn``` is legal, definable and callable. Requiring every segment to
+    be a bare identifier meant a name the ``run`` RPC executed happily was
+    rejected outright the moment a ``let()`` binding pushed the call onto the
+    query path - so an unrelated ``let()`` elsewhere in a program broke a
+    ``run()`` call that had always worked.
+    """
+    if not name:
+        raise ValueError("run() needs a function name, got an empty string")
+
+    segments = name.split("::")
+    rendered: list[str] = []
+    for segment in segments:
+        if not segment:
+            raise ValueError(
+                f"{name!r} is not a valid SurrealDB function name: it has an "
+                "empty segment"
+            )
+        if _PLAIN_SEGMENT_RE.match(segment):
+            rendered.append(segment)
+            continue
+        if any(char in segment for char in _UNQUOTABLE):
+            raise ValueError(
+                f"{name!r} is not a valid SurrealDB function name: the segment "
+                f"{segment!r} contains a character that cannot be quoted"
+            )
+        rendered.append(f"`{segment}`")
+    return "::".join(rendered)
 
 
 def _clip(text: str) -> str:

--- a/src/surrealdb/data/__init__.py
+++ b/src/surrealdb/data/__init__.py
@@ -10,10 +10,12 @@ from surrealdb.data.types.geometry import (
 )
 from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.table import Table
 
 __all__ = (
     "Null",
+    "SurrealSet",
     "NullType",
     "GeometryPoint",
     "GeometryLine",

--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -25,6 +25,7 @@ from surrealdb.data.types.geometry import (
 from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
 from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.table import Table
 from surrealdb.errors import UnexpectedResponseError
 
@@ -192,17 +193,15 @@ def tag_decoder(
         return decimal.Decimal(tag.value)
 
     elif tag.tag == constants.TAG_SET:
-        # A list, not a Python `set`. SurrealDB's set holds any value - a
-        # `set<object>` or `set<array>` field is ordinary - while a Python set
-        # takes only hashable members, so `set(...)` raised `unhashable type:
-        # 'dict'` and took the whole response with it. Every `SELECT *` over
-        # such a table failed, and the field could not be read at all.
-        #
-        # A list is also what SurrealDB 2.x returns for a set, and what the
-        # server's own JSON endpoint returns, so this is the shape the rest of
-        # the ecosystem already uses. Encoding is unchanged: a Python `set`
-        # still goes out under the set tag.
-        return list(tag.value) if isinstance(tag.value, list) else tag.value
+        # `SurrealSet`, not a Python `set` and not a plain list. A Python set
+        # cannot hold the objects and arrays a `set<object>` column contains, so
+        # decoding into one raised `unhashable type: 'dict'` and lost the whole
+        # response. A plain list can hold them but is a *different type* to the
+        # server, so writing a record back either failed on a schemafull field
+        # or silently turned a schemaless one into an array. `SurrealSet` reads
+        # like the sequence it is and encodes back as a set - see
+        # `surrealdb.data.types.set`.
+        return SurrealSet(tag.value) if isinstance(tag.value, list) else tag.value
 
     else:
         # Unlike the encoder's unsupported-type case, this is not a caller
@@ -244,6 +243,15 @@ class _SurrealEncoder(CBOREncoder):
         super().__init__(*args, **kwargs)
         self._encoders.pop(set, None)
         self._encoders.pop(frozenset, None)
+
+        # `SurrealSet` is a `list` subclass, and the generic lookup resolves a
+        # subclass through `issubclass`, so it would find `list`'s encoder and
+        # emit a plain array - which is exactly the bug this type exists to
+        # stop. An exact-type registration is consulted first, so this wins.
+        def _encode_surreal_set(encoder: CBOREncoder, value: SurrealSet) -> None:
+            encoder.encode(CBORTag(constants.TAG_SET, list(value)))
+
+        self._encoders[SurrealSet] = _encode_surreal_set
 
         # Registered for the exact subclass only, so a plain `datetime` keeps
         # cbor2's native encoding untouched. Without this the native encoder

--- a/src/surrealdb/data/types/duration.py
+++ b/src/surrealdb/data/types/duration.py
@@ -1,6 +1,5 @@
 import re
 from dataclasses import dataclass
-from math import floor
 
 from surrealdb.errors import InvalidDurationError
 
@@ -29,7 +28,10 @@ _PART_RE = re.compile(rf"(\d+)({_UNIT_PATTERN})")
 # "1.5s" parsed as the "5s" inside it, "-1s" lost its sign and came out
 # positive, and "1e3s" became three seconds. Each produced a wrong value rather
 # than an error, which is the worst of the three possible outcomes.
-_DURATION_RE = re.compile(rf"^(?:\d+(?:{_UNIT_PATTERN}))+$")
+# `\Z`, not `$`: `$` also matches immediately before a single trailing newline,
+# so `"1s\n"` slipped through while `"1s "` and `"1s\r"` were rejected - the
+# anchor disagreed with itself about what "end of string" meant.
+_DURATION_RE = re.compile(rf"(?:\d+(?:{_UNIT_PATTERN}))+\Z")
 
 
 @dataclass
@@ -56,7 +58,13 @@ class Duration:
             return Duration(nanoseconds + value * UNITS["s"])
 
         # Support compound durations: "1h30m", "2d3h15m", etc.
-        text = value.lower()
+        #
+        # Surrounding whitespace is stripped because the server accepts it
+        # (`<duration>' 1s '` parses), but the case of the unit is left alone:
+        # SurrealDB rejects `1S`, `1MS`, `1NS` and `1H30M`. Lowercasing first
+        # silently turned every one of those into a duration the server would
+        # have refused, which is the opposite of what this validation is for.
+        text = value.strip()
         if not _DURATION_RE.match(text):
             raise InvalidDurationError(f"Invalid duration format: {value}")
 
@@ -67,9 +75,17 @@ class Duration:
         return Duration(total_ns)
 
     def get_seconds_and_nano(self) -> tuple[int, int]:
-        sec = floor(self.elapsed / UNITS["s"])
-        nsec = self.elapsed - (sec * UNITS["s"])
-        return sec, nsec
+        """Split into the ``[seconds, nanoseconds]`` pair the wire format uses.
+
+        Integer ``divmod``, not float division. ``floor(elapsed / 1e9)`` loses
+        precision once ``elapsed`` is large enough that the quotient cannot be
+        represented exactly, and rounds *up* when the remainder is close to a
+        full second - so ``Duration(31536000999999999)`` (1y999999999ns, a value
+        this class parses happily) split into ``(31536001, -1)``. The encoder
+        sent that verbatim and the server rejected the frame, which made an
+        ordinary read-modify-write of such a duration impossible.
+        """
+        return divmod(self.elapsed, UNITS["s"])
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Duration):
@@ -116,13 +132,23 @@ class Duration:
         return self.elapsed // UNITS["y"]
 
     def to_string(self) -> str:
+        """Render as SurrealQL compact-unit syntax, e.g. ``1h30m``.
+
+        A negative duration renders with a leading ``-`` rather than being fed
+        through ``divmod`` as-is: Python's ``divmod`` floors, so ``Duration(-1)``
+        - one nanosecond before zero - came out as ``52w23h59m59s999ms999us999ns``,
+        a value nowhere near what it holds. SurrealDB has no negative durations,
+        so nothing can consume the result either way, but reporting the sign
+        beats reporting almost a year.
+        """
+        sign = "-" if self.elapsed < 0 else ""
+        remaining = abs(self.elapsed)
         result = ""
-        remaining = self.elapsed
         for unit in ["y", "w", "d", "h", "m", "s", "ms", "us", "ns"]:
             amount, remaining = divmod(remaining, UNITS[unit])
             if amount > 0:
                 result += f"{amount}{unit}"
-        return result or "0ns"
+        return f"{sign}{result}" if result else "0ns"
 
     def __str__(self) -> str:
         """

--- a/src/surrealdb/data/types/set.py
+++ b/src/surrealdb/data/types/set.py
@@ -1,0 +1,51 @@
+"""SurrealDB's ``set<T>``, which neither a Python ``set`` nor a ``list`` models.
+
+A SurrealDB set is a *deduplicated sequence*. Two things follow, and no builtin
+gives both:
+
+* it holds any value, including objects and arrays - ``set<object>`` is an
+  ordinary column - which a Python ``set`` cannot, because its members must be
+  hashable;
+* it is a distinct type from an array, and the server enforces that: a
+  schemafull ``set<T>`` field refuses a plain array, and a schemaless field that
+  holds a set stops deduplicating once it is overwritten with one.
+
+Decoding into a Python ``set`` failed the first: ``unhashable type: 'dict'``,
+raised while decoding, took the whole response with it, so any ``SELECT *``
+touching such a field died and the record could not be read in its native form.
+
+Decoding into a plain ``list`` failed the second, and did it silently. Reading a
+record and writing it back - the most ordinary operation there is - either
+failed outright::
+
+    row = db.select(rec)          # {"nums": [1, 2]}
+    db.update(rec, row)
+    # InternalError: Couldn't coerce value for field `nums`:
+    #                Expected `set` but found `[1, 2]`
+
+or, on a schemaless table, quietly changed the field's type::
+
+    stored before: {'a', 'b'}
+    stored after : ['a', 'b']      # after a read-modify-write
+    after += 'a' : ['a', 'b', 'a'] # deduplication gone
+
+:class:`SurrealSet` is a ``list`` subclass, so it reads and indexes like the
+sequence it is and compares equal to the equivalent list, and it encodes back
+under SurrealDB's set tag, so the round trip keeps the field a set.
+
+The order is whatever the server sent - SurrealDB normalises a set, so
+``<set>[3,1,2]`` comes back as ``[1,2,3]`` - and it is significant for equality,
+as it is for any list. Writing a plain Python ``set`` still works and is still
+sent as a set; that path never changed.
+"""
+
+from typing import Any
+
+
+class SurrealSet(list[Any]):
+    """A SurrealDB ``set<T>``. See the module docstring for why it exists."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return f"SurrealSet({list.__repr__(self)})"

--- a/src/surrealdb/types.py
+++ b/src/surrealdb/types.py
@@ -26,6 +26,7 @@ from surrealdb.data.types.geometry import (
 from surrealdb.data.types.null import NullType
 from surrealdb.data.types.range import Range
 from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.table import Table
 
 # Define recursive Value type that represents all possible SurrealDB values
@@ -53,6 +54,16 @@ Value = (
     | GeometryMultiLine
     | GeometryMultiPolygon
     | GeometryCollection
+    # A SurrealDB set. A `list` subclass, so `list["Value"]` below already
+    # covers it structurally - named explicitly so the distinct type is
+    # visible in the public union rather than hidden inside it.
+    | SurrealSet
+    # A Python set is accepted on the way *in* and encoded under the set tag;
+    # it has been since sets were supported, but the union never said so, so
+    # passing one failed a type check on perfectly valid code. `Any` members
+    # rather than "Value" because a set can only hold the hashable ones.
+    | set[Any]
+    | frozenset[Any]
     | dict[str, "Value"]
     | list["Value"]
 )

--- a/tests/unit_tests/connections/test_duration_and_range_wire.py
+++ b/tests/unit_tests/connections/test_duration_and_range_wire.py
@@ -24,8 +24,36 @@ from surrealdb.data.types.null import Null
 from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
 from surrealdb.errors import InvalidDurationError
 
-DURATIONS = ["1s", "0s", "1ns", "1us", "1µs", "500ms", "1h30m", "1s500ms", "1y"]
-NOT_DURATIONS = ["1.5s", "-1s", "1e3s", "0.5h", "1x", "1"]
+DURATIONS = [
+    "1s",
+    "0s",
+    "1ns",
+    "1us",
+    "1µs",
+    "500ms",
+    "1h30m",
+    "1s500ms",
+    "1y",
+    # Surrounding whitespace: the server takes it, so the SDK must too.
+    " 1s",
+    "1s ",
+    "1s\n",
+    "1s\t",
+]
+NOT_DURATIONS = [
+    "1.5s",
+    "-1s",
+    "1e3s",
+    "0.5h",
+    "1x",
+    "1",
+    # Units are case-sensitive on the server.
+    "1S",
+    "1MS",
+    "1NS",
+    "1H30M",
+    "1 s",
+]
 
 
 @pytest.mark.parametrize("text", DURATIONS)

--- a/tests/unit_tests/connections/test_set_round_trip.py
+++ b/tests/unit_tests/connections/test_set_round_trip.py
@@ -1,0 +1,206 @@
+"""A record with a set field survives being read and written back.
+
+SurrealDB's ``set<T>`` is a deduplicated sequence that holds any value. Neither
+builtin models it, and each wrong choice broke something different:
+
+* decoding into a Python ``set`` raised ``unhashable type: 'dict'`` on a
+  ``set<object>`` column, which killed the whole response - the record could not
+  be read at all;
+* decoding into a plain ``list`` made it readable but lost the type. A list goes
+  back out as a CBOR array, so reading a record and writing it back either
+  failed outright on a schemafull field::
+
+      InternalError: Couldn't coerce value for field `nums`:
+                     Expected `set` but found `[1, 2]`
+
+  or, on a schemaless one, silently turned the field into an array and took its
+  deduplication with it.
+
+:class:`~surrealdb.data.types.set.SurrealSet` is a ``list`` subclass that
+encodes back under the set tag, so both hold.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data import cbor
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.set import SurrealSet
+
+
+def _fresh(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def _supports_cbor_sets(version: str) -> bool:
+    """Whether this server has a CBOR set representation at all.
+
+    SurrealDB 2.x has none: it returns a SurrealQL set as a plain array and
+    answers anything carrying the set tag with "unknown CBOR tag". That is
+    documented in the README's 2.x compatibility section, so there is nothing
+    for these tests to assert there.
+    """
+    text = (version or "").strip().lower()
+    for prefix in ("surrealdb-", "v"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    try:
+        return int(text.split(".")[0]) >= 3
+    except (ValueError, IndexError):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _needs_cbor_sets(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
+    if not _supports_cbor_sets(blocking_ws_connection.version()):
+        pytest.skip("SurrealDB 2.x has no CBOR set representation")
+
+
+# ------------------------------------------------------------ the round trip
+
+
+def test_a_schemafull_set_field_can_be_written_back(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _fresh("sf")
+    blocking_ws_connection.query(
+        f"DEFINE TABLE {table} SCHEMAFULL; DEFINE FIELD nums ON {table} TYPE set<int>;"
+    ).execute()
+    blocking_ws_connection.query(f"CREATE {table}:1 SET nums = <set>[1,2]").execute()
+
+    row = blocking_ws_connection.select(RecordID(table, 1))
+    assert isinstance(row["nums"], SurrealSet)
+
+    # The whole point: this used to raise a coercion error.
+    blocking_ws_connection.update(RecordID(table, 1), row)
+
+    after = blocking_ws_connection.select(RecordID(table, 1))
+    assert after["nums"] == [1, 2]
+
+
+def test_a_schemaless_set_field_stays_a_set(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The silent half: no error, the field just stopped being a set."""
+    table = _fresh("sl")
+    blocking_ws_connection.query(
+        f"CREATE {table}:1 SET tags = <set>['a','b']"
+    ).execute()
+
+    blocking_ws_connection.update(
+        RecordID(table, 1), blocking_ws_connection.select(RecordID(table, 1))
+    )
+
+    # Asked of the server, not of the decoded value: what matters is the type
+    # the field now has in the database.
+    blocking_ws_connection.query(f"UPDATE {table}:1 SET tags += 'a'").execute()
+    stored = blocking_ws_connection.query(f"RETURN {table}:1.tags").first()
+    assert isinstance(stored, list)
+    assert sorted(stored) == ["a", "b"], (
+        "the field lost its set semantics: a duplicate was accepted"
+    )
+
+
+async def test_async_set_round_trip(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    table = _fresh("as")
+    await async_ws_connection.query(
+        f"DEFINE TABLE {table} SCHEMAFULL; DEFINE FIELD nums ON {table} TYPE set<int>;"
+    ).execute()
+    await async_ws_connection.query(f"CREATE {table}:1 SET nums = <set>[1,2]").execute()
+
+    row = await async_ws_connection.select(RecordID(table, 1))
+    await async_ws_connection.update(RecordID(table, 1), row)
+
+    after = await async_ws_connection.select(RecordID(table, 1))
+    assert after["nums"] == [1, 2]
+
+
+# ------------------------------------------------- what a set decodes to now
+
+
+def test_a_set_of_objects_is_readable(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The original defect: a Python ``set`` cannot hold these at all."""
+    assert blocking_ws_connection.query("RETURN <set>[{a:1},{a:2}];").first() == [
+        {"a": 1},
+        {"a": 2},
+    ]
+    assert blocking_ws_connection.query("RETURN <set>[[1,2]];").first() == [[1, 2]]
+
+
+def test_a_set_reads_as_a_sequence(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """``SurrealSet`` is a ``list``, so it indexes and compares like one.
+
+    The order is the server's, not the order written: SurrealDB normalises a
+    set, so ``<set>[3,1,2]`` comes back ``[1,2,3]``. The SDK preserves whatever
+    it receives rather than imposing an order of its own.
+    """
+    value = blocking_ws_connection.query("RETURN <set>[3,1,2];").first()
+
+    assert isinstance(value, SurrealSet)
+    assert isinstance(value, list)
+    assert value == [1, 2, 3]
+    assert value[0] == 1
+    assert len(value) == 3
+
+
+def test_writing_a_python_set_still_works(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The path that always worked, unchanged."""
+    table = _fresh("ps")
+    created = blocking_ws_connection.create(RecordID(table, "a"), {"tags": {"x", "y"}})
+
+    tags = created["tags"]
+    assert isinstance(tags, list)
+    assert sorted(tags) == ["x", "y"]
+    blocking_ws_connection.query(f"UPDATE {table}:a SET tags += 'x'").execute()
+    after = blocking_ws_connection.query(f"RETURN {table}:a.tags").first()
+    assert isinstance(after, list)
+    assert sorted(after) == ["x", "y"]
+
+
+# --------------------------------------------------------- encoding, offline
+
+
+def test_a_surreal_set_encodes_under_the_set_tag() -> None:
+    """Tag 56, not a plain array - a `list` subclass would otherwise match
+    `list`'s encoder through the generic subclass lookup."""
+    assert cbor.encode(SurrealSet([1, 2]))[:2] == b"\xd8\x38"
+    assert cbor.encode({1, 2})[:2] == b"\xd8\x38"
+    assert cbor.encode([1, 2])[:2] != b"\xd8\x38"
+
+
+def test_a_surreal_set_round_trips_offline() -> None:
+    decoded = cbor.decode(cbor.encode(SurrealSet([{"k": "a"}, [1, 2]])))
+
+    assert isinstance(decoded, SurrealSet)
+    assert decoded == [{"k": "a"}, [1, 2]]
+    # And re-encoding is stable, so a value can be written back repeatedly.
+    assert cbor.encode(decoded) == cbor.encode(SurrealSet([{"k": "a"}, [1, 2]]))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"a": SurrealSet([1])}, id="in-an-object"),
+        pytest.param([SurrealSet([1])], id="in-an-array"),
+        pytest.param({"a": {"b": SurrealSet([1])}}, id="nested"),
+    ],
+)
+def test_a_set_keeps_its_type_in_any_position(payload: Any) -> None:
+    decoded = cbor.decode(cbor.encode(payload))
+
+    found = decoded["a"] if isinstance(decoded, dict) else decoded[0]
+    if isinstance(found, dict):
+        found = found["b"]
+    assert isinstance(found, SurrealSet)

--- a/tests/unit_tests/connections/test_transport_agreement.py
+++ b/tests/unit_tests/connections/test_transport_agreement.py
@@ -178,20 +178,75 @@ def test_a_version_cannot_be_combined_with_bindings_over_http(
     [
         "fn::x(); DROP TABLE users; --",
         "fn::x) OR true --",
-        "",
         "1fn::x",
         "fn::x y",
         "⟨injected⟩",
     ],
 )
-def test_a_function_name_that_is_not_an_identifier_is_refused(name: str) -> None:
+def test_a_hostile_function_name_is_quoted_not_executed(name: str) -> None:
     """The name is the one part that cannot be parameter-bound.
 
-    Everything else in the generated query is a bound parameter, so this is the
-    only inlining the SDK does here and it is anchored to a plain identifier.
+    It is rendered as a *quoted identifier* rather than refused, because
+    SurrealDB accepts backtick-quoted identifiers in a function name and
+    refusing them broke legal calls (``fn::`my-fn```). What matters is that
+    nothing in the name can escape the quoting and become SurrealQL: the
+    rendered call is one identifier and one pair of parentheses, whatever the
+    name contained.
     """
-    with pytest.raises(ValueError, match="function name"):
+    query, arguments = build_run_query(name, None)
+
+    assert arguments == {}
+    # Everything after `RETURN ` up to `()` is the rendered name, and every
+    # segment of it is either a plain identifier or backtick-quoted.
+    rendered = query.removeprefix("RETURN ").removesuffix("();")
+    for segment in rendered.split("::"):
+        plain = segment.replace("_", "a").isalnum() and not segment[0].isdigit()
+        assert plain or (segment.startswith("`") and segment.endswith("`")), (
+            f"segment {segment!r} is neither a plain identifier nor quoted"
+        )
+    # A quoted segment contains no backtick of its own, so it cannot end early.
+    assert rendered.count("`") % 2 == 0
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("fn::", id="empty-segment"),
+        pytest.param("fn::x`; DROP", id="contains-backtick"),
+        pytest.param("fn::x\nDROP", id="contains-newline"),
+    ],
+)
+def test_a_function_name_that_cannot_be_quoted_is_refused(name: str) -> None:
+    """A backtick or newline would end the quoting, so those are refused."""
+    with pytest.raises(ValueError):
         build_run_query(name, None)
+
+
+def test_a_legal_quoted_function_name_is_accepted() -> None:
+    """``fn::`my-fn``` is definable and callable, so ``run()`` must allow it.
+
+    Rejecting it meant an unrelated ``let()`` elsewhere in the program broke a
+    ``run()`` call that had always worked, because only the bindings path
+    validated the name.
+    """
+    query, _ = build_run_query("fn::my-fn", None)
+
+    assert query == "RETURN fn::`my-fn`();"
+
+
+@pytest.mark.parametrize(
+    "args", [pytest.param("xy", id="str"), pytest.param({"a": 1}, id="dict")]
+)
+def test_run_args_must_be_a_sequence(args: object) -> None:
+    """``enumerate`` accepts any iterable, which silently spread a string.
+
+    ``run("fn::f", "ab")`` called ``f("a", "b")`` - two arguments from one
+    value. The server rejects a non-array ``args`` too, so this refuses the
+    same input, earlier and by name.
+    """
+    with pytest.raises(TypeError, match="list or tuple"):
+        build_run_query("fn::f", args)  # type: ignore[arg-type]
 
 
 def test_the_generated_query_binds_every_argument() -> None:

--- a/tests/unit_tests/data_types/test_duration_parsing.py
+++ b/tests/unit_tests/data_types/test_duration_parsing.py
@@ -37,16 +37,28 @@ REJECTED = [
     pytest.param("1E3s", id="exponent-upper"),
     pytest.param("abc", id="not-a-duration"),
     pytest.param("", id="empty"),
-    pytest.param("1s ", id="trailing-space"),
-    pytest.param(" 1s", id="leading-space"),
     pytest.param("1s;DROP", id="trailing-junk"),
     pytest.param("about 1s please", id="prose"),
     pytest.param("1", id="no-unit"),
     pytest.param("s", id="no-number"),
     pytest.param("1x", id="unknown-unit"),
+    # SurrealDB units are lower-case; `.lower()`-ing the input silently turned
+    # each of these into a duration the server would have refused.
+    pytest.param("1S", id="uppercase-seconds"),
+    pytest.param("1MS", id="uppercase-millis"),
+    pytest.param("1NS", id="uppercase-nanos"),
+    pytest.param("1H30M", id="uppercase-compound"),
+    pytest.param("1 s", id="space-before-unit"),
 ]
 
+# The server accepts surrounding whitespace (`<duration>' 1s '` parses), so the
+# SDK does too - these were previously asserted as rejected on nothing more than
+# a guess about what the server would do.
 ACCEPTED = [
+    pytest.param(" 1s", 1_000_000_000, id="leading-space"),
+    pytest.param("1s ", 1_000_000_000, id="trailing-space"),
+    pytest.param("1s\n", 1_000_000_000, id="trailing-newline"),
+    pytest.param("1s\t", 1_000_000_000, id="trailing-tab"),
     pytest.param("1s", 1_000_000_000, id="seconds"),
     pytest.param("0s", 0, id="zero"),
     pytest.param("1ns", 1, id="nanoseconds"),
@@ -82,3 +94,58 @@ def test_the_nanoseconds_argument_still_adds() -> None:
     """Unchanged behaviour: the offset is added to the parsed value."""
     assert Duration.parse("1s", nanoseconds=7).elapsed == 1_000_000_007
     assert Duration.parse(2, nanoseconds=7).elapsed == 2_000_000_007
+
+
+@pytest.mark.parametrize(
+    ("elapsed", "expected"),
+    [
+        pytest.param(0, (0, 0), id="zero"),
+        pytest.param(1, (0, 1), id="one-nanosecond"),
+        pytest.param(1_000_000_000, (1, 0), id="one-second"),
+        pytest.param(1_500_000_000, (1, 500_000_000), id="one-and-a-half"),
+        # The remainder is one nanosecond short of a full second, and the
+        # quotient is large enough that float division rounds it up: this used
+        # to split into (31536001, -1). The encoder sent that pair verbatim and
+        # the server rejected the frame, so a duration the SDK parses happily
+        # could be read from the database but never written back.
+        pytest.param(
+            31_536_000_999_999_999, (31_536_000, 999_999_999), id="1y-minus-1ns"
+        ),
+        pytest.param(
+            999_999_999_999_999_999, (999_999_999, 999_999_999), id="very-large"
+        ),
+    ],
+)
+def test_the_wire_split_is_exact(elapsed: int, expected: tuple[int, int]) -> None:
+    """``[seconds, nanoseconds]`` must be integer-exact at any magnitude.
+
+    Nanoseconds can never be negative: the server rejects such a pair outright.
+    """
+    seconds, nanoseconds = Duration(elapsed).get_seconds_and_nano()
+
+    assert (seconds, nanoseconds) == expected
+    assert nanoseconds >= 0, "a negative nanosecond component is unsendable"
+    assert seconds * 1_000_000_000 + nanoseconds == elapsed
+
+
+def test_a_large_duration_survives_a_round_trip() -> None:
+    """Decode -> encode -> decode, at a magnitude where the split used to break."""
+    from surrealdb.data import cbor
+
+    original = Duration(31_536_000_999_999_999)
+    assert cbor.decode(cbor.encode(original)) == original
+
+
+@pytest.mark.parametrize(
+    ("elapsed", "rendered"),
+    [
+        pytest.param(0, "0ns", id="zero"),
+        pytest.param(1_000_000_000, "1s", id="one-second"),
+        pytest.param(5_400_000_000_000, "1h30m", id="compound"),
+        # `divmod` floors, so a negative used to render as a value close to a
+        # full year rather than as the nanosecond before zero.
+        pytest.param(-1, "-1ns", id="negative"),
+    ],
+)
+def test_rendering(elapsed: int, rendered: str) -> None:
+    assert str(Duration(elapsed)) == rendered

--- a/tests/unit_tests/test_live_queue_release.py
+++ b/tests/unit_tests/test_live_queue_release.py
@@ -1,0 +1,154 @@
+"""A subscription that is never iterated releases its queue.
+
+``subscribe_live`` registers the consumer's queue eagerly, before anything is
+iterated - it has to, because a notification arriving between ``live()`` and the
+first ``next()`` would otherwise find no queue and be dropped.
+
+Deregistration lived in the generator's ``finally``, which a generator that was
+never started does not run, on ``close()`` or on garbage collection. So a
+subscription set up and then abandoned - on an early error, behind a conditional
+consumer, in a retry loop that re-subscribes - stayed registered for the life of
+the connection, and every notification for that live id kept being routed into a
+queue nobody would ever drain.
+
+Server-free: registration and release are bookkeeping on the connection object,
+and the generator is deliberately never started, so no socket is ever opened.
+"""
+
+import asyncio
+import gc
+import uuid
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+WS_URL = "ws://localhost:8000"
+LIVE_ID = str(uuid.UUID(int=1))
+
+
+def test_blocking_registers_before_anything_is_iterated() -> None:
+    """The property the eager registration exists for."""
+    connection = BlockingWsSurrealConnection(WS_URL)
+
+    subscription = connection.subscribe_live(LIVE_ID)
+
+    assert len(connection.live_queues[LIVE_ID]) == 1, (
+        "the queue is registered only once the consumer iterates, so a "
+        "notification arriving before that is dropped"
+    )
+    subscription.close()
+
+
+def test_blocking_releases_a_subscription_that_was_never_iterated() -> None:
+    connection = BlockingWsSurrealConnection(WS_URL)
+    subscription = connection.subscribe_live(LIVE_ID)
+    assert len(connection.live_queues[LIVE_ID]) == 1
+
+    del subscription
+    gc.collect()
+
+    assert not connection.live_queues.get(LIVE_ID), (
+        "the queue outlived the subscription; notifications will accumulate in "
+        "it for the life of the connection"
+    )
+
+
+def test_blocking_releases_on_close_without_iterating() -> None:
+    """``close()`` on a never-started generator also has to release."""
+    connection = BlockingWsSurrealConnection(WS_URL)
+    subscription = connection.subscribe_live(LIVE_ID)
+
+    subscription.close()
+    del subscription
+    gc.collect()
+
+    assert not connection.live_queues.get(LIVE_ID)
+
+
+def test_blocking_releases_only_its_own_queue() -> None:
+    """Two subscribers on one query: dropping one must not unregister the other."""
+    connection = BlockingWsSurrealConnection(WS_URL)
+    first = connection.subscribe_live(LIVE_ID)
+    second = connection.subscribe_live(LIVE_ID)
+    assert len(connection.live_queues[LIVE_ID]) == 2
+
+    del first
+    gc.collect()
+
+    assert len(connection.live_queues[LIVE_ID]) == 1
+    second.close()
+
+
+def test_the_finalizer_adds_no_reference_of_its_own() -> None:
+    """Dropping both the subscription and the connection collects both.
+
+    The generator itself holds the connection - it comes from a bound method,
+    and it needs the connection to read from - so a live subscription keeping
+    one alive is correct. What must not happen is the *finalizer* adding a
+    reference beyond that, which a bound-method callback would: the connection
+    would then outlive both, kept alive by its own cleanup.
+    """
+    import weakref
+
+    connection = BlockingWsSurrealConnection(WS_URL)
+    subscription = connection.subscribe_live(LIVE_ID)
+    ref = weakref.ref(connection)
+
+    del subscription
+    del connection
+    gc.collect()
+
+    assert ref() is None, "the connection outlived both references to it"
+
+
+async def test_async_releases_a_subscription_that_was_never_iterated() -> None:
+    connection = AsyncWsSurrealConnection(WS_URL)
+    subscription = await connection.subscribe_live(LIVE_ID)
+    assert len(connection.live_queues[LIVE_ID]) == 1
+
+    del subscription
+    gc.collect()
+    # An un-started async generator schedules its close on the loop.
+    await asyncio.sleep(0)
+    gc.collect()
+
+    assert not connection.live_queues.get(LIVE_ID)
+
+
+async def test_async_registers_before_anything_is_iterated() -> None:
+    connection = AsyncWsSurrealConnection(WS_URL)
+
+    subscription = await connection.subscribe_live(LIVE_ID)
+
+    assert len(connection.live_queues[LIVE_ID]) == 1
+    await subscription.aclose()
+
+
+def test_kill_wakes_its_own_subscribers_locally() -> None:
+    """``kill()`` ends the caller's own subscription without the server's help.
+
+    3.x announces a kill with a ``KILLED`` notification, so waiting for the
+    server worked there. 2.x sends nothing at all, and the caller's own
+    subscription - on the very query it had just killed itself - blocked
+    forever. The sentinel is pushed locally so this holds on every version,
+    which is what the async transport has always done.
+
+    Asserted on the queue rather than through a server, so it is the local
+    mechanism being tested and not 3.x's notification masking its absence.
+    """
+    from surrealdb.connections import blocking_ws
+
+    connection = BlockingWsSurrealConnection(WS_URL)
+    # Held deliberately: dropping it would release the queue, which is what the
+    # tests above are for.
+    subscription = connection.subscribe_live(LIVE_ID)
+    queue = connection.live_queues[LIVE_ID][0]
+    assert queue.empty()
+
+    # `kill()` sends an RPC; stub it out so no socket is needed.
+    connection._send = lambda *args, **kwargs: {"result": None}  # type: ignore[method-assign]
+    connection.kill(LIVE_ID)
+
+    assert not queue.empty(), "kill() left its own subscriber waiting"
+    assert queue.get_nowait()["action"] == blocking_ws._LIVE_KILLED
+    subscription.close()

--- a/tests/unit_tests/test_uncorrelated_errors.py
+++ b/tests/unit_tests/test_uncorrelated_errors.py
@@ -1,0 +1,151 @@
+"""A protocol error the server could not correlate reaches only its own request.
+
+When SurrealDB cannot parse a frame it answers with an error carrying no ``id``,
+because it never read one. Exactly one request is affected - the one whose frame
+was rejected, which is the one that will never be answered - and the SDK cannot
+tell from the wire which it is.
+
+Failing every pending future turned one bad request into N failures. Holding the
+error until *whoever times out next* collects it fixed that and introduced a
+subtler version of the same bug: a caller that abandons its request before the
+deadline (an application-level timeout, a cancelled task) never collects the
+error, so it sat there and was handed to an unrelated request minutes later,
+telling a perfectly valid query it had a parse error.
+
+The error is now bound to the request ids that were in flight when it arrived.
+Anything started afterwards has its own reply coming and can never be the one
+the server rejected.
+
+Server-free: this is about which pending request the error is routed to, so it
+is exercised through the routing helpers directly rather than by waiting out a
+30-second RPC deadline.
+"""
+
+import asyncio
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.errors import SurrealError, ValidationError
+
+WS_URL = "ws://localhost:8000"
+
+
+def _connection() -> AsyncWsSurrealConnection:
+    """A connection object with no socket - nothing here touches the network."""
+    return AsyncWsSurrealConnection(WS_URL)
+
+
+def _pending(connection: AsyncWsSurrealConnection, *query_ids: str) -> None:
+    """Register *query_ids* as in flight, as ``_send`` does."""
+    loop = asyncio.get_running_loop()
+    for query_id in query_ids:
+        connection.qry[query_id] = loop.create_future()
+
+
+async def test_a_single_in_flight_request_is_failed_immediately() -> None:
+    """With one candidate there is no ambiguity, so it need not wait."""
+    connection = _connection()
+    _pending(connection, "only")
+    error = ValidationError(kind="Validation", message="Parse error")
+
+    connection._deliver_uncorrelated(error)
+
+    assert connection.qry.get("only") is None, "the request was not resolved"
+    assert connection._uncorrelated_error is None, "nothing should be held"
+
+
+async def test_the_error_is_held_when_several_are_in_flight() -> None:
+    connection = _connection()
+    _pending(connection, "a", "b", "c")
+    error = ValidationError(kind="Validation", message="Parse error")
+
+    connection._deliver_uncorrelated(error)
+
+    # No future is resolved: the other two still have their own replies coming.
+    assert all(not fut.done() for fut in connection.qry.values())
+    assert connection._uncorrelated_error is error
+    assert connection._uncorrelated_for == {"a", "b", "c"}
+
+
+async def test_only_a_request_that_was_in_flight_can_collect_it() -> None:
+    """The defect: a later, unrelated request used to be handed this error."""
+    connection = _connection()
+    _pending(connection, "a", "b")
+    error = ValidationError(kind="Validation", message="Parse error")
+    connection._deliver_uncorrelated(error)
+
+    assert connection._take_uncorrelated("later") is None, (
+        "a request started after the failure collected an error that cannot "
+        "possibly be about it"
+    )
+    # And it is still there for one that could be responsible.
+    assert connection._take_uncorrelated("a") is error
+
+
+async def test_collecting_it_once_consumes_it() -> None:
+    connection = _connection()
+    _pending(connection, "a", "b")
+    error = ValidationError(kind="Validation", message="Parse error")
+    connection._deliver_uncorrelated(error)
+
+    assert connection._take_uncorrelated("a") is error
+    assert connection._take_uncorrelated("b") is None, "delivered twice"
+
+
+async def test_an_abandoned_candidate_set_drops_the_error() -> None:
+    """Nobody left to blame means the error must not outlive them.
+
+    This is exactly the leak: both candidates gave up before their deadline, so
+    without pruning the error waited for an unrelated request much later.
+    """
+    connection = _connection()
+    _pending(connection, "a", "b")
+    connection._deliver_uncorrelated(
+        ValidationError(kind="Validation", message="Parse error")
+    )
+
+    # Both callers abandon their requests, as `_send`'s finally does.
+    connection.qry.pop("a")
+    connection._prune_uncorrelated()
+    assert connection._uncorrelated_error is not None, "one candidate remains"
+
+    connection.qry.pop("b")
+    connection._prune_uncorrelated()
+
+    assert connection._uncorrelated_error is None
+    assert connection._uncorrelated_for == set()
+    assert connection._take_uncorrelated("anything") is None
+
+
+async def test_a_surviving_candidate_keeps_the_error() -> None:
+    """Pruning must not throw the error away while it can still be delivered."""
+    connection = _connection()
+    _pending(connection, "a", "b")
+    error = ValidationError(kind="Validation", message="Parse error")
+    connection._deliver_uncorrelated(error)
+
+    connection.qry.pop("a")
+    connection._prune_uncorrelated()
+
+    assert connection._take_uncorrelated("b") is error
+
+
+async def test_closing_forgets_a_held_error() -> None:
+    """A new socket is a new conversation; nothing carries over."""
+    connection = _connection()
+    _pending(connection, "a", "b")
+    connection._deliver_uncorrelated(
+        ValidationError(kind="Validation", message="Parse error")
+    )
+
+    await connection.close()
+
+    assert connection._uncorrelated_error is None
+    assert connection._uncorrelated_for == set()
+
+
+@pytest.mark.parametrize("error", [ValidationError(kind="Validation", message="x")])
+def test_the_held_error_is_a_surreal_error(error: SurrealError) -> None:
+    """Whatever is delivered stays inside the documented exception tree."""
+    assert isinstance(error, SurrealError)


### PR DESCRIPTION
A re-run of the pre-publication gate against the merged beta found 25 defects, **twelve of them introduced by the nine PRs that had just landed**. This is those twelve.

## §1 Sets lost their type on the way back

The worst of them, and the same defect class the change that caused it was fixing.

Decoding a set to a plain `list` made `set<object>` readable, but a list encodes as a CBOR array — so reading a record and writing it back either failed outright:

```
InternalError: Couldn't coerce value for field `nums`: Expected `set` but found `[1, 2]`
```

or, on a schemaless table, silently changed the field's type:

```
stored before: {'a', 'b'}
stored after : ['a', 'b']       ← after a read-modify-write
after += 'a' : ['a', 'b', 'a']  ← deduplication gone
```

Neither builtin models a SurrealDB set: a Python `set` cannot hold the objects a `set<object>` column contains, and a `list` is a different type to the server. `SurrealSet` is a `list` subclass — it indexes and compares like the sequence it is — that encodes back under the set tag, so both properties hold.

It is registered for its **exact type** in the encoder: the generic subclass lookup resolves through `issubclass`, so it would otherwise find `list`'s encoder and emit the array this type exists to prevent.

`Value` now also admits a plain Python `set`, which the SDK has always encoded but the union never named — passing one failed a downstream type check on perfectly valid code.

## §2 A held protocol error ambushed an unrelated request

Holding an uncorrelatable error until the doomed request's deadline assumed that request would reach it. A caller that abandons its own request never does:

```
phase1: abandoned the malformed query
phase2: ValidationError: Parse error   ← a valid query, told it had a parse error
```

The error is now bound to the request ids that were in flight when it arrived — anything started later has its own reply coming — and dropped once none of them is pending. `close()` clears it unconditionally rather than only when a socket existed.

## §3 `subscribe_live` leaked the queue it registered eagerly

Registration moved out of the generator so a notification arriving before the first `next()` is not lost, but deregistration stayed in the generator's `finally`, which a generator that is never started never runs:

```
after subscribe_live(): 1
after del + gc        : 1     (expected 0)
orphan queue depth    : 49    after 50 writes
```

A finalizer now releases it, closing over `live_queues` rather than `self` so it adds no reference of its own.

## §4 Duration

Four separate defects: the anchor used `$`, which matches before a trailing newline, so `"1s\n"` was accepted while `"1s "` was not; the input was lowercased, so `1S` / `1MS` / `1H30M` — all rejected by the server — silently became durations; `get_seconds_and_nano` used float division, so a large value with a near-full-second remainder split into `(31536001, -1)`, a negative nanosecond component the server refuses, making an ordinary read-modify-write of such a value impossible; and `str()` on a negative rendered almost a year.

The accepted and rejected sets are asserted **against a live server**, including the whitespace and case cases — which were previously asserted on a guess about what the server would do, and were wrong.

## §5 `run()`

A legal backtick-quoted function name (`` fn::`my-fn` ``, which the RPC path executes happily) was refused the moment any `let()` binding existed, so an unrelated `let()` elsewhere broke a call that had always worked. Names are now quoted rather than rejected; only a segment containing a backtick or newline — which would end the quoting — is refused.

And `args` was splatted by `enumerate`, so `run("fn::f", "ab")` called `f("a", "b")`.

## §6 Blocking `kill()`

It relied on the server's `KILLED` notification, which 2.x never sends, so the caller's own subscription blocked forever on the query it had just killed — contradicting what the README promised. It now wakes its own subscribers locally, as the async transport always has.

## Verification

**2.0.5 / 2.3.10 / 3.2.3: 1248 / 1248 / 1286 passing.** Clean `ruff`, `mypy` (src and tests), `pyright` at the existing baseline.

Six mutations are each caught. **Two survived the first attempt** — which is how the held-error and queue-release fixes turned out to have no tests at all, having only been checked by hand. Writing those tests then found two further gaps: `close()` skipped its cleanup when there was no socket, and my first reference test asserted something false (a live subscription legitimately keeps its connection alive — what must not happen is the *finalizer* adding a reference of its own).

Set tests are version-gated: 2.x has no CBOR set representation, which the README already documents.