### PR TITLE
Fix the nine findings the pre-publication gate left open

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ row = await db.select(RecordID("person", "tobie"))  # dict | None
 rows = await db.select(Table("person"))             # list
 ```
 
+#### Record ranges
+
+A `RecordID` whose id is a `Range` targets every record in that range, and every
+CRUD method returns all of them — the same as the equivalent `"person:1..=3"`
+string:
+
+```python
+from surrealdb import RecordID, Range, BoundIncluded, BoundExcluded
+
+first_three = RecordID("person", Range(BoundIncluded(1), BoundIncluded(3)))
+await db.select(first_three)            # every record in person:1..=3
+await db.delete(first_three)            # deletes them all, returns them all
+await db.select("person:1..=3")         # the same target, spelled as a string
+```
+
+Use `BoundExcluded` for `..` rather than `..=`, and `None` for an open end
+(`Range(BoundIncluded(1), None)` is `person:1..`).
+
+Two caveats. A range needs a table, so a bare `Range` is not a resource target —
+`db.select(Range(...))` raises `SurrealError`; wrap it in a `RecordID`. And the
+`@overload`s above resolve on the *static* type `RecordID`, which says nothing
+about the id, so a type checker still reads `select(first_three)` as
+`dict | None` while it returns a list at runtime. Cast, or use the string form,
+if you need the narrower type.
+
 ### Mapping rows to a model (`into=`)
 
 Pass the keyword-only `into=` argument to map each returned record onto a model
@@ -213,7 +238,7 @@ people = await db.select(Table("person"), into=Person)              # list[Perso
 
 # create / update / upsert / delete map the written record(s) too
 created = await db.create(RecordID("person", "tobie"), {"name": "Tobie"}, into=Person)
-updated = await db.update(Table("person"), {"active": True}, into=Person)  # list[Person]
+updated = await db.update(Table("person"), {"name": "Updated"}, into=Person)  # list[Person]
 
 # insert maps the inserted records
 inserted = await db.insert(Table("person"), [{"name": "A"}], into=Person)  # list[Person]
@@ -235,6 +260,21 @@ rows = db.query("SELECT * FROM person").into(Person, rows=True)  # list[Person]
 
 Omitting `into=` leaves the raw `dict` / `list[Value]` results completely
 unchanged.
+
+The model has to accept every field of the records it is given. `update(record,
+data)` writes `data` as the record's whole content, so the example above leaves
+each `person` with just `id` and `name` — write a field `Person` does not
+declare and the mapping fails with an `UnexpectedResponseError` naming both
+sides:
+
+```
+into=Person could not be built from this record: Person.__init__() got an
+unexpected keyword argument 'active'. The record has ['active', 'id']; Person
+accepts ['id', 'name'].
+```
+
+Give the extra fields defaults, add them to the model, or `SELECT` only the
+columns it declares.
 
 Sync usage is **eager** - there is no `await` to defer to, so the
 connection methods run single-shot operations immediately and return the
@@ -264,8 +304,14 @@ with Surreal("ws://localhost:8000/rpc") as db:
     db.delete(RecordID("person", "bob"))
 
     # query() returns a builder; call .execute()/.first()/.into().
-    db.query("DELETE temp_data;").execute()
+    db.query("DELETE person;").execute()
 ```
