### PR TITLE
Make four tests from the last PR actually hold

### DIFF
--- a/tests/unit_tests/connections/test_async_ws_lifetime.py
+++ b/tests/unit_tests/connections/test_async_ws_lifetime.py
@@ -85,7 +85,19 @@ def test_close_works_from_a_different_loop(
     connection_params: dict[str, Any],
 ) -> None:
     """Otherwise the advice the error gives - build a new connection - leaves
-    the old one with no way to release its socket."""
+    the old one with no way to release its socket.
+
+    The descriptor is what this asserts on, not the two attributes. Checking
+    only that ``socket`` and ``recv_task`` are ``None`` is satisfied by an
+    implementation that forgets the socket without closing it, which is the
+    failure this branch exists to prevent: gutting the branch body down to
+    ``self.socket = None`` left all nine tests in this file green while the
+    connection leaked its descriptor.
+
+    ``state`` is no use here - it is the websocket protocol's own state, and a
+    socket closed underneath the protocol still reports ``OPEN``. ``fileno()``
+    returning ``-1`` is what says the descriptor is gone.
+    """
     connection = AsyncWsSurrealConnection(connection_params["ws_url"])
     first = asyncio.new_event_loop()
     try:
@@ -93,10 +105,14 @@ def test_close_works_from_a_different_loop(
     finally:
         first.close()
 
+    raw = connection.socket.transport._sock  # pyright: ignore[reportPrivateUsage]
+    assert raw.fileno() != -1, "precondition: the descriptor is open to begin with"
+
     asyncio.run(connection.close())
 
     assert connection.socket is None
     assert connection.recv_task is None
+    assert raw.fileno() == -1, "close() forgot the socket instead of releasing it"
 
 
 async def test_one_loop_is_unaffected(connection_params: dict[str, Any]) -> None:
@@ -156,22 +172,41 @@ async def test_dropping_connections_does_not_accumulate_descriptors(
     """A counter, because the leak only shows as a program stays up.
 
     Each connection used to keep its file descriptor for the life of the