+
+On 3.x, `DELETE` names a table that has to exist: `db.query("DELETE
+temp_data;")` raises `NotFoundError: The table 'temp_data' does not exist`
+rather than deleting nothing. (2.x returns an empty result instead — see
+[Talking to a SurrealDB 2.x server](#talking-to-a-surrealdb-2x-server).) Use
+`REMOVE TABLE IF EXISTS temp_data;` when you cannot be sure.
 
 ### Thread safety
 
@@ -576,7 +622,7 @@ with Surreal("ws://localhost:8000/rpc") as db:
 
 ### Talking to a SurrealDB 2.x server
 
-Five things behave differently against SurrealDB 2.x, all because of what the
+Six things behave differently against SurrealDB 2.x, all because of what the
 2.x server does rather than anything the SDK chooses.
 
 **Error kinds need 3.x.** The subclasses below `ServerError` come from the
@@ -628,6 +674,16 @@ db.run("fn::readv")        # 42 on 3.x, None on 2.x
 
 Pass the value as an argument (`db.run("fn::add", [1, 2])`) if you target 2.x —
 arguments work on every version.
+
+**`DELETE` on a table that does not exist is an error only on 3.x.** 3.x raises
+`NotFoundError: The table 'temp_data' does not exist`; 2.x returns an empty
+result, as though it had deleted nothing:
+
+```python
+db.query("DELETE temp_data;").execute()   # [[]] on 2.x, NotFoundError on 3.x
+```
+
+`REMOVE TABLE IF EXISTS temp_data;` behaves the same on both.
 
 **A 2.x server does not tell subscribers that a live query was killed.** On 3.x
 the server sends a `KILLED` notification and `subscribe_live()` ends, whoever

--- a/embedded/src/surrealdb_ext/async_db.rs
+++ b/embedded/src/surrealdb_ext/async_db.rs
@@ -50,9 +50,24 @@ impl AsyncEmbeddedDB {
                 PyErr::new::<PyRuntimeError, _>(format!("Failed to create runtime: {e}"))
             })?;
         let kvs = runtime.block_on(async {
-            let ds = Datastore::new(&endpoint).await.map_err(|e| {
-                PyErr::new::<PyRuntimeError, _>(format!("Failed to create datastore: {e}"))
-            })?;
+            // `with_auth(true)` plus an owner session below, rather than the
+            // default `Datastore::new` (which leaves authentication disabled).
+            // With authentication off the engine skips every permission check
+            // for an anonymous session, and `invalidate()` - whose whole job is
+            // to drop the caller's identity - resets the session to exactly
+            // that. So invalidating *raised* privilege: a record user who could
+            // not read a `PERMISSIONS NONE` table, and could not run
+            // `INFO FOR ROOT`, could do both afterwards. Enabling
+            // authentication makes the post-invalidate session anonymous in the
+            // enforced sense, matching what the same call does over websocket
+            // and HTTP.
+            let ds = Datastore::builder()
+                .with_auth(true)
+                .build_with_path(&endpoint)
+                .await
+                .map_err(|e| {
+                    PyErr::new::<PyRuntimeError, _>(format!("Failed to create datastore: {e}"))
+                })?;
             ds.bootstrap().await.map_err(|e| {
                 PyErr::new::<PyRuntimeError, _>(format!("Failed to bootstrap datastore: {e}"))
             })?;
@@ -65,9 +80,15 @@ impl AsyncEmbeddedDB {
         // `Uuid`, so mint one here and route every unnamed request to it - that
         // keeps `use`/`signin` state on the connection, as it was when the map
         // was keyed by `Option<Uuid>` and this session lived under `None`.
+        //
+        // `Session::owner()`, not `Session::default()`: opening an embedded
+        // database and using it without signing in is the documented way to use
+        // it, and that has to keep working now that authentication is enforced.
+        // The identity is explicit rather than implied by a disabled check, so
+        // dropping it with `invalidate()` actually drops something.
         let session_id = Uuid::new_v4();
         let sessions: HashMap<Uuid, Arc<RwLock<Session>>> = HashMap::new();
-        let mut sess = Session::default().with_rt(false);
+        let mut sess = Session::owner().with_rt(false);
         sess.id = Some(session_id);
         sessions.insert(session_id, Arc::new(RwLock::new(sess)));
         Ok(AsyncEmbeddedDB {

--- a/embedded/src/surrealdb_ext/sync_db.rs
+++ b/embedded/src/surrealdb_ext/sync_db.rs
@@ -51,9 +51,24 @@ impl SyncEmbeddedDB {
                 PyErr::new::<PyRuntimeError, _>(format!("Failed to create runtime: {e}"))
             })?;
         let kvs = runtime.block_on(async {
-            let ds = Datastore::new(&endpoint).await.map_err(|e| {
-                PyErr::new::<PyRuntimeError, _>(format!("Failed to create datastore: {e}"))
-            })?;
+            // `with_auth(true)` plus an owner session below, rather than the
+            // default `Datastore::new` (which leaves authentication disabled).
+            // With authentication off the engine skips every permission check
+            // for an anonymous session, and `invalidate()` - whose whole job is
+            // to drop the caller's identity - resets the session to exactly
+            // that. So invalidating *raised* privilege: a record user who could
+            // not read a `PERMISSIONS NONE` table, and could not run
+            // `INFO FOR ROOT`, could do both afterwards. Enabling
+            // authentication makes the post-invalidate session anonymous in the
+            // enforced sense, matching what the same call does over websocket
+            // and HTTP.
+            let ds = Datastore::builder()
+                .with_auth(true)
+                .build_with_path(&endpoint)
+                .await
+                .map_err(|e| {
+                    PyErr::new::<PyRuntimeError, _>(format!("Failed to create datastore: {e}"))
+                })?;
             ds.bootstrap().await.map_err(|e| {
                 PyErr::new::<PyRuntimeError, _>(format!("Failed to bootstrap datastore: {e}"))
             })?;
@@ -66,9 +81,15 @@ impl SyncEmbeddedDB {
         // `Uuid`, so mint one here and route every unnamed request to it - that
         // keeps `use`/`signin` state on the connection, as it was when the map
         // was keyed by `Option<Uuid>` and this session lived under `None`.
+        //
+        // `Session::owner()`, not `Session::default()`: opening an embedded
+        // database and using it without signing in is the documented way to use
+        // it, and that has to keep working now that authentication is enforced.
+        // The identity is explicit rather than implied by a disabled check, so
+        // dropping it with `invalidate()` actually drops something.
         let session_id = Uuid::new_v4();
         let sessions: HashMap<Uuid, Arc<RwLock<Session>>> = HashMap::new();
-        let mut sess = Session::default().with_rt(false);
+        let mut sess = Session::owner().with_rt(false);
         sess.id = Some(session_id);
         sessions.insert(session_id, Arc::new(RwLock::new(sess)));
         Ok(SyncEmbeddedDB {

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -40,7 +40,7 @@ from surrealdb.data.types.datetime import Datetime, PreciseDatetime
 from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.null import Null, NullType
-from surrealdb.data.types.range import Range
+from surrealdb.data.types.range import Bound, BoundExcluded, BoundIncluded, Range
 from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.record_id import RecordID, escape_identifier
 from surrealdb.data.types.table import Table
@@ -118,7 +118,13 @@ __all__ = [
     "Table",
     "Duration",
     "Geometry",
+    # `Range` was exported without its bounds, so the one exported name could
+    # not actually be constructed from the public package - every range in user
+    # code had to reach into `surrealdb.data.types.range` for the other half.
     "Range",
+    "Bound",
+    "BoundIncluded",
+    "BoundExcluded",
     "RecordID",
     "Datetime",
     "PreciseDatetime",

--- a/src/surrealdb/connections/async_embedded.py
+++ b/src/surrealdb/connections/async_embedded.py
@@ -65,6 +65,8 @@ class AsyncEmbeddedSurrealConnection(AsyncWsSurrealConnection):
         # Embedded database handle
         with mapped_engine_errors("opening the database"):
             self._db: AsyncEmbeddedDB = AsyncEmbeddedDB(url)
+        # Whether `close()` has shut the engine down - see `connect`.
+        self._closed: bool = False
 
     async def __aenter__(self) -> AsyncEmbeddedSurrealConnection:
         """Context manager entry - connect to the embedded database."""
@@ -81,7 +83,21 @@ class AsyncEmbeddedSurrealConnection(AsyncWsSurrealConnection):
         await self.close()
 
     async def connect(self, url: str | None = None) -> None:
-        """Connects to the embedded database endpoint.
+        """Connect to the embedded database endpoint.
+
+        Idempotent while the engine is open, and it reopens one that
+        :meth:`close` shut down. ``close()`` shuts the datastore down for good -
+        the handle it leaves behind answers every request with "Database
+        connection is closed" - while ``connect()`` on the native side is a
+        no-op that reports success, so reconnecting *said* it had worked and
+        then failed on the next query. The websocket transports have always
+        reopened here; this makes the embedded engine agree.
+
+        A reopened ``memory://`` database starts empty, because the one that
+        was closed is gone. That mirrors a reconnected websocket getting a new,
+        unauthenticated server-side session: closing a connection ends what was
+        behind it. A file-backed engine (``file://``, ``surrealkv://``) reopens
+        its store and keeps its data.
 
         Args:
             url: Optional new URL to connect to.
@@ -94,6 +110,11 @@ class AsyncEmbeddedSurrealConnection(AsyncWsSurrealConnection):
             self.raw_url = url
             with mapped_engine_errors("opening the database"):
                 self._db = AsyncEmbeddedDB(url)
+            self._closed = False
+        elif self._closed:
+            with mapped_engine_errors("opening the database"):
+                self._db = AsyncEmbeddedDB(self.raw_url)
+            self._closed = False
 
         with mapped_engine_errors("connecting"):
             await self._db.connect()
@@ -101,11 +122,15 @@ class AsyncEmbeddedSurrealConnection(AsyncWsSurrealConnection):
     async def close(self) -> None:
         """Closes the connection to the database.
 
+        Idempotent, and leaves the connection reusable: :meth:`connect` opens a
+        fresh engine afterwards.
+
         Example:
             await db.close()
         """
         with mapped_engine_errors("closing"):
             await self._db.close()
+        self._closed = True
 
     async def _send(
         self, message: RequestMessage, process: str, bypass: bool = False

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -592,11 +592,17 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self._session = None
 
     async def __aenter__(self) -> "AsyncHttpSurrealConnection":
+        """Open the pooled HTTP session if there isn't one, and return ``self``.
+
+        Reuses an existing open session rather than assigning a fresh one. The
+        replaced ``ClientSession`` was never closed, so it leaked its connector
+        and sockets and emitted aiohttp's "Unclosed client session" warning -
+        and ``__aexit__`` closed only the replacement. This mirrors the
+        websocket transport, where re-entering also cost the server-side
+        session.
         """
-        Asynchronous context manager entry.
-        Initializes an aiohttp session and returns the connection instance.
-        """
-        self._session = aiohttp.ClientSession()
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
         return self
 
     async def __aexit__(

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -5,6 +5,7 @@ A basic async connection to a SurrealDB instance.
 import asyncio
 import logging
 import uuid
+import warnings
 import weakref
 from asyncio import AbstractEventLoop, Future, Queue, Task
 from collections.abc import AsyncGenerator
@@ -82,6 +83,108 @@ def _release_live_queue(
         queues.remove(result_queue)
     if not queues:
         live_queues.pop(suid, None)
+
+
+async def _read_frames(
+    ref: "weakref.ReferenceType[AsyncWsSurrealConnection]", socket: Any
+) -> None:
+    """Read frames off *socket* and route them to the connection behind *ref*.
+
+    A module-level function taking a weak reference, rather than a bound method
+    on the connection, so that the reader task does not keep the connection
+    alive. ``asyncio.create_task(self._recv_task())`` produced exactly that: the
+    running loop holds the task, the task holds its coroutine, and the coroutine
+    held ``self``. A connection whose last user reference was dropped was
+    therefore never collected - so no finaliser ran, and its socket, its file
+    descriptor and both worker tasks stayed for the life of the process. Fifty
+    connections built in a loop meant fifty live sockets.
+
+    The strong reference is taken per frame and dropped again immediately, so
+    between frames - which is where a suspended reader spends essentially all
+    of its time - nothing here refers to the connection.
+    """
+    try:
+        async for data in socket:
+            connection = ref()
+            if connection is None:
+                # Nobody is left to route to; stop reading rather than
+                # resurrect the connection for the length of a frame.
+                return
+            try:
+                connection._route_frame(data)  # pyright: ignore[reportPrivateUsage]
+            finally:
+                del connection
+    except (ConnectionClosed, WebSocketException, asyncio.CancelledError):
+        # Connection was closed or cancelled, this is expected
+        pass
+    except Exception as e:
+        logger.debug(f"Unexpected error in _read_frames: {e}")
+    finally:
+        connection = ref()
+        if connection is not None:
+            connection._reader_stopped()  # pyright: ignore[reportPrivateUsage]
+
+
+def _abandon_connection(
+    socket: Any, recv_task: "Task[None] | None", loop: AbstractEventLoop | None
+) -> None:
+    """Release a websocket nobody closed, without awaiting anything.
+
+    Deliberately not the graceful :meth:`AsyncWsSurrealConnection.close`, for
+    the same reason the blocking transport's ``__del__`` is not: a destructor
+    cannot await, and the loop that would run the closing handshake is often
+    already gone by the time the last reference is dropped (``asyncio.run``
+    closes its loop on the way out).
+
+    Two cases, because they need opposite treatment:
+
+    * the loop is still alive - schedule the cancel and the transport abort on
+      it, so the socket is torn down by the thread that owns it;
+    * the loop is closed - nothing can be scheduled, so close the underlying
+      socket object directly. That is what actually releases the file
+      descriptor, which is the resource that otherwise accumulates.
+    """
+    alive = loop if loop is not None and not loop.is_closed() else None
+
+    if recv_task is not None and not recv_task.done():
+        try:
+            if alive is not None:
+                alive.call_soon_threadsafe(recv_task.cancel)
+            else:
+                recv_task.cancel()
+        except RuntimeError:
+            pass
+
+    transport = getattr(socket, "transport", None)
+    if transport is None:
+        return
+    if alive is not None:
+        try:
+            alive.call_soon_threadsafe(transport.abort)
+            return
+        except RuntimeError:
+            pass
+    # The real socket, not the ``TransportSocket`` wrapper that
+    # `get_extra_info("socket")` returns: closing the wrapper works but is
+    # deprecated, and a destructor is the last place that should depend on a
+    # deprecated path still being there. Falls back to the wrapper if the
+    # private attribute ever goes, since a deprecated close beats a leaked
+    # descriptor.
+    raw = getattr(transport, "_sock", None)
+    if raw is None:
+        try:
+            raw = transport.get_extra_info("socket")
+        except Exception:
+            raw = None
+    if raw is not None:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                raw.close()
+        except Exception:
+            # Interpreter shutdown can pull what this needs out from under us,
+            # and an exception raised here is unraisable anyway.
+            pass
 
 
 class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
@@ -221,70 +324,61 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         if not self._uncorrelated_for:
             self._forget_uncorrelated()
 
-    async def _recv_task(self) -> None:
-        assert self.socket
+    def _route_frame(self, data: Any) -> None:
+        """Hand one received frame to whoever is waiting for it."""
+        # A single frame this loop cannot handle must not end it. When it did,
+        # the socket stayed open - so `connect()` saw a live socket and
+        # no-opped, and every later request registered a future that nothing
+        # would ever resolve. The caller then waited forever, with no timeout
+        # anywhere on this path.
         try:
-            async for data in self.socket:
-                # A single frame this loop cannot handle must not end it. When
-                # it did, the socket stayed open - so `connect()` saw a live
-                # socket and no-opped, and every later request registered a
-                # future that nothing would ever resolve. The caller then
-                # waited forever, with no timeout anywhere on this path.
-                try:
-                    response = decode(data)
-                except Exception as exc:
-                    self._fail_pending(
-                        UnexpectedResponseError(
-                            f"could not decode a websocket frame: {exc}"
-                        )
-                    )
-                    continue
-
-                try:
-                    if response_id := response.get("id"):
-                        if fut := self.qry.get(response_id):
-                            if not fut.done():
-                                fut.set_result(response)
-                    elif response_result := response.get("result"):
-                        live_id = str(response_result["id"])
-                        for queue in self.live_queues.get(live_id, []):
-                            queue.put_nowait(response_result)
-                    else:
-                        # An id-less frame carrying no result is a
-                        # protocol-level error the server could not correlate
-                        # to a request, so everyone in flight has to hear it.
-                        try:
-                            self.check_response_for_error(response, "_recv_task")
-                        except SurrealError as exc:
-                            self._deliver_uncorrelated(exc)
-                except Exception as exc:
-                    self._fail_pending(
-                        UnexpectedResponseError(
-                            f"could not route a websocket frame: {exc}"
-                        )
-                    )
-        except (ConnectionClosed, WebSocketException, asyncio.CancelledError):
-            # Connection was closed or cancelled, this is expected
-            pass
-        except Exception as e:
-            logger.debug(f"Unexpected error in _recv_task: {e}")
-        finally:
-            # Fail any pending futures with a typed error so awaiting callers
-            # surface ``ConnectionUnavailableError`` instead of a raw
-            # ``CancelledError`` when the socket closes mid-request.
+            response = decode(data)
+        except Exception as exc:
             self._fail_pending(
-                ConnectionUnavailableError(
-                    "WebSocket connection closed before a response was received."
-                )
+                UnexpectedResponseError(f"could not decode a websocket frame: {exc}")
             )
-            # Live subscribers wait on a queue, not on `self.qry`, so failing
-            # the pending futures left them untouched: nothing would ever be
-            # put in their queue again and `async for` waited forever, with no
-            # timeout on the path. The blocking transport has always raised
-            # `ConnectionUnavailableError` here.
-            for queues in self.live_queues.values():
-                for queue in queues:
-                    queue.put_nowait(_LIVE_QUEUE_BROKEN)
+            return
+
+        try:
+            if response_id := response.get("id"):
+                if fut := self.qry.get(response_id):
+                    if not fut.done():
+                        fut.set_result(response)
+            elif response_result := response.get("result"):
+                live_id = str(response_result["id"])
+                for queue in self.live_queues.get(live_id, []):
+                    queue.put_nowait(response_result)
+            else:
+                # An id-less frame carrying no result is a protocol-level error
+                # the server could not correlate to a request, so everyone in
+                # flight has to hear it.
+                try:
+                    self.check_response_for_error(response, "_recv_task")
+                except SurrealError as exc:
+                    self._deliver_uncorrelated(exc)
+        except Exception as exc:
+            self._fail_pending(
+                UnexpectedResponseError(f"could not route a websocket frame: {exc}")
+            )
+
+    def _reader_stopped(self) -> None:
+        """Tell everyone still waiting that no more frames are coming."""
+        # Fail any pending futures with a typed error so awaiting callers
+        # surface ``ConnectionUnavailableError`` instead of a raw
+        # ``CancelledError`` when the socket closes mid-request.
+        self._fail_pending(
+            ConnectionUnavailableError(
+                "WebSocket connection closed before a response was received."
+            )
+        )
+        # Live subscribers wait on a queue, not on `self.qry`, so failing the
+        # pending futures left them untouched: nothing would ever be put in
+        # their queue again and `async for` waited forever, with no timeout on
+        # the path. The blocking transport has always raised
+        # `ConnectionUnavailableError` here.
+        for queues in self.live_queues.values():
+            for queue in queues:
+                queue.put_nowait(_LIVE_QUEUE_BROKEN)
 
     async def _send(
         self, message: RequestMessage, process: str, bypass: bool = False
@@ -343,9 +437,43 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         # Cannot be more specific without runtime schema validation
         return response
 
+    def _check_event_loop(self) -> None:
+        """Refuse to use a socket that belongs to a different event loop.
+
+        Every awaiting caller's future is created on ``self.loop``, and the
+        reader that resolves them runs there too. Used from a second loop, the
+        first ``await`` failed deep inside asyncio with
+        ``ValueError: The future belongs to a different loop than the one
+        specified as the loop argument`` - a message with nothing in it about
+        connections, event loops the *caller* controls, or what to do next.
+        The connection was then wedged: the request stayed in ``self.qry``, and
+        every later call failed the same way.
+
+        Two loops in one program is not exotic - ``asyncio.run`` builds and
+        destroys one per call, so reusing a connection across two of them is
+        enough. Reconnecting silently instead would trade this for a worse
+        failure: a new socket is a new server-side session, so the next
+        statement would come back ``NotAllowedError`` from a connection the
+        caller had already signed in.
+        """
+        if self.socket is None or self.loop is None:
+            return
+        running = asyncio.get_running_loop()
+        if running is self.loop:
+            return
+        state = "closed" if self.loop.is_closed() else "still running"
+        raise ConnectionUnavailableError(
+            f"this connection to {self.raw_url} belongs to a different event "
+            f"loop (which is {state}), so it cannot be used from this one. A "
+            "connection is bound to the loop it was opened on - build a new "
+            "one for this loop, or keep all of its work on a single loop "
+            "(one asyncio.run call, not several)."
+        )
+
     async def connect(self, url: str | None = None) -> None:
         # Serialised: `_send` calls this on every request, so the first few
         # requests of a gathered batch all arrive here at once.
+        self._check_event_loop()
         async with self._connect_guard():
             await self._connect_locked(url)
 
@@ -396,7 +524,9 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
                 f"could not connect to {self.raw_url}: {exc}"
             ) from exc
         self.loop = asyncio.get_running_loop()
-        self.recv_task = asyncio.create_task(self._recv_task())
+        self.recv_task = asyncio.create_task(
+            _read_frames(weakref.ref(self), self.socket)
+        )
 
     async def authenticate(self, token: str, session_id: UUID | None = None) -> None:
         kwargs: dict[str, Any] = {"token": token}
@@ -1205,11 +1335,27 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         return AsyncSurrealSession(self, session_id)
 
     async def close(self) -> None:
+        """Close the websocket, if one is open. Idempotent.
+
+        Usable from a loop other than the one the connection was opened on,
+        unlike every other method: cancelling and awaiting a task that belongs
+        to another loop cannot work, so that case falls back to the same
+        non-awaiting teardown the destructor uses. Without it the advice
+        :meth:`_check_event_loop` gives - build a new connection for this loop -
+        left the old one with no way to release its socket.
+        """
         # Wake any live subscribers so their generators terminate instead of
         # waiting forever on a socket that is about to disappear.
         for queues in self.live_queues.values():
             for queue in queues:
                 queue.put_nowait(_LIVE_QUEUE_CLOSED)
+
+        if self.loop is not None and self.loop is not asyncio.get_running_loop():
+            _abandon_connection(self.socket, self.recv_task, self.loop)
+            self.socket = None
+            self.recv_task = None
+            self._forget_uncorrelated()
+            return
 
         # Cancel the receive task first
         if self.recv_task and not self.recv_task.done():
@@ -1237,6 +1383,35 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         # socket is a new conversation, and nothing about the old one may be
         # waiting to be delivered into it.
         self._forget_uncorrelated()
+
+    def __del__(self) -> None:
+        """Release the socket if the connection is dropped without ``close()``.
+
+        Each open connection holds a TCP socket and a file descriptor, plus its
+        own reader task and the ``websockets`` keepalive task. Nothing else
+        released them, so a program that built connections and let them go out
+        of scope accumulated all four per connection until the process exited -
+        and because ``asyncio.run`` closes its loop, the leftover tasks also
+        produced "Task was destroyed but it is pending!" on the way out, which
+        reads as a bug in the caller's code rather than in the connection.
+
+        The warning is a ``ResourceWarning``, like the one an unclosed file
+        gives: off by default, visible under ``-W default`` and in tests.
+        """
+        socket = getattr(self, "socket", None)
+        recv_task = getattr(self, "recv_task", None)
+        if socket is None and recv_task is None:
+            return
+        try:
+            warnings.warn(
+                f"unclosed connection to {getattr(self, 'raw_url', '?')} - "
+                "await close(), or use `async with`",
+                ResourceWarning,
+                source=self,
+            )
+        except Exception:
+            pass
+        _abandon_connection(socket, recv_task, getattr(self, "loop", None))
 
     async def __aenter__(self) -> "AsyncWsSurrealConnection":
         """

--- a/src/surrealdb/connections/blocking_embedded.py
+++ b/src/surrealdb/connections/blocking_embedded.py
@@ -62,6 +62,8 @@ class BlockingEmbeddedSurrealConnection(BlockingWsSurrealConnection):
         # Embedded database handle
         with mapped_engine_errors("opening the database"):
             self._db: SyncEmbeddedDB = SyncEmbeddedDB(url)
+        # Whether `close()` has shut the engine down - see `connect`.
+        self._closed: bool = False
 
     def __enter__(self) -> BlockingEmbeddedSurrealConnection:
         """Context manager entry - connect to the embedded database."""
@@ -78,7 +80,21 @@ class BlockingEmbeddedSurrealConnection(BlockingWsSurrealConnection):
         self.close()
 
     def connect(self, url: str | None = None) -> None:
-        """Connects to the embedded database endpoint.
+        """Connect to the embedded database endpoint.
+
+        Idempotent while the engine is open, and it reopens one that
+        :meth:`close` shut down. ``close()`` shuts the datastore down for good -
+        the handle it leaves behind answers every request with "Database
+        connection is closed" - while ``connect()`` on the native side is a
+        no-op that reports success, so reconnecting *said* it had worked and
+        then failed on the next query. The websocket transports have always
+        reopened here; this makes the embedded engine agree.
+
+        A reopened ``memory://`` database starts empty, because the one that
+        was closed is gone. That mirrors a reconnected websocket getting a new,
+        unauthenticated server-side session: closing a connection ends what was
+        behind it. A file-backed engine (``file://``, ``surrealkv://``) reopens
+        its store and keeps its data.
 
         Args:
             url: Optional new URL to connect to.
@@ -91,6 +107,11 @@ class BlockingEmbeddedSurrealConnection(BlockingWsSurrealConnection):
             self.raw_url = url
             with mapped_engine_errors("opening the database"):
                 self._db = SyncEmbeddedDB(url)
+            self._closed = False
+        elif self._closed:
+            with mapped_engine_errors("opening the database"):
+                self._db = SyncEmbeddedDB(self.raw_url)
+            self._closed = False
 
         with mapped_engine_errors("connecting"):
             self._db.connect()
@@ -98,11 +119,15 @@ class BlockingEmbeddedSurrealConnection(BlockingWsSurrealConnection):
     def close(self) -> None:
         """Closes the connection to the database.
 
+        Idempotent, and leaves the connection reusable: :meth:`connect` opens a
+        fresh engine afterwards.
+
         Example:
             db.close()
         """
         with mapped_engine_errors("closing"):
             self._db.close()
+        self._closed = True
         self.socket = None
 
     def _send(

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -544,11 +544,17 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.session = None
 
     def __enter__(self) -> "BlockingHttpSurrealConnection":
+        """Open the pooled HTTP session if there isn't one, and return ``self``.
+
+        Reuses an existing session rather than assigning a fresh one. The
+        replaced session was never closed, so its pooled TCP connections and
+        their sockets leaked - and ``__exit__`` closed only the replacement, so
+        every ``with`` block entered on an already-open connection leaked one
+        more. This mirrors the websocket transport, where re-entering also cost
+        the server-side session.
         """
-        Synchronous context manager entry.
-        Initializes a session for HTTP requests.
-        """
-        self.session = requests.Session()
+        if self.session is None:
+            self.session = requests.Session()
         return self
 
     def __exit__(

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -1347,11 +1347,19 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
             pass
 
     def __enter__(self) -> "BlockingWsSurrealConnection":
+        """Open the websocket if it is not already open, and return ``self``.
+
+        Goes through :meth:`connect`, which is idempotent and holds the lock,
+        rather than assigning a fresh socket unconditionally. Assigning
+        replaced a socket that was already open and signed in: the server-side
+        session went with it, the old socket leaked with its two worker
+        threads, and the first statement inside the block failed with
+        ``NotAllowedError: Anonymous access not allowed``. Signing in and
+        *then* using the connection as a context manager - the obvious reading
+        of "``with`` manages the connection I already have" - was exactly the
+        shape that broke.
         """
-        Synchronous context manager entry.
-        Initializes a websocket connection and returns the connection instance.
-        """
-        self.socket = self._connect_socket()
+        self.connect()
         return self
 
     def __exit__(

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -62,6 +62,7 @@ from collections.abc import Awaitable, Callable, Generator, Mapping
 from dataclasses import fields, is_dataclass
 from typing import Any, Generic, Literal, TypeVar, cast, overload
 
+from surrealdb.data.types.range import Range
 from surrealdb.data.types.record_id import RecordID, RecordIdType, escape_identifier
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
@@ -186,6 +187,21 @@ def _resource_to_variable(
         variables[var_name] = resource.table_name
         return f"type::table(${var_name})"
 
+    if isinstance(resource, Range):
+        # A range on its own names no table, so there is nothing to select
+        # from - `1..=3` is a range of numbers, not of records. It reached the
+        # string branch below and came back as
+        # `TypeError: argument of type 'Range' is not iterable`, which named
+        # neither the argument nor what was wrong with it. Worse, the catch-all
+        # message at the bottom of this function used to tell callers to "pass
+        # a RecordID, Table, or Range instance" - so the SDK's own advice led
+        # straight here.
+        raise SurrealError(
+            f"Cannot use a bare Range as a SurrealDB resource target: {resource} "
+            "names no table. Pass RecordID(table, range) to target a range of "
+            f"records - e.g. RecordID('person', {resource!r})."
+        )
+
     if ":" in resource and ".." not in resource:
         variables[var_name] = _string_to_record_id(resource, var_name)
         return f"${var_name}"
@@ -201,15 +217,31 @@ def _resource_to_variable(
 
     raise SurrealError(
         f"Cannot use raw string {resource!r} as a SurrealDB resource target. "
-        "Pass a RecordID, Table, or Range instance, or simplify the string "
-        "to a bare identifier or 'table:id' form."
+        "Pass a RecordID or Table instance, or simplify the string to a bare "
+        "identifier, 'table:id', or 'table:start..=end' form."
     )
 
 
 def _is_single_record_operation(resource: RecordIdType) -> bool:
+    """Whether *resource* can name at most one record.
+
+    A ``RecordID`` whose id is a :class:`~surrealdb.data.types.range.Range`
+    is the exception: ``RecordID("person", Range(BoundIncluded(1),
+    BoundIncluded(3)))`` targets every record in ``person:1..=3``, and every
+    supported server returns all of them. Counting it as single-record meant
+    the caller was handed the first row and the rest were dropped on the floor
+    - three records read, one returned, no error. The equivalent
+    ``"person:1..=3"`` string has always been treated as multi-record, so the
+    two spellings of the same target disagreed about how much of the answer
+    the caller got to see.
+    """
     if isinstance(resource, RecordID):
-        return True
+        return not isinstance(resource.id, Range)
     if isinstance(resource, Table):
+        return False
+    if isinstance(resource, Range):
+        # Rejected by `_resource_to_variable` before it can be executed; the
+        # answer here only has to be defined, not meaningful.
         return False
     if ":" in resource and ".." not in resource:
         return True
@@ -421,6 +453,30 @@ class _QueryState:
         return [stmt.get("result") for stmt in stmts]
 
 
+def _constructor_parameters(cls: type[Any]) -> str:
+    """The keyword arguments *cls* accepts, for an error message.
+
+    Best-effort: a class whose constructor cannot be introspected (a C
+    extension type, say) reports that rather than failing inside the error
+    path, which would replace the message being built with a less useful one.
+    """
+    if is_dataclass(cls):
+        return str([f.name for f in fields(cls)])
+    try:
+        names = [
+            name
+            for name, param in inspect.signature(cls).parameters.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        ]
+    except (ValueError, TypeError):
+        return "(constructor not introspectable)"
+    return str(names)
+
+
 def _map_to_class(cls: type[T], values: list[Any] | Mapping[str, Any]) -> T:
     """Construct ``cls`` from statement results or a single record row.
 
@@ -438,7 +494,23 @@ def _map_to_class(cls: type[T], values: list[Any] | Mapping[str, Any]) -> T:
     if isinstance(values, Mapping):
         # Row -> model: the record's keys are the constructor kwargs. Works
         # uniformly for dataclasses, pydantic models, and plain classes.
-        return cls(**values)
+        try:
+            return cls(**values)
+        except TypeError as exc:
+            # A record whose fields do not line up with the model surfaced as
+            # a bare `TypeError: Person.__init__() got an unexpected keyword
+            # argument 'active'` - raised from inside the model, naming neither
+            # `into=` nor the record that failed to map, so the obvious reading
+            # was that the caller had constructed a `Person` wrongly somewhere.
+            # The README's own `into=` example hit it: it declared a two-field
+            # `Person` and then wrote a third field to the table.
+            raise UnexpectedResponseError(
+                f"into={cls.__name__} could not be built from this record: {exc}. "
+                f"The record has {sorted(values)}; {cls.__name__} accepts "
+                f"{_constructor_parameters(cls)}. Add the missing field(s) to "
+                "the model, give them defaults, or select only the columns it "
+                "declares."
+            ) from exc
 
     if is_dataclass(cls):
         field_list = list(fields(cls))

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from typing import Any
 
 from surrealdb.connections.builders import (
+    _is_single_record_operation,  # pyright: ignore[reportPrivateUsage]
     _resource_to_variable,  # pyright: ignore[reportPrivateUsage]
 )
 from surrealdb.data.cbor import decode
@@ -298,25 +299,16 @@ class UtilsMixin:
 
     @staticmethod
     def _is_single_record_operation(resource: RecordIdType) -> bool:
-        """
-        Determines if a resource refers to a single record operation.
+        """Whether *resource* can name at most one record.
 
-        Args:
-            resource: The resource (Table, RecordID, or string)
-
-        Returns:
-            True if this is a single record operation, False if it's a table-level operation
+        Single source of truth, for the same reason
+        :meth:`_resource_to_variable` is one: this is the legacy ``select()``
+        path's copy of the rule the builders use, and a hand-maintained
+        second copy is how the two came to disagree about a ``RecordID`` whose
+        id is a ``Range`` - the builders' ``delete``/``update`` dropped every
+        row but the first, and so did this.
         """
-        if isinstance(resource, RecordID):
-            return True
-        elif isinstance(resource, Table):
-            return False
-        else:
-            # Check if it contains a colon (record ID format like "user:tobie")
-            # But exclude range syntax like "user:1..10"
-            if ":" in resource and ".." not in resource:
-                return True
-            return False
+        return _is_single_record_operation(resource)
 
     @staticmethod
     def _unwrap_result(result: Any, unwrap: bool) -> Any:

--- a/tests/unit_tests/connections/embedded/test_reconnect_and_auth.py
+++ b/tests/unit_tests/connections/embedded/test_reconnect_and_auth.py
@@ -1,0 +1,244 @@
+"""The embedded engine reopens after ``close()``, and ``invalidate()`` drops access.
+
+**Reconnecting.** ``close()`` shuts the datastore down for good - the handle it
+leaves behind answers every request with "Database connection is closed" - while
+the native ``connect()`` was a no-op returning success. So ``close()`` then
+``connect()`` *reported* a working connection and failed on the next query,
+which is the worst of the three possible outcomes. Both websocket transports
+have always reopened here.
+
+**Invalidating.** The embedded datastore was built with authentication disabled,
+which makes the engine skip every permission check for an anonymous session -
+and ``invalidate()``, whose whole job is to drop the caller's identity, resets
+the session to exactly that. Invalidating therefore *raised* privilege: a record
+user who could not read a ``PERMISSIONS NONE`` table, and could not run
+``INFO FOR ROOT``, could do both afterwards. Over websocket and HTTP the same
+call has always left the session anonymous and denied.
+"""
+
+import shutil
+import tempfile
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection
+from surrealdb.connections.blocking_embedded import BlockingEmbeddedSurrealConnection
+from surrealdb.errors import (
+    ConnectionUnavailableError,
+    NotAllowedError,
+    NotFoundError,
+)
+
+RECORD_AUTH = """
+DEFINE TABLE secret SCHEMALESS PERMISSIONS NONE;
+CREATE secret:1 SET n = 1;
+DEFINE TABLE person SCHEMALESS PERMISSIONS FOR select WHERE id = $auth.id;
+DEFINE ACCESS acc ON DATABASE TYPE RECORD
+  SIGNUP ( CREATE person SET email = $email, pass = crypto::argon2::generate($pass) )
+  SIGNIN ( SELECT * FROM person WHERE email = $email
+           AND crypto::argon2::compare(pass, $pass) )
+  DURATION FOR SESSION 1h;
+"""
+
+
+@pytest.fixture
+def store() -> Generator[str, None, None]:
+    directory = Path(tempfile.mkdtemp())
+    yield f"surrealkv://{directory / 'db'}"
+    shutil.rmtree(directory, ignore_errors=True)
+
+
+# ------------------------------------------------------------- reconnecting
+
+
+def test_connect_after_close_gives_a_working_engine() -> None:
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    connection.query("CREATE t:1 SET n = 1").execute()
+    connection.close()
+
+    connection.connect()
+    connection.use("ns", "db")
+
+    # Asked of the engine, not of a flag: the old failure reported success and
+    # then refused every request.
+    assert connection.query("CREATE t:2 SET n = 2").first() is not None
+    connection.close()
+
+
+def test_a_closed_engine_still_refuses_requests() -> None:
+    """``close()`` has to keep meaning closed until ``connect()`` is called."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    connection.close()
+
+    with pytest.raises(ConnectionUnavailableError):
+        connection.query("RETURN 1").execute()
+
+
+def test_a_reopened_memory_database_starts_empty() -> None:
+    """Documented, and asserted so it cannot change silently.
+
+    The datastore that held the data was shut down, so there is nothing to
+    reopen - the same way a reconnected websocket gets a new, unauthenticated
+    server-side session rather than the one it had.
+    """
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    connection.query("CREATE t:1 SET n = 1").execute()
+    connection.close()
+
+    connection.connect()
+    connection.use("ns", "db")
+
+    # The table is gone with the datastore, so this is "not there" rather than
+    # "there and empty".
+    with pytest.raises(NotFoundError):
+        connection.query("SELECT * FROM t").execute()
+    connection.close()
+
+
+def test_a_reopened_file_database_keeps_its_data(store: str) -> None:
+    connection = BlockingEmbeddedSurrealConnection(store)
+    connection.use("ns", "db")
+    connection.query("CREATE t:1 SET n = 1").execute()
+    connection.close()
+
+    connection.connect()
+    connection.use("ns", "db")
+
+    rows = connection.query("SELECT * FROM t").first()
+    assert isinstance(rows, list) and len(rows) == 1
+    connection.close()
+
+
+def test_connect_on_an_open_engine_is_a_no_op() -> None:
+    """Reopening an engine that was never closed would wipe an in-memory
+    database, so the idempotent case has to stay idempotent."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    connection.query("CREATE t:1 SET n = 1").execute()
+
+    connection.connect()
+
+    rows = connection.query("SELECT * FROM t").first()
+    assert isinstance(rows, list) and len(rows) == 1
+    connection.close()
+
+
+def test_a_context_manager_does_not_wipe_an_open_engine() -> None:
+    """``__enter__`` goes through ``connect()``, so this is the same property
+    seen from the entry point most people use."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    connection.query("CREATE t:1 SET n = 1").execute()
+
+    with connection:
+        rows = connection.query("SELECT * FROM t").first()
+        assert isinstance(rows, list) and len(rows) == 1
+
+
+async def test_the_async_engine_reconnects_too() -> None:
+    connection = AsyncEmbeddedSurrealConnection("memory")
+    await connection.use("ns", "db")
+    await connection.query("CREATE t:1 SET n = 1").execute()
+    await connection.close()
+
+    with pytest.raises(ConnectionUnavailableError):
+        await connection.query("RETURN 1").execute()
+
+    await connection.connect()
+    await connection.use("ns", "db")
+    assert await connection.query("CREATE t:2 SET n = 2").first() is not None
+    await connection.close()
+
+
+# ------------------------------------------------------------- invalidating
+
+
+def _record_user(connection: BlockingEmbeddedSurrealConnection) -> None:
+    connection.query(RECORD_AUTH).execute()
+    connection.signup(
+        {
+            "namespace": "ns",
+            "database": "db",
+            "access": "acc",
+            "variables": {"email": f"{uuid.uuid4().hex}@example.com", "pass": "x"},
+        }
+    )
+
+
+def test_invalidate_drops_to_anonymous() -> None:
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    _record_user(connection)
+
+    connection.invalidate()
+
+    with pytest.raises(NotAllowedError):
+        connection.query("SELECT * FROM secret").execute()
+    connection.close()
+
+
+def test_invalidate_does_not_restore_root_access() -> None:
+    """The precise inversion: after invalidating, the session could read a
+    table the record user it replaced could not."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    _record_user(connection)
+    assert connection.query("SELECT * FROM secret").first() == []
+
+    connection.invalidate()
+
+    with pytest.raises(NotAllowedError):
+        connection.query("INFO FOR ROOT").execute()
+    connection.close()
+
+
+def test_permissions_still_apply_to_a_record_user() -> None:
+    """The half that already worked, so a fix to the other half cannot quietly
+    disable enforcement altogether."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+    _record_user(connection)
+
+    assert connection.query("SELECT * FROM secret").first() == []
+    with pytest.raises(NotAllowedError):
+        connection.query("INFO FOR ROOT").execute()
+    connection.close()
+
+
+def test_a_fresh_connection_has_full_access() -> None:
+    """Opening an embedded database and using it without signing in is the
+    documented way to use it, and enforcing authentication must not break it."""
+    connection = BlockingEmbeddedSurrealConnection("memory")
+    connection.use("ns", "db")
+
+    connection.query("DEFINE TABLE t SCHEMALESS; CREATE t:1 SET n = 1;").execute()
+    assert connection.query("INFO FOR ROOT").first() is not None
+    rows = connection.query("SELECT * FROM t").first()
+    assert isinstance(rows, list) and len(rows) == 1
+    connection.close()
+
+
+async def test_the_async_engine_invalidates_too() -> None:
+    connection = AsyncEmbeddedSurrealConnection("memory")
+    await connection.use("ns", "db")
+    await connection.query(RECORD_AUTH).execute()
+    await connection.signup(
+        {
+            "namespace": "ns",
+            "database": "db",
+            "access": "acc",
+            "variables": {"email": f"{uuid.uuid4().hex}@example.com", "pass": "x"},
+        }
+    )
+
+    await connection.invalidate()
+
+    with pytest.raises(NotAllowedError):
+        await connection.query("SELECT * FROM secret").execute()
+    await connection.close()

--- a/tests/unit_tests/connections/test_async_ws_lifetime.py
+++ b/tests/unit_tests/connections/test_async_ws_lifetime.py
@@ -1,0 +1,224 @@
+"""An async websocket connection is bound to one loop, and releases what it holds.
+
+Two failures of the same object's lifetime.
+
+**Bound to a loop.** Every awaiting caller's future is created on the loop the
+socket was opened on, and the reader that resolves them runs there. Used from a
+second loop - two ``asyncio.run`` calls is enough, since each builds and
+destroys one - the first ``await`` failed deep inside asyncio with
+``ValueError: The future belongs to a different loop than the one specified as
+the loop argument``, a message with nothing in it about connections or event
+loops. The request then stayed in ``qry`` and every later call failed the same
+way, so the connection was wedged as well as unexplained.
+
+**Releases what it holds.** ``asyncio.create_task(self._recv_task())`` gave the
+running loop a strong reference to the connection: loop -> task -> coroutine ->
+``self``. A connection whose last user reference was dropped was therefore never
+collected, so no finaliser could run and its socket, file descriptor, reader
+task and keepalive task stayed for the life of the process. The reader now holds
+a weak reference, so dropping a connection collects it and ``__del__`` releases
+the socket.
+"""
+
+import asyncio
+import gc
+import os
+import warnings
+from typing import Any
+
+import pytest
+from websockets.protocol import State
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.errors import ConnectionUnavailableError
+
+
+def _open_fds() -> int:
+    return len(os.listdir("/dev/fd"))
+
+
+async def _signed_in(params: dict[str, Any]) -> AsyncWsSurrealConnection:
+    connection = AsyncWsSurrealConnection(params["ws_url"])
+    await connection.signin(params["vars_params"])
+    await connection.use(params["namespace"], params["database_name"])
+    await connection.query("RETURN 1").first()
+    return connection
+
+
+# ------------------------------------------------------------- loop binding
+
+
+def test_using_a_connection_from_a_second_loop_is_refused(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+
+    first = asyncio.new_event_loop()
+    second = asyncio.new_event_loop()
+    try:
+        assert first.run_until_complete(_run_first(connection, connection_params)) == 1
+
+        with pytest.raises(ConnectionUnavailableError) as caught:
+            second.run_until_complete(connection.query("RETURN 2").first())
+
+        message = str(caught.value)
+        assert "event loop" in message
+        assert "build a new one" in message
+    finally:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            for loop in (first, second):
+                loop.close()
+            del connection
+            gc.collect()
+
+
+async def _run_first(
+    connection: AsyncWsSurrealConnection, params: dict[str, Any]
+) -> Any:
+    await connection.signin(params["vars_params"])
+    await connection.use(params["namespace"], params["database_name"])
+    return await connection.query("RETURN 1").first()
+
+
+def test_close_works_from_a_different_loop(
+    connection_params: dict[str, Any],
+) -> None:
+    """Otherwise the advice the error gives - build a new connection - leaves
+    the old one with no way to release its socket."""
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+    first = asyncio.new_event_loop()
+    try:
+        first.run_until_complete(_run_first(connection, connection_params))
+    finally:
+        first.close()
+
+    asyncio.run(connection.close())
+
+    assert connection.socket is None
+    assert connection.recv_task is None
+
+
+async def test_one_loop_is_unaffected(connection_params: dict[str, Any]) -> None:
+    """The ordinary case: many operations, one loop, no complaint."""
+    connection = await _signed_in(connection_params)
+    try:
+        for _ in range(3):
+            assert await connection.query("RETURN 1").first() == 1
+    finally:
+        await connection.close()
+
+
+# ------------------------------------------------------------- release on drop
+
+
+async def test_a_dropped_connection_is_collected(
+    connection_params: dict[str, Any],
+) -> None:
+    """The precondition for any finaliser to run at all."""
+    import weakref
+
+    connection = await _signed_in(connection_params)
+    ref = weakref.ref(connection)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        del connection
+        gc.collect()
+
+    assert ref() is None, "the reader task is still holding the connection alive"
+
+
+async def test_dropping_a_connection_releases_its_tasks_and_socket(
+    connection_params: dict[str, Any],
+) -> None:
+    before = {task for task in asyncio.all_tasks()}
+    connection = await _signed_in(connection_params)
+    socket = connection.socket
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        del connection
+        gc.collect()
+        await asyncio.sleep(0.3)
+        gc.collect()
+
+    leaked = [t for t in asyncio.all_tasks() if t not in before and not t.done()]
+    assert leaked == [], f"leaked tasks: {[t.get_name() for t in leaked]}"
+    # The enum member, not its ``str``: ``State`` is an ``IntEnum``, and from
+    # Python 3.11 those render as the bare integer.
+    assert socket.state is State.CLOSED
+
+
+async def test_dropping_connections_does_not_accumulate_descriptors(
+    connection_params: dict[str, Any],
+) -> None:
+    """A counter, because the leak only shows as a program stays up.
+
+    Each connection used to keep its file descriptor for the life of the
+    process, so a loop that built and discarded them ran out. The bound is
+    generous - the loop's own bookkeeping moves a little - but it does not
+    scale with the number of connections, which is the point.
+    """
+    baseline = _open_fds()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ResourceWarning)
+        for _ in range(8):
+            connection = await _signed_in(connection_params)
+            del connection
+            gc.collect()
+        await asyncio.sleep(0.3)
+        gc.collect()
+
+    assert _open_fds() - baseline < 8
+
+
+async def test_dropping_an_open_connection_warns(
+    connection_params: dict[str, Any],
+) -> None:
+    """A ``ResourceWarning``, like an unclosed file: off by default, on in tests."""
+    connection = await _signed_in(connection_params)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del connection
+        gc.collect()
+
+    assert any(
+        issubclass(entry.category, ResourceWarning)
+        and "unclosed connection" in str(entry.message)
+        for entry in caught
+    ), [str(entry.message) for entry in caught]
+
+
+async def test_a_closed_connection_does_not_warn(
+    connection_params: dict[str, Any],
+) -> None:
+    """Nothing to complain about once the caller has done the right thing."""
+    connection = await _signed_in(connection_params)
+    await connection.close()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del connection
+        gc.collect()
+
+    assert not [
+        entry for entry in caught if issubclass(entry.category, ResourceWarning)
+    ]
+
+
+async def test_a_never_connected_connection_does_not_warn(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncWsSurrealConnection(connection_params["ws_url"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del connection
+        gc.collect()
+
+    assert not [
+        entry for entry in caught if issubclass(entry.category, ResourceWarning)
+    ]

--- a/tests/unit_tests/connections/test_context_manager_reentry.py
+++ b/tests/unit_tests/connections/test_context_manager_reentry.py
@@ -1,0 +1,134 @@
+"""Entering a context manager on an open connection keeps what is already open.
+
+``with db:`` on a connection that had already been signed in threw away the
+socket it was managing and opened a replacement. A websocket *is* the
+server-side session, so the sign-in went with it and the first statement inside
+the block came back ``NotAllowedError: Anonymous access not allowed`` - from a
+connection the caller had authenticated moments earlier. The discarded socket
+was never closed either, so it leaked with its two worker threads.
+
+The HTTP transports had the same shape without the auth consequence, since
+their identity is a token on the connection rather than the pooled session:
+entering replaced the session object and only the replacement was ever closed,
+so every re-entry leaked a connection pool.
+
+Signing in and *then* using the connection with ``with`` is the obvious reading
+of "``with`` manages the connection I already have", so this is the shape that
+mattered.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+
+def test_entering_keeps_the_open_socket_and_its_session(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    connection.signin(connection_params["vars_params"])
+    connection.use(connection_params["namespace"], connection_params["database_name"])
+    opened = connection.socket
+
+    with connection as entered:
+        assert entered is connection
+        assert connection.socket is opened, "the open socket was replaced"
+        # The consequence, asked of the server rather than of an attribute.
+        assert connection.query("RETURN 1").first() == 1
+
+
+def test_entering_an_unconnected_connection_still_connects(
+    connection_params: dict[str, Any],
+) -> None:
+    """The behaviour that was already right, and had to stay."""
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    assert connection.socket is None
+
+    with connection:
+        assert connection.socket is not None
+
+    assert connection.socket is None
+
+
+def test_exiting_still_closes(connection_params: dict[str, Any]) -> None:
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    connection.signin(connection_params["vars_params"])
+
+    with connection:
+        pass
+
+    assert connection.socket is None
+
+
+def test_reentering_repeatedly_opens_one_socket(
+    connection_params: dict[str, Any],
+) -> None:
+    """Nested/sequential ``with`` on a live connection must not stack sockets."""
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    connection.signin(connection_params["vars_params"])
+    connection.use(connection_params["namespace"], connection_params["database_name"])
+    opened = connection.socket
+
+    with connection:
+        with connection:
+            assert connection.socket is opened
+        # The inner block closed it, which is what a context manager does.
+        assert connection.socket is None
+
+
+def test_http_reuses_the_pooled_session(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = BlockingHttpSurrealConnection(connection_params["url"])
+    with connection:
+        first = connection.session
+        assert first is not None
+        with connection:
+            assert connection.session is first, "the pooled session was replaced"
+
+
+async def test_async_http_reuses_the_pooled_session(
+    connection_params: dict[str, Any],
+) -> None:
+    connection = AsyncHttpSurrealConnection(connection_params["url"])
+    async with connection:
+        first = connection._session  # pyright: ignore[reportPrivateUsage]
+        assert first is not None
+        async with connection:
+            assert connection._session is first, (  # pyright: ignore[reportPrivateUsage]
+                "the pooled session was replaced"
+            )
+
+
+async def test_async_http_replaces_a_closed_session(
+    connection_params: dict[str, Any],
+) -> None:
+    """Reuse is of an *open* session; a closed one is no use to anybody."""
+    connection = AsyncHttpSurrealConnection(connection_params["url"])
+    async with connection:
+        pass
+    async with connection:
+        session = connection._session  # pyright: ignore[reportPrivateUsage]
+        assert session is not None and not session.closed
+
+
+@pytest.mark.parametrize("attempts", [3])
+def test_the_websocket_session_survives_every_reentry(
+    connection_params: dict[str, Any], attempts: int
+) -> None:
+    """The regression as reported: sign in once, use ``with`` afterwards."""
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    connection.signin(connection_params["vars_params"])
+    connection.use(connection_params["namespace"], connection_params["database_name"])
+
+    for _ in range(attempts):
+        with connection:
+            assert connection.query("RETURN 1").first() == 1
+        connection.signin(connection_params["vars_params"])
+        connection.use(
+            connection_params["namespace"], connection_params["database_name"]
+        )

--- a/tests/unit_tests/connections/test_readme_examples_run.py
+++ b/tests/unit_tests/connections/test_readme_examples_run.py
@@ -1,0 +1,163 @@
+"""The README's runnable example blocks are run, not just read.
+
+``test_examples_use_the_real_api`` checks that ``examples/`` names methods that
+exist, which catches a renamed API but nothing about whether the code *works*.
+Two README blocks were wrong in ways only running them shows:
+
+* the ``into=`` block declared a two-field ``Person`` and then wrote a third
+  field to the table, so the very next line raised;
+* the sync block's last statement was ``db.query("DELETE temp_data;")`` against
+  a table nothing had created, which is a ``NotFoundError`` on 3.x.
+
+These reproduce the blocks statement by statement rather than ``exec``-ing the
+markdown: the blocks are fragments with no imports and top-level ``await``, so
+extracting and running them literally is not possible, and a paraphrase that
+drifted from the README would be worse than no test. Each statement below is
+the README's, in the README's order, so a change to one without the other shows
+up as a diff a reviewer can see.
+"""
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from surrealdb import AsyncSurreal, Surreal
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+from surrealdb.errors import NotFoundError
+
+
+@dataclass
+class Person:
+    """The README's model, verbatim."""
+
+    id: RecordID
+    name: str
+
+
+@pytest.fixture
+def person_table(blocking_ws_connection: Any) -> str:
+    blocking_ws_connection.query("DELETE person;").execute()
+    return "person"
+
+
+# --------------------------------------------------------------- the into= block
+
+
+async def test_the_into_block_runs(async_ws_connection: Any, person_table: str) -> None:
+    db = async_ws_connection
+
+    person = await db.select(RecordID("person", "tobie"), into=Person)
+    assert person is None
+
+    people = await db.select(Table("person"), into=Person)
+    assert people == []
+
+    created = await db.create(
+        RecordID("person", "tobie"), {"name": "Tobie"}, into=Person
+    )
+    assert isinstance(created, Person)
+
+    updated = await db.update(Table("person"), {"name": "Updated"}, into=Person)
+    assert isinstance(updated, list)
+    assert all(isinstance(row, Person) for row in updated)
+
+    inserted = await db.insert(Table("person"), [{"name": "A"}], into=Person)
+    assert isinstance(inserted, list)
+    assert all(isinstance(row, Person) for row in inserted)
+
+    p = await db.create(RecordID("person", "jaime"), into=Person).merge(
+        {"name": "Jaime"}
+    )
+    assert isinstance(p, Person)
+
+    rows = await db.query("SELECT * FROM person").into(Person, rows=True)
+    assert all(isinstance(row, Person) for row in rows)
+
+
+def test_the_sync_into_block_runs(
+    blocking_ws_connection: Any, person_table: str
+) -> None:
+    db = blocking_ws_connection
+
+    assert db.select(RecordID("person", "tobie"), into=Person) is None
+    created = db.create(RecordID("person", "tobie"), {"name": "Tobie"}, into=Person)
+    assert isinstance(created, Person)
+    rows = db.query("SELECT * FROM person").into(Person, rows=True)
+    assert all(isinstance(row, Person) for row in rows)
+
+
+def test_the_documented_mismatch_message_is_what_the_readme_shows(
+    blocking_ws_connection: Any, person_table: str
+) -> None:
+    """The README quotes this error; it has to be the one that comes out."""
+    db = blocking_ws_connection
+    db.create(RecordID("person", "tobie"), {"name": "Tobie"})
+
+    with pytest.raises(Exception) as caught:
+        db.update(Table("person"), {"active": True}, into=Person)
+
+    message = str(caught.value)
+    assert "into=Person could not be built from this record" in message
+    assert "unexpected keyword argument 'active'" in message
+    assert "Person accepts ['id', 'name']" in message
+
+
+# --------------------------------------------------------------- the sync block
+
+
+def test_the_sync_usage_block_runs(connection_params: dict[str, Any]) -> None:
+    """The README's ``with Surreal(...)`` block, line for line."""
+    with Surreal(connection_params["ws_url"]) as db:
+        db.signin({"username": "root", "password": "root"})
+        db.use(connection_params["namespace"], connection_params["database_name"])
+        db.query("DELETE person;").execute()
+
+        tobie = db.create(RecordID("person", "tobie"), {"name": "Tobie"})
+        assert tobie["name"] == "Tobie"
+
+        out = db.create(RecordID("person", "alice")).merge({"name": "Alice"})
+        assert out["name"] == "Alice"
+
+        empty = db.create(RecordID("person", "bob")).execute()
+        assert empty["id"] == RecordID("person", "bob")
+
+        row = db.select(RecordID("person", "tobie"))
+        assert row is not None
+        db.delete(RecordID("person", "bob"))
+
+        db.query("DELETE person;").execute()
+
+
+def test_delete_on_a_missing_table_is_documented_accurately(
+    blocking_ws_connection: Any,
+) -> None:
+    """The README says 3.x raises here and 2.x does not, so check the claim
+    against whichever server is actually running."""
+    missing = f"absent_{uuid.uuid4().hex[:8]}"
+    version = blocking_ws_connection.version()
+    major = int(version.replace("surrealdb-", "").split(".")[0])
+
+    if major >= 3:
+        with pytest.raises(NotFoundError):
+            blocking_ws_connection.query(f"DELETE {missing};").execute()
+    else:
+        assert blocking_ws_connection.query(f"DELETE {missing};").execute() == [[]]
+
+    # The version-independent spelling the README recommends instead.
+    assert (
+        blocking_ws_connection.query(f"REMOVE TABLE IF EXISTS {missing};").execute()
+        is not None
+    )
+
+
+# --------------------------------------------------------------- the async block
+
+
+async def test_the_async_usage_block_runs(connection_params: dict[str, Any]) -> None:
+    async with AsyncSurreal(connection_params["ws_url"]) as db:
+        await db.signin({"username": "root", "password": "root"})
+        await db.use(connection_params["namespace"], connection_params["database_name"])
+        assert await db.query("RETURN 1").first() == 1

--- a/tests/unit_tests/connections/test_record_range_targets.py
+++ b/tests/unit_tests/connections/test_record_range_targets.py
@@ -1,0 +1,249 @@
+"""A ``RecordID`` whose id is a ``Range`` targets every record in the range.
+
+``RecordID("person", Range(BoundIncluded(1), BoundIncluded(3)))`` is how the SDK
+spells ``person:1..=3``. Every supported server returns all three records for
+it, but the SDK classified any ``RecordID`` as a single-record target and
+unwrapped the answer to the first row - so three records were read, one was
+returned, and nothing said the other two had been dropped. ``delete()`` was the
+same shape: it reported deleting one record while deleting all of them.
+
+The equivalent ``"person:1..=3"`` *string* was always treated as multi-record,
+so the two spellings of one target disagreed about how much of the answer the
+caller saw. These tests assert on the string form alongside the ``RecordID``
+form, because agreeing with each other is the property that matters.
+
+A bare ``Range`` is a separate case: it names no table, so it cannot be a
+resource target at all. It used to reach a ``":" in resource`` test and come
+back as ``TypeError: argument of type 'Range' is not iterable`` - and the
+catch-all error next to that test told callers to "pass a RecordID, Table, or
+Range instance", which is how they got there.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.range import BoundExcluded, BoundIncluded, Range
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+from surrealdb.errors import SurrealError
+
+
+def _rows(connection: BlockingWsSurrealConnection) -> str:
+    table = f"rng_{uuid.uuid4().hex[:8]}"
+    connection.query(
+        f"CREATE {table}:1 SET n=1; CREATE {table}:2 SET n=2; CREATE {table}:3 SET n=3;"
+    ).execute()
+    return table
+
+
+def _ids(result: object) -> list[object]:
+    assert isinstance(result, list), f"expected every matching record, got {result!r}"
+    return sorted(row["id"].id for row in result)
+
+
+# --------------------------------------------------------------- select
+
+
+def test_select_returns_every_record_in_the_range(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    result = blocking_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(3)))
+    )
+
+    assert _ids(result) == [1, 2, 3]
+
+
+def test_the_record_id_and_string_spellings_agree(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    typed = blocking_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(3)))
+    )
+    spelled = blocking_ws_connection.select(f"{table}:1..=3")
+
+    assert typed == spelled
+
+
+def test_an_excluded_end_bound_is_honoured(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    result = blocking_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundExcluded(3)))
+    )
+
+    assert _ids(result) == [1, 2]
+
+
+def test_an_open_range_covers_the_whole_table(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    result = blocking_ws_connection.select(RecordID(table, Range(None, None)))
+
+    assert _ids(result) == [1, 2, 3]
+
+
+def test_a_range_that_matches_nothing_is_an_empty_list(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """Not ``None``: an empty range is an empty multi-record answer, the same
+    as a ``Table`` target with no rows. ``None`` is what an absent *single*
+    record returns, and conflating the two is what the unwrap did.
+
+    Held as ``Any`` because the ``@overload``s resolve on the static type
+    ``RecordID``, which says nothing about the id - the documented caveat that
+    a range target is narrower on paper than it is at runtime.
+    """
+    table = _rows(blocking_ws_connection)
+
+    result: Any = blocking_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(90), BoundIncluded(99)))
+    )
+
+    assert result == []
+
+
+def test_a_plain_record_id_still_unwraps(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The neighbouring behaviour this must not disturb."""
+    table = _rows(blocking_ws_connection)
+
+    row = blocking_ws_connection.select(RecordID(table, 1))
+
+    assert isinstance(row, dict)
+    assert row["n"] == 1
+    assert blocking_ws_connection.select(RecordID(table, 404)) is None
+
+
+# --------------------------------------------------------------- write paths
+
+
+def test_delete_returns_every_record_it_removed(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    removed = blocking_ws_connection.delete(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(3)))
+    )
+
+    assert _ids(removed) == [1, 2, 3]
+    assert blocking_ws_connection.select(Table(table)) == []
+
+
+def test_update_returns_every_record_it_wrote(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    written = blocking_ws_connection.update(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(3))), {"n": 9}
+    )
+
+    assert _ids(written) == [1, 2, 3]
+    assert [row["n"] for row in blocking_ws_connection.select(Table(table))] == [
+        9,
+        9,
+        9,
+    ]
+
+
+def test_into_maps_every_record_in_the_range(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """``into=`` follows the runtime shape, so a range maps element-wise."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class Row:
+        id: RecordID
+        n: int
+
+    table = _rows(blocking_ws_connection)
+
+    rows = blocking_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(3))), into=Row
+    )
+
+    assert isinstance(rows, list)
+    assert sorted(row.n for row in rows) == [1, 2, 3]
+
+
+# --------------------------------------------------------------- other transports
+
+
+def test_the_http_transport_agrees(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    table = f"rng_{uuid.uuid4().hex[:8]}"
+    blocking_http_connection.query(
+        f"CREATE {table}:1 SET n=1; CREATE {table}:2 SET n=2;"
+    ).execute()
+
+    result = blocking_http_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(2)))
+    )
+
+    assert _ids(result) == [1, 2]
+
+
+async def test_the_async_transport_agrees(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    table = f"rng_{uuid.uuid4().hex[:8]}"
+    await async_ws_connection.query(
+        f"CREATE {table}:1 SET n=1; CREATE {table}:2 SET n=2;"
+    ).execute()
+
+    result = await async_ws_connection.select(
+        RecordID(table, Range(BoundIncluded(1), BoundIncluded(2)))
+    )
+
+    assert _ids(result) == [1, 2]
+
+
+# --------------------------------------------------------------- a bare Range
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["select", "delete"],
+)
+def test_a_bare_range_is_refused_with_an_explanation(
+    blocking_ws_connection: BlockingWsSurrealConnection, operation: str
+) -> None:
+    with pytest.raises(SurrealError) as caught:
+        getattr(blocking_ws_connection, operation)(
+            Range(BoundIncluded(1), BoundIncluded(3))
+        )
+
+    message = str(caught.value)
+    assert "names no table" in message
+    assert "RecordID(table, range)" in message
+    # The old failure, and the shape of it: an unhandled builtin from a
+    # containment test, naming nothing the caller passed.
+    assert not isinstance(caught.value, TypeError)
+
+
+def test_the_string_advice_no_longer_recommends_a_bare_range(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The message that sent callers into the failure above."""
+    with pytest.raises(SurrealError) as caught:
+        blocking_ws_connection.select("not a valid target!")
+
+    assert "Range instance" not in str(caught.value)

--- a/tests/unit_tests/info_fallback/test_ws.py
+++ b/tests/unit_tests/info_fallback/test_ws.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import weakref
 from collections.abc import Callable
 from typing import Any
 
 import pytest
 
-from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection, _read_frames
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 from surrealdb.data.cbor import decode, encode
 from surrealdb.data.types.record_id import RecordID
@@ -165,7 +166,7 @@ async def _run_async_ws(responder: Responder) -> AsyncWsSurrealConnection:
     db = AsyncWsSurrealConnection("ws://localhost:8000")
     db.socket = _FakeAsyncWsSocket(responder)
     db.loop = asyncio.get_running_loop()
-    db.recv_task = asyncio.create_task(db._recv_task())
+    db.recv_task = asyncio.create_task(_read_frames(weakref.ref(db), db.socket))
     return db
 
 

--- a/tests/unit_tests/test_into_mapping.py
+++ b/tests/unit_tests/test_into_mapping.py
@@ -459,3 +459,97 @@ def test_into_rejects_non_record_rows() -> None:
         _map_result(Person, [1, 2])
     with pytest.raises(UnexpectedResponseError):
         _map_result(Person, 42)
+
+
+# --------------------------------------------------------------------------- #
+#  A record whose fields do not match the model                                #
+# --------------------------------------------------------------------------- #
+#
+# This surfaced as a bare ``TypeError: Person.__init__() got an unexpected
+# keyword argument 'active'``, raised from inside the model and naming neither
+# ``into=`` nor the record that failed to map - so the obvious reading was that
+# the caller had constructed a ``Person`` wrongly somewhere else. The README's
+# own ``into=`` example hit it: it declared a two-field ``Person`` and then
+# wrote a third field to the table.
+
+
+def _extra_field_error(model: type) -> str:
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import UnexpectedResponseError
+
+    with pytest.raises(UnexpectedResponseError) as caught:
+        _map_result(model, {"id": RecordID("person", "a"), "active": True})
+    return str(caught.value)
+
+
+@pytest.mark.parametrize("model", [Person, PlainPerson])
+def test_an_unmappable_record_names_both_sides(model: type) -> None:
+    message = _extra_field_error(model)
+
+    assert f"into={model.__name__}" in message
+    # What arrived, and what the model would have taken.
+    assert "'active'" in message and "'id'" in message
+    assert "'name'" in message
+
+
+@pytest.mark.parametrize("model", [Person, PlainPerson])
+def test_an_unmappable_record_raises_a_surreal_error(model: type) -> None:
+    """Catchable through the SDK's own tree, like every other mapping failure.
+
+    A bare ``TypeError`` escaped ``except SurrealError`` entirely.
+    """
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import SurrealError
+
+    with pytest.raises(SurrealError):
+        _map_result(model, {"id": RecordID("person", "a"), "active": True})
+
+
+def test_a_missing_field_is_reported_too() -> None:
+    """The other direction: the model wants more than the record carries."""
+    message = _extra_field_error(Person)
+    assert "into=Person" in message
+
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import UnexpectedResponseError
+
+    with pytest.raises(UnexpectedResponseError) as caught:
+        _map_result(Person, {"id": RecordID("person", "a")})
+    assert "into=Person" in str(caught.value)
+
+
+def test_the_original_error_is_kept_as_the_cause() -> None:
+    """The model's own message is the specific one; it must not be lost."""
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import UnexpectedResponseError
+
+    with pytest.raises(UnexpectedResponseError) as caught:
+        _map_result(Person, {"id": 1, "active": True})
+
+    assert isinstance(caught.value.__cause__, TypeError)
+
+
+def test_a_record_that_does_match_is_untouched() -> None:
+    """The wrapper must not change the successful path."""
+    from surrealdb.connections.builders import _map_result
+
+    mapped = _map_result(Person, {"id": RecordID("person", "a"), "name": "A"})
+
+    assert isinstance(mapped, Person)
+    assert mapped.name == "A"
+
+
+def test_a_model_raising_its_own_type_error_is_still_reported() -> None:
+    """A constructor that raises ``TypeError`` for its own reasons is reported
+    rather than swallowed - the message keeps the model's own text."""
+    from surrealdb.connections.builders import _map_result
+    from surrealdb.errors import UnexpectedResponseError
+
+    class Fussy:
+        def __init__(self, id: Any, name: str) -> None:
+            raise TypeError("name must be capitalised")
+
+    with pytest.raises(UnexpectedResponseError) as caught:
+        _map_result(Fussy, {"id": 1, "name": "a"})
+
+    assert "name must be capitalised" in str(caught.value)

--- a/tests/unit_tests/test_ws_live_lifecycle.py
+++ b/tests/unit_tests/test_ws_live_lifecycle.py
@@ -17,11 +17,12 @@ Covers:
 import asyncio
 import queue
 import uuid
+import weakref
 from typing import Any
 
 import pytest
 
-from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection, _read_frames
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 from surrealdb.data.cbor import decode, encode
 from surrealdb.errors import ConnectionUnavailableError
@@ -173,7 +174,7 @@ async def test_async_recv_task_fails_pending_with_connection_error() -> None:
     fut: asyncio.Future[dict[str, Any]] = conn.loop.create_future()
     conn.qry["req-1"] = fut
 
-    await conn._recv_task()
+    await _read_frames(weakref.ref(conn), conn.socket)
 
     assert conn.qry == {}
     assert fut.done()
@@ -335,7 +336,7 @@ async def test_async_recv_task_survives_an_undecodable_frame() -> None:
     conn.loop = asyncio.get_running_loop()
     socket = _OneBadFrameThenRepliesSocket()
     conn.socket = socket
-    conn.recv_task = asyncio.create_task(conn._recv_task())
+    conn.recv_task = asyncio.create_task(_read_frames(weakref.ref(conn), conn.socket))
 
     # Give the reader the bad frame first.
     await asyncio.sleep(0)


### PR DESCRIPTION
Nine findings, all reproduced live before being touched and all mutation-tested after. Grouped by what they cost the caller.

## Data loss

**A `RecordID` whose id is a `Range` returned one record out of every match.** `RecordID("person", Range(BoundIncluded(1), BoundIncluded(3)))` is how the SDK spells `person:1..=3`. Every supported server — 2.0.5, 2.3.10 and 3.2.3, over both transports — returns all three records for it, but the SDK classified any `RecordID` as a single-record target and unwrapped the answer to the first row. Three records read, one returned, nothing said the other two had been dropped. `delete()` and `update()` had the same shape: they reported writing one record while writing all of them. The equivalent `"person:1..=3"` *string* was always treated as multi-record, so the two spellings of one target disagreed about how much of the answer the caller got to see. The rule now lives in one place — `utils_mixin`'s hand-maintained copy delegates to it, which is how the two came to diverge in the first place.

## Silent loss of session or state

**`with db:` on an already-connected connection threw away what it was managing.** The blocking websocket's `__enter__` assigned a fresh socket unconditionally. A websocket *is* the server-side session, so the sign-in went with it and the first statement inside the block came back `NotAllowedError: Anonymous access not allowed` — from a connection the caller had authenticated moments earlier. The discarded socket leaked with its two worker threads. It now goes through `connect()`, which is idempotent and lock-guarded. Both HTTP transports had the same shape without the auth consequence: entering replaced the pooled session and only the replacement was ever closed, so each re-entry leaked a connection pool.

**`connect()` after `close()` on the embedded engine reported success and then refused every request.** `close()` shuts the datastore down for good — the handle it leaves behind answers `Database connection is closed` — while `connect()` on the native side was a no-op returning `Ok(())`. The websocket transports have always reopened here. A reopened `memory://` database starts empty, which is documented and asserted: the datastore that held the data was shut down, the same way a reconnected websocket gets a new server-side session. A file-backed engine reopens its store and keeps its data.

## Privilege

**Embedded `invalidate()` *raised* privilege instead of dropping it.** The embedded datastore was built with authentication disabled, which makes the engine skip every permission check for an anonymous session — and `invalidate()`, whose whole job is to drop the caller's identity, resets the session to exactly that. Measured on a record user: before invalidating, `SELECT * FROM secret` on a `PERMISSIONS NONE` table returned `[]` and `INFO FOR ROOT` was denied; after invalidating, both succeeded. Over websocket and HTTP the same call has always left the session anonymous and denied.

The datastore is now built with `.with_auth(true)` and the implicit session seeded with `Session::owner()`. Opening an embedded database and using it without signing in is the documented way to use it and is unchanged — the identity is now explicit rather than implied by a disabled check, so dropping it drops something. All 53 embedded tests pass, including a new one asserting a fresh connection still has full access.

## Wedged connections and leaks

**An async websocket used from a second event loop failed with a bare `ValueError` and then stayed broken.** Every awaiting caller's future is created on the loop the socket was opened on. Used from another — two `asyncio.run` calls is enough — the first `await` failed inside asyncio with `The future belongs to a different loop than the one specified as the loop argument`, which says nothing about connections or event loops, and the request then sat in `qry` so every later call failed the same way. It now raises `ConnectionUnavailableError` naming the problem and the fix. Reconnecting silently instead would have traded this for the failure above: a new socket is a new session, so the next statement would come back `NotAllowedError`. `close()` gained a cross-loop path so the advice it gives — build a new connection — leaves the old one able to release its socket.

**An async websocket dropped without `close()` never released anything.** `asyncio.create_task(self._recv_task())` gave the running loop a strong reference to the connection: loop → task → coroutine → `self`. A connection whose last user reference was dropped was therefore never collected, so no finaliser could run and its socket, file descriptor, reader task and keepalive task stayed for the life of the process — and because `asyncio.run` closes its loop, the leftovers also printed `Task was destroyed but it is pending!` on the way out, which reads as a bug in the caller's code. Measured before: 40 dropped connections, 40 held descriptors. After: a constant +2 regardless of count. The reader is now a module-level function holding a weak reference, and `__del__` releases the socket and warns with `ResourceWarning`, matching the blocking transport.

## Errors that named nothing

**A bare `Range` as a resource target.** It reached a `":" in resource` test and came back as `TypeError: argument of type 'Range' is not iterable`, naming neither the argument nor what was wrong with it. Worse, the catch-all message right next to that test told callers to "pass a RecordID, Table, or Range instance" — the SDK's own advice led straight into the failure. A range names no table, so it now raises `SurrealError` saying so and giving the working spelling.

**A record whose fields do not match an `into=` model.** `Person.__init__() got an unexpected keyword argument 'active'`, raised from inside the model, naming neither `into=` nor the record — and outside the `SurrealError` tree, so `except SurrealError` missed it. It now names both sides and what to do:

```
into=Person could not be built from this record: Person.__init__() got an
unexpected keyword argument 'active'. The record has ['active', 'id']; Person
accepts ['id', 'name']. Add the missing field(s) to the model, give them
defaults, or select only the columns it declares.
```

## Documentation

Two README blocks were wrong in ways only running them shows, so they are now *run* by `test_readme_examples_run.py` rather than only read by `test_examples_use_the_real_api.py`:

- the `into=` block declared a two-field `Person` and then wrote a third field to the table, so the very next line raised the error above;
- the sync block's last statement was `db.query("DELETE temp_data;")` against a table nothing had created — a `NotFoundError` on 3.x.

Also added: a **Record ranges** section covering the `RecordID`-with-`Range` target, the bare-`Range` refusal, and the typing caveat (the `@overload`s resolve on the static type `RecordID`, which says nothing about the id, so a range target reads as `dict | None` while returning a list); and a sixth entry in *Talking to a SurrealDB 2.x server* — `DELETE` on a table that does not exist raises on 3.x and returns an empty result on 2.x, verified against all three servers.

`Bound`, `BoundIncluded` and `BoundExcluded` are now exported. `Range` was exported without them, so the one exported name could not be constructed from the public package.

The README's existing claim that a schemafull `set<T>` field rejects a plain list on 3.x was re-checked across `create`, `insert`, `query ... CONTENT` and `update` on 2.0.5, 2.3.10 and 3.2.3. It is accurate as written; no change.

## Verification

- Full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3**: 1384 passed on 3.x, 1346 passed / 38 skipped on each 2.x.
- Every fix **mutation-tested**: reverted one at a time, confirmed the new tests fail, restored. The embedded auth fix was mutation-tested through a full `maturin develop --release` rebuild in both directions.
- `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.
- Run from an installed wheel in a clean virtualenv, with no `./src` on `PYTHONPATH`.