-    process, so a loop that built and discarded them ran out. The bound is
-    generous - the loop's own bookkeeping moves a little - but it does not
-    scale with the number of connections, which is the point.
+    process, so a loop that built and discarded them ran out.
+
+    The settle before the baseline is load-bearing, not hygiene. Without it
+    this test passed against the *unfixed* reader whenever the file ran in its
+    normal order: the tests above leave collectable garbage, the ``gc.collect()``
+    calls inside the loop below released those descriptors, and the credit
+    cancelled out the eight this loop was leaking - measured delta 7 against a
+    bound of 8. Alone, the same test failed at 10. A guard that only holds when
+    it runs first is not a guard, and the bound was loose enough to hide half a
+    leak on top.
     """
+    # Whatever ran before this has to be finished releasing before the
+    # measurement starts, or its descriptors are counted as this loop's.
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0.1)
+
+    connections = 8
     baseline = _open_fds()
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", ResourceWarning)
-        for _ in range(8):
+        for _ in range(connections):
             connection = await _signed_in(connection_params)
             del connection
             gc.collect()
         await asyncio.sleep(0.3)
         gc.collect()
 
-    assert _open_fds() - baseline < 8
+    leaked = _open_fds() - baseline
+    # Held descriptors must not scale with the number of connections. Fixed,
+    # this is 0-2 whatever the order; unfixed it is one per connection.
+    assert leaked < connections // 2, (
+        f"{leaked} descriptors held after {connections} dropped connections"
+    )
 
 
 async def test_dropping_an_open_connection_warns(

--- a/tests/unit_tests/connections/test_context_manager_reentry.py
+++ b/tests/unit_tests/connections/test_context_manager_reentry.py
@@ -104,16 +104,40 @@ async def test_async_http_reuses_the_pooled_session(
             )
 
 
-async def test_async_http_replaces_a_closed_session(
+async def test_async_http_reopens_after_exiting(
     connection_params: dict[str, Any],
 ) -> None:
-    """Reuse is of an *open* session; a closed one is no use to anybody."""
+    """``__aexit__`` nulls the session, so re-entering opens a fresh one."""
     connection = AsyncHttpSurrealConnection(connection_params["url"])
     async with connection:
         pass
     async with connection:
         session = connection._session  # pyright: ignore[reportPrivateUsage]
         assert session is not None and not session.closed
+
+
+async def test_async_http_replaces_a_session_closed_out_from_under_it(
+    connection_params: dict[str, Any],
+) -> None:
+    """Reuse is of an *open* session; a closed one is no use to anybody.
+
+    Reached by closing the session in place rather than by exiting the block:
+    ``close()`` ends with ``self._session = None``, so the ordinary paths never
+    leave a session that is both attached and closed, and a test that went
+    through them only ever exercised the ``is None`` half of the guard. Dropping
+    ``or self._session.closed`` left the whole suite green.
+    """
+    connection = AsyncHttpSurrealConnection(connection_params["url"])
+    async with connection:
+        stale = connection._session  # pyright: ignore[reportPrivateUsage]
+        assert stale is not None
+        await stale.close()
+        assert stale.closed
+
+        async with connection:
+            fresh = connection._session  # pyright: ignore[reportPrivateUsage]
+            assert fresh is not stale, "a closed session was reused"
+            assert fresh is not None and not fresh.closed
 
 
 @pytest.mark.parametrize("attempts", [3])

--- a/tests/unit_tests/connections/test_record_range_targets.py
+++ b/tests/unit_tests/connections/test_record_range_targets.py
@@ -162,6 +162,34 @@ def test_update_returns_every_record_it_wrote(
     ]
 
 
+@pytest.mark.parametrize("operation", ["delete", "update", "select"])
+def test_a_range_matching_one_record_still_returns_a_list(
+    blocking_ws_connection: BlockingWsSurrealConnection, operation: str
+) -> None:
+    """The case that actually exercises the unwrap.
+
+    The builder collapses a *single-element* list and leaves anything longer
+    alone, so a range over three rows never reaches that branch: the
+    ``delete``/``update`` tests above passed with the defect still in place.
+    Only a range that matches exactly one record tells the two apart - it comes
+    back as a bare ``dict`` when the target is misclassified as single-record,
+    and as a one-element ``list`` when it is not.
+    """
+    table = _rows(blocking_ws_connection)
+    one = RecordID(table, Range(BoundIncluded(2), BoundIncluded(2)))
+
+    result: Any = (
+        blocking_ws_connection.update(one, {"n": 9})
+        if operation == "update"
+        else getattr(blocking_ws_connection, operation)(one)
+    )
+
+    assert isinstance(result, list), (
+        f"{operation}() collapsed a one-record range to a single record"
+    )
+    assert _ids(result) == [2]
+
+
 def test_into_maps_every_record_in_the_range(
     blocking_ws_connection: BlockingWsSurrealConnection,
 ) -> None:


### PR DESCRIPTION
A regression review of #331 found that four of the tests it added pass against the code they exist to guard. The shipped behaviour is correct in every case — this PR changes no `src/` code at all — but the guards were not, so a future revert of any of those fixes would have shipped silently.

The root cause is one mistake repeated four times: mutation testing checked that the *file* went red, not that the test written for the fix did. Every mutation was caught by something, so each one looked verified.

## The fd-leak guard was passing against the unfixed reader

`test_dropping_connections_does_not_accumulate_descriptors` passed against the pre-#331 reader whenever the file ran in its normal order — which is how pytest and CI run it. It only failed in isolation, which is the one way I happened to check it.

The tests above it leave collectable garbage; the `gc.collect()` calls inside its own loop released those descriptors; and the credit cancelled out the eight the loop was leaking. Measured delta 7, against a bound of 8. Alone, the same test measured 10 and failed.

It now settles the process before taking the baseline, so nothing else's descriptors are counted as this loop's, and the bound scales with the connection count instead of sitting just above a full leak. Against the unfixed reader:

```
E   AssertionError: 8 descriptors held after 8 dropped connections
```

in file order and whole-directory order alike.

## The delete/update range tests never exercised the unwrap

Both used a three-row range. The builder collapses a *single-element* list and leaves anything longer alone, so a three-row range never reaches that branch — and both tests passed with `_is_single_record_operation` reverted to `return True`. Only a range matching exactly one record tells the two spellings apart: it comes back a bare `dict` when the target is misclassified and a one-element `list` when it is not. That is now a parametrised case across `delete`, `update` and `select`.

## Cross-loop close was asserted by attribute, not by effect

`test_close_works_from_a_different_loop` asserted only that `socket` and `recv_task` were `None`, which any implementation that forgets the socket without closing it satisfies. Gutting the cross-loop branch down to `self.socket = None` left all nine tests in the file green while the descriptor leaked.

It now asserts the descriptor is actually gone. `state` is no use here — it is the websocket protocol's own state and still reports `OPEN` when the socket is closed underneath it — so the assertion is on `fileno()` returning `-1`.

## The closed-HTTP-session arm was unreachable

`test_async_http_replaces_a_closed_session` never reached the arm it names: `close()` always ends with `self._session = None`, so no public path leaves a session both attached and closed. Dropping `or self._session.closed` left the whole suite green. It now closes the session in place to reach that state, and the plain reopen-after-exit case keeps its own test under a name that says what it actually does.

## Verification

The fix for the process, not just the four tests: a per-test mutation harness that names, for each mutation, the tests that MUST fail — and checks them in both file order and whole-directory order rather than in isolation.

```
[ok     ] §1 RecordID(table, Range) treated as single-record again
[ok     ] §5 bare Range no longer refused
[ok     ] §2 blocking ws __enter__ replaces the socket again
[ok     ] §2 async http __aenter__ replaces the session again
[ok     ] §2 async http drops only the closed-session arm
[ok     ] §2 blocking http __enter__ replaces the session again
[ok     ] §3 embedded connect() no longer reopens a closed engine
[ok     ] §4 event-loop guard removed
[ok     ] §4 cross-loop close forgets instead of releasing
[ok     ] §7 __del__ no longer releases the socket
[ok     ] §7 reader holds the connection strongly again
[ok     ] §8 into= mapping error unwrapped again

Every mutation is caught by the specific test written for it, in both orders.
```

Two of those twelve — the cross-loop close and the closed-session arm — caught nothing at all before this PR.

Also: full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3** (1388 passed on 3.x; 1350 passed / 38 skipped on each 2.x); the three edited files run twelve times over with no flakes, and the whole `connections` directory three times; `ruff`, `mypy src/`, `mypy tests/`, `pyright src/` all clean.
