### PR TITLE
Refuse the arguments RecordID and Table cannot use

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,38 @@ row = await db.select(RecordID("person", "tobie"))  # dict | None
 rows = await db.select(Table("person"))             # list
 ```
 
+#### What a `RecordID` and a `Table` accept
+
+Both constructors check their arguments, so a mistake raises `TypeError` at the
+line that made it rather than coming back from the server as `Parse error`.
+
+A **table name** must be a `str`, and that is the only rule — SurrealDB accepts
+any string, including one that is empty, has spaces, is unicode, starts with a
+digit, or contains a colon.
+
+A **record id** must be one of `str`, `int`, `uuid.UUID`, `list`, `tuple`,
+`dict`, or a `Range` (see below). The union is exported as `RecordIdValue` if
+you want to annotate against it. Notably rejected: `None`, `bool` (Python's
+`bool` is an `int`, but SurrealDB has no boolean id), `float`, and `bytes` —
+the server refuses all of them.
+
+```python
+RecordID("person", "tobie")     # ok
+RecordID("person", ["a", 1])    # ok — composite ids are arrays or objects
+RecordID(1, "tobie")            # TypeError: the arguments look swapped
+Table(None)                     # TypeError: name must be a str
+```
+
+The check applies to values *you* construct. Records decoded from a response
+bypass it, so that a future server sending an id type this SDK does not know
+about still reads back — `RecordID.id` is therefore typed more widely than
+`RecordIdValue`, and is not guaranteed to be one of the types above.
+
+> Before 3.0.0, `Table(None)` was not rejected anywhere and
+> `db.insert(Table(None), rows)` **succeeded**, writing to a table literally
+> named `None`. If you have code that builds a table name dynamically, that is
+> the case to check.
+
 #### Record ranges
 
 A `RecordID` whose id is a `Range` targets every record in that range, and every

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -42,7 +42,11 @@ from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import Bound, BoundExcluded, BoundIncluded, Range
 from surrealdb.data.types.set import SurrealSet
-from surrealdb.data.types.record_id import RecordID, escape_identifier
+from surrealdb.data.types.record_id import (
+    RecordID,
+    RecordIdValue,
+    escape_identifier,
+)
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     AlreadyExistsDetailKind,
@@ -126,6 +130,10 @@ __all__ = [
     "BoundIncluded",
     "BoundExcluded",
     "RecordID",
+    # The id types SurrealDB accepts. `RecordID.id` is deliberately wider
+    # (a decoded value can be anything a server sends), so this is the name to
+    # annotate or cast a value you construct against.
+    "RecordIdValue",
     "Datetime",
     "PreciseDatetime",
     "Null",

--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -138,10 +138,17 @@ def tag_decoder(
         return None
 
     elif tag.tag == constants.TAG_RECORD_ID:
-        return RecordID(tag.value[0], tag.value[1])
+        # `_unchecked`, not the constructor: the constructor validates the id
+        # type, and applying that to a value the *server* chose would turn a
+        # future server's new id type into an unreadable record - and lose the
+        # rest of the response with it, since this runs inside the decode of the
+        # whole frame.
+        return RecordID._unchecked(  # pyright: ignore[reportPrivateUsage]
+            tag.value[0], tag.value[1]
+        )
 
     elif tag.tag == constants.TAG_TABLE_NAME:
-        return Table(tag.value)
+        return Table._unchecked(tag.value)  # pyright: ignore[reportPrivateUsage]
 
     elif tag.tag == constants.TAG_BOUND_INCLUDED:
         return BoundIncluded(tag.value)

--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -4,13 +4,16 @@ Defines the data type for the record ID.
 
 from __future__ import annotations
 
+import uuid as uuid_module
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Union, cast
 
 from pydantic_core import core_schema
 from pydantic_core.core_schema import ValidationInfo
 
-from surrealdb.data.types.table import Table
+from surrealdb.data.types.range import Range
+from surrealdb.data.types.set import SurrealSet
+from surrealdb.data.types.table import Table, table_name_type_error
 from surrealdb.errors import InvalidRecordIdError
 
 if TYPE_CHECKING:
@@ -18,6 +21,68 @@ if TYPE_CHECKING:
     from pydantic.json_schema import JsonSchemaValue
 
 RecordIdType = Union[str, "RecordID", Table]
+
+#: What SurrealDB accepts as a record id. Exported so callers have a name to
+#: annotate or cast against - ``RecordID.id`` is deliberately wider (see the
+#: attribute's docs), so this is the type to use for a value you construct.
+RecordIdValue = Union[
+    str, int, uuid_module.UUID, "list[Any]", "tuple[Any, ...]", "dict[str, Any]", Range
+]
+
+# The runtime half of `RecordIdValue`. Derived by probing every candidate value
+# against live 2.0.5 and 3.2.3 servers rather than from the documentation: these
+# are exactly the id types a server accepts and hands back, plus `Range`, which
+# is never a *stored* id but is how this SDK spells the `person:1..=3` target.
+#
+# `tuple` earns its place empirically. `RecordID(t, ("a", 1))` round-trips on
+# both servers - cbor2 encodes a tuple as a CBOR array - so leaving it out would
+# have silently broken anyone using composite keys.
+_ID_TYPES: tuple[type, ...] = (str, int, uuid_module.UUID, list, tuple, dict, Range)
+
+# Two allowed types have subclasses the server refuses, and `isinstance` would
+# wave both through: `bool` is a subclass of `int`, and `SurrealSet` is a
+# subclass of `list`. They are excluded before the allowlist is consulted.
+_ID_TYPE_IMPOSTORS: tuple[type, ...] = (bool, SurrealSet)
+
+_ID_TYPE_NAMES = "str, int, uuid.UUID, list, tuple, dict or Range"
+
+
+def _id_type_error(identifier: Any) -> TypeError:
+    """Build the message for a record id of an unusable type.
+
+    Three types get a hint of their own, because the generic "use one of these
+    instead" reads as wrong to the caller who hit them: someone passing a bool
+    knows perfectly well that a bool is an int, someone passing ``None`` has not
+    made a typo at all, and someone passing a float wants to know which way to
+    round.
+    """
+    got = type(identifier).__name__
+    if isinstance(identifier, bool):
+        hint = (
+            " Python's bool is a subclass of int, but SurrealDB has no boolean"
+            " record id - pass 1 or 0 if you meant the numeric id."
+        )
+    elif identifier is None:
+        hint = (
+            " SurrealDB has no NONE record id. To have the server generate one,"
+            " pass the table instead - e.g. db.create(Table('person'), data)."
+        )
+    elif isinstance(identifier, float):
+        hint = (
+            f" SurrealDB has no float record id - use an int, or"
+            f" {str(identifier)!r} for a string id."
+        )
+    elif isinstance(identifier, SurrealSet):
+        hint = (
+            " A SurrealSet is a set on the wire, which is not a record id -"
+            " pass list(...) if you meant an array id."
+        )
+    else:
+        hint = ""
+    return TypeError(
+        f"RecordID() id must be one of {_ID_TYPE_NAMES}, got {got}:"
+        f" {identifier!r}.{hint}"
+    )
 
 
 def escape_identifier(identifier: str) -> str:
@@ -82,25 +147,79 @@ class RecordID:
             escaped id fragment.
     """
 
-    def __init__(self, table_name: str, identifier: Any) -> None:
+    def __init__(self, table_name: str, identifier: RecordIdValue) -> None:
         """
         The constructor for the RecordID class.
 
         Args:
             table_name: The table name associated with the record ID
             identifier: The ID of the row
+
+        Raises:
+            TypeError: if *table_name* is not a string, or *identifier* is not
+                a type SurrealDB accepts as a record id.
+
+        Both arguments used to accept anything at all, and the mistake surfaced
+        only after a round trip: ``RecordID(1, "x")``, ``RecordID("t", 1.5)``
+        and ``RecordID("t", None)`` all encoded cleanly and came back from the
+        server as ``ValidationError: Parse error`` - which names neither the
+        argument nor what was wrong with it, for a mistake that was fully
+        decidable before any I/O.
+
+        The check is *not* an invariant on the attributes: values decoded from
+        the wire bypass it (see :meth:`_unchecked`), so this catches what you
+        construct rather than guaranteeing what ``.id`` holds.
         """
         from surrealdb.types import Value  # imported here to prevent circular import
 
+        if not isinstance(table_name, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise table_name_type_error(
+                "RecordID", table_name, "table_name", identifier
+            )
+        if isinstance(identifier, _ID_TYPE_IMPOSTORS) or not isinstance(
+            identifier, _ID_TYPES
+        ):
+            raise _id_type_error(identifier)
+
         self.table_name: str = table_name
+        #: Deliberately wider than :data:`RecordIdValue`. Every record read back
+        #: is built through :meth:`_unchecked`, so a server the SDK has not been
+        #: taught about can put anything here; narrowing the annotation would
+        #: describe hand-built ids correctly and every decoded one wrongly.
         self.id: Value = cast(Value, identifier)
+
+    @classmethod
+    def _unchecked(cls, table_name: Any, identifier: Any) -> RecordID:
+        """Build a ``RecordID`` without validating, for the CBOR decoder.
+
+        The decoder builds one of these for every record it reads, so a check
+        here would run against whatever a server sends rather than against
+        anything a caller wrote - and a future server's new id type would stop
+        the record being *readable* at all. That is strictly worse than the
+        late error this validation exists to replace: you can work around a bad
+        write, but not a record you cannot load.
+
+        Worse still, ``tag_decoder`` runs inside the decode of a whole response,
+        so raising here loses every other row with it. This module has shipped
+        that failure twice already - the empty-``Duration`` ``IndexError`` and
+        the ``set``-of-dicts ``unhashable type`` - and neither is worth a third.
+        """
+        record = object.__new__(cls)
+        record.table_name = table_name
+        record.id = identifier
+        return record
 
     def __str__(self) -> str:
         # Only escape if the identifier is a string
         if isinstance(self.id, str):
             return f"{self.table_name}:{escape_identifier(self.id)}"
         if isinstance(self.id, bytes):
-            return f"{self.table_name}:{escape_identifier(self.id.decode())}"
+            # Rendered, not decoded. `_unchecked` means a wire value can still
+            # be bytes, so this branch is live - and decoding it was wrong
+            # twice over: it raised `UnicodeDecodeError` on anything that was
+            # not UTF-8, and it rendered b"xy" as `t:xy`, which is a *different*
+            # record from the one it names.
+            return f"{self.table_name}:{self.id!r}"
         return f"{self.table_name}:{self.id}"
 
     def __repr__(self) -> str:

--- a/src/surrealdb/data/types/table.py
+++ b/src/surrealdb/data/types/table.py
@@ -2,9 +2,48 @@
 Defines a Table class to represent a database table by its name.
 """
 
-from typing import Union
+from typing import Any, Union
 
 TableType = Union[str, "Table"]
+
+
+def table_name_type_error(
+    owner: str,
+    table_name: Any,
+    argument: str = "name",
+    identifier: Any = None,
+) -> TypeError:
+    """Build the message for a table name that is not a string.
+
+    Shared with :class:`~surrealdb.data.types.record_id.RecordID`, and it lives
+    here rather than there because ``record_id`` already imports this module
+    and the reverse would be a cycle.
+
+    Only the *type* is checked, never the content: SurrealDB accepts any string
+    as a table name - empty, spaces, unicode, a leading digit, all digits, even
+    one containing a colon - so there is nothing else to be sure of.
+
+    *identifier*, when given, is the other argument to ``RecordID``. It is used
+    only to spot swapped arguments, which is much the likeliest way a non-string
+    table name gets here.
+    """
+    got = type(table_name).__name__
+    hint = ""
+    if isinstance(identifier, str) and not isinstance(table_name, str):
+        hint = (
+            f" The arguments look swapped - did you mean"
+            f" {owner}({identifier!r}, {table_name!r})?"
+        )
+    elif isinstance(table_name, Table):
+        hint = f" Pass the name itself: {owner}(table.table_name, ...)."
+    elif table_name is None:
+        hint = (
+            " A table name is always a string, so there is no table this could"
+            " have meant."
+        )
+    return TypeError(
+        f"{owner}() {argument} must be a str, got {got}: {table_name!r}.{hint}"
+    )
 
 
 class Table:
@@ -21,8 +60,35 @@ class Table:
 
         Args:
             table_name: The name of the table.
+
+        Raises:
+            TypeError: if *table_name* is not a string.
+
+        A non-string name is refused here because nothing downstream refused
+        it. ``Table(None)`` reached the server as the *table named* ``None``
+        and the write succeeded: ``db.insert(Table(None), [row])`` returned a
+        plausible-looking record, ``SELECT * FROM ⟨None⟩`` found it, and
+        ``INFO FOR DB`` listed a table called ``None`` - on both SurrealDB 2.x
+        and 3.x. The row was really written, just nowhere any query against the
+        intended table would ever look. ``Table(123)`` failed differently and
+        no better, with ``TypeError: 'int' object is not iterable`` raised from
+        inside the SDK's identifier escaping, naming neither the argument nor
+        the mistake.
         """
-        self.table_name = table_name
+        if not isinstance(table_name, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise table_name_type_error("Table", table_name)
+        self.table_name: str = table_name
+
+    @classmethod
+    def _unchecked(cls, table_name: Any) -> "Table":
+        """Build a ``Table`` without validating, for the CBOR decoder.
+
+        See :meth:`RecordID._unchecked` for why the decode path bypasses the
+        check rather than sharing it.
+        """
+        table = object.__new__(cls)
+        table.table_name = table_name
+        return table
 
     def __str__(self) -> str:
         """

--- a/tests/unit_tests/connections/test_async_ws_resilience.py
+++ b/tests/unit_tests/connections/test_async_ws_resilience.py
@@ -31,7 +31,14 @@ _BUDGET_SECONDS = 15.0
         # serve here; it no longer reaches the server, because the encoder now
         # refuses an int outside SurrealDB's signed 64-bit range rather than
         # letting it wrap silently.
-        ("record id with a null table", lambda db: db.select(RecordID(None, 1))),
+        # `_unchecked`, not the constructor: `RecordID(None, 1)` is now a
+        # `TypeError` before anything is sent. This test is about what the
+        # reader does when the *server* rejects a frame, so the frame still
+        # has to reach the wire.
+        (
+            "record id with a null table",
+            lambda db: db.select(RecordID._unchecked(None, 1)),  # pyright: ignore[reportPrivateUsage]
+        ),
     ],
 )
 async def test_connection_survives_a_protocol_error(

--- a/tests/unit_tests/connections/test_context_manager_reentry.py
+++ b/tests/unit_tests/connections/test_context_manager_reentry.py
@@ -144,14 +144,24 @@ async def test_async_http_replaces_a_session_closed_out_from_under_it(
 def test_the_websocket_session_survives_every_reentry(
     connection_params: dict[str, Any], attempts: int
 ) -> None:
-    """The regression as reported: sign in once, use ``with`` afterwards."""
+    """The regression as reported: sign in once, use ``with`` afterwards.
+
+    ``INFO FOR DB``, not ``RETURN 1``. A replacement socket is a new
+    server-side session with no namespace or database selected - but it can
+    still evaluate ``RETURN 1``, which touches nothing the session owns, so
+    that assertion passed with the socket being swapped underneath it and the
+    test caught nothing. The mutation harness found it: reverting
+    ``__enter__`` to assign a fresh socket left this test green.
+    ``INFO FOR DB`` needs the session, and fails with ``Specify a namespace to
+    use`` without it.
+    """
     connection = BlockingWsSurrealConnection(connection_params["ws_url"])
     connection.signin(connection_params["vars_params"])
     connection.use(connection_params["namespace"], connection_params["database_name"])
 
     for _ in range(attempts):
         with connection:
-            assert connection.query("RETURN 1").first() == 1
+            assert connection.query("INFO FOR DB").first() is not None
         connection.signin(connection_params["vars_params"])
         connection.use(
             connection_params["namespace"], connection_params["database_name"]

--- a/tests/unit_tests/connections/test_table_name_misplacement.py
+++ b/tests/unit_tests/connections/test_table_name_misplacement.py
@@ -1,0 +1,73 @@
+"""A non-string table name no longer writes real data somewhere unfindable.
+
+This is the half of constructor validation that was a data bug rather than a
+message one, so it is asserted against a live server rather than offline.
+
+``Table(None)`` was not rejected anywhere: not by the constructor, not by the
+encoder, and not by the server. ``insert(Table(None), [row])`` *succeeded*,
+returned a plausible-looking record, and put the row in a table literally named
+``None`` - confirmed on SurrealDB 2.0.5 and 3.2.3 alike, with ``INFO FOR DB``
+listing the table afterwards. Nothing anywhere said the write had gone
+somewhere other than where it was aimed.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.table import Table
+
+
+@pytest.mark.parametrize("name", [None, 123, b"person"])
+def test_a_non_string_table_name_never_reaches_the_server(
+    blocking_ws_connection: BlockingWsSurrealConnection, name: Any
+) -> None:
+    with pytest.raises(TypeError):
+        blocking_ws_connection.insert(Table(name), [{"marker": "x"}])
+
+
+def test_nothing_is_written_to_a_table_named_none(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The observable consequence, asked of the database.
+
+    Not "did it raise" but "is the row anywhere", because the failure mode was
+    a successful-looking write that landed in the wrong place.
+    """
+    marker = uuid.uuid4().hex[:12]
+
+    with pytest.raises(TypeError):
+        blocking_ws_connection.insert(Table(None), [{"marker": marker}])
+
+    # ⟨None⟩ is the table the row used to land in. It should not exist at all,
+    # but a previous run of the old code could have created it - so search it
+    # for this run's marker rather than asserting it is absent.
+    blocking_ws_connection.query(
+        "DEFINE TABLE IF NOT EXISTS ⟨None⟩ SCHEMALESS"
+    ).execute()
+    stray = blocking_ws_connection.query(
+        "SELECT * FROM ⟨None⟩ WHERE marker = $m", vars={"m": marker}
+    ).first()
+
+    assert stray == [], f"the row was written to a table named None: {stray!r}"
+
+
+def test_a_valid_table_name_still_writes(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The neighbouring behaviour the guard must not disturb.
+
+    ``"has space"`` is here because the guard checks the *type* only - the
+    server takes any string, and a name needing escaping must keep working.
+    A name with non-ASCII letters is deliberately not exercised: ``insert``
+    rejects one today for an unrelated reason (``escape_identifier`` treats
+    accented letters as safe and leaves them unquoted, and ``insert`` is the
+    one path that inlines the table name), which predates this change and is
+    tracked separately.
+    """
+    for name in (f"tbl_{uuid.uuid4().hex[:8]}", "has space"):
+        written = blocking_ws_connection.insert(Table(name), [{"marker": "ok"}])
+        assert isinstance(written, list) and written
+        assert written[0]["id"].table_name == name

--- a/tests/unit_tests/connections/test_ws_protocol_errors.py
+++ b/tests/unit_tests/connections/test_ws_protocol_errors.py
@@ -54,7 +54,14 @@ def _within_budget(call: Any) -> tuple[str, Any]:
 @pytest.mark.parametrize(
     ("label", "make_call"),
     [
-        ("record id with a null table", lambda db: db.select(RecordID(None, 1))),
+        # `_unchecked`, not the constructor: `RecordID(None, 1)` is now a
+        # `TypeError` before anything is sent. These tests are about what
+        # the reader does when the *server* rejects a frame, so the frame
+        # still has to reach the wire.
+        (
+            "record id with a null table",
+            lambda db: db.select(RecordID._unchecked(None, 1)),  # pyright: ignore[reportPrivateUsage]
+        ),
     ],
 )
 def test_protocol_error_raises_instead_of_hanging(
@@ -75,7 +82,9 @@ def test_connection_still_usable_after_a_protocol_error(
 ) -> None:
     """The socket survives the error frame, so the connection is not poisoned."""
     with pytest.raises(SurrealError):
-        blocking_ws_connection.select(RecordID(None, 1))
+        blocking_ws_connection.select(
+            RecordID._unchecked(None, 1)  # pyright: ignore[reportPrivateUsage]
+        )
 
     assert blocking_ws_connection.query("RETURN 1").first() == 1
 

--- a/tests/unit_tests/connections/test_ws_request_isolation.py
+++ b/tests/unit_tests/connections/test_ws_request_isolation.py
@@ -29,7 +29,14 @@ from surrealdb.errors import SurrealError, TransportTimeoutError
 # A record id whose table name is not a string. The server cannot parse the
 # frame, so it answers with an error carrying no `id` - the shape this file is
 # about. Every non-string table name behaves the same way.
-UNPARSEABLE: Any = RecordID(1, "x")  # type: ignore[arg-type]
+#
+# Built through `_unchecked` because `RecordID(1, "x")` is now a `TypeError` at
+# the constructor - which is the point of that validation, and is why this file
+# has to reach past it. What is under test here is the reader's behaviour when
+# the *server* rejects a frame, so the frame still has to be sendable; the
+# constructor guard stops callers making this mistake by accident, it does not
+# change what the wire does with one.
+UNPARSEABLE: Any = RecordID._unchecked(1, "x")  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_a_bad_request_does_not_fail_its_neighbours(

--- a/tests/unit_tests/data_types/test_constructor_validation.py
+++ b/tests/unit_tests/data_types/test_constructor_validation.py
@@ -1,0 +1,280 @@
+"""``RecordID`` and ``Table`` refuse arguments SurrealDB cannot use.
+
+Both constructors used to accept anything at all, and the two halves failed
+very differently.
+
+``Table`` was a data bug, not a message one. ``Table(None)`` reached the server
+as the *table named* ``None`` and the write succeeded: ``insert(Table(None),
+[row])`` returned a plausible-looking record, ``SELECT * FROM ⟨None⟩`` found it,
+and ``INFO FOR DB`` listed a table called ``None`` - on 2.x and 3.x alike. The
+row was really written, just nowhere any query against the intended table would
+look. ``Table(123)`` died inside ``escape_identifier`` with ``TypeError: 'int'
+object is not iterable``, naming neither argument nor mistake.
+
+``RecordID`` was the message half: every bad id encoded cleanly and came back
+from the server as ``ValidationError: Parse error``, which names nothing, for a
+mistake decidable before any I/O.
+
+The accept set is empirical, not from the documentation - each type below was
+created server-side and read back on live 2.0.5 and 3.2.3 servers. ``tuple`` is
+in it for that reason: it round-trips today, so rejecting it would have broken
+composite-key users silently.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.data.types.range import BoundIncluded, Range
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.set import SurrealSet
+from surrealdb.data.types.table import Table
+
+# --------------------------------------------------------------- what is legal
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        pytest.param("abc", id="str"),
+        pytest.param("", id="empty-str"),
+        pytest.param("has space", id="str-with-space"),
+        pytest.param("héllo→", id="unicode-str"),
+        pytest.param(1, id="int"),
+        pytest.param(-5, id="negative-int"),
+        pytest.param(9223372036854775807, id="i64-max"),
+        pytest.param(uuid.uuid4(), id="uuid"),
+        pytest.param(["a", 1], id="list"),
+        pytest.param(("a", 1), id="tuple"),
+        pytest.param({"a": 1}, id="dict"),
+        pytest.param([1.5, None, True], id="list-with-inner-floats"),
+        pytest.param({"k": 1.5}, id="dict-with-inner-float"),
+        pytest.param(Range(BoundIncluded(1), BoundIncluded(3)), id="range"),
+    ],
+)
+def test_every_id_the_server_accepts_is_accepted(identifier: Any) -> None:
+    """Including the two that a stricter check would wrongly refuse.
+
+    The allowlist is deliberately *shallow*: a list or dict id is accepted
+    whatever it contains, because a recursive check would reject ids that
+    demonstrably round-trip - ``["a", 1.5, None]`` comes back with its types
+    intact even though a bare ``1.5`` is not a legal id.
+    """
+    assert RecordID("person", identifier).id == identifier
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["person", "", "has space", "héllo", "1tbl", "12345", "a:b"],
+)
+def test_every_table_name_the_server_accepts_is_accepted(name: str) -> None:
+    """Only the type is checked, never the content.
+
+    SurrealDB takes any string as a table name - all of these were created and
+    read back on a live server - so there is nothing else to be sure of.
+    """
+    assert Table(name).table_name == name
+    assert RecordID(name, 1).table_name == name
+
+
+# --------------------------------------------------------------- what is not
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected_in_message"),
+    [
+        pytest.param(None, "no NONE record id", id="none"),
+        pytest.param(True, "subclass of int", id="bool"),
+        pytest.param(1.5, "no float record id", id="float"),
+        pytest.param(b"xy", "bytes", id="bytes"),
+        pytest.param({1, 2}, "set", id="set"),
+        pytest.param(object(), "object", id="object"),
+        pytest.param(Table("person"), "Table", id="table"),
+    ],
+)
+def test_an_id_the_server_refuses_is_refused_here(
+    identifier: Any, expected_in_message: str
+) -> None:
+    with pytest.raises(TypeError) as caught:
+        RecordID("person", identifier)
+
+    message = str(caught.value)
+    assert "RecordID() id must be one of" in message
+    assert expected_in_message in message
+    # The value itself, so the caller can see which one of several it was.
+    assert repr(identifier) in message
+
+
+def test_bool_is_refused_despite_being_an_int() -> None:
+    """``isinstance(True, int)`` is ``True``, so a plain allowlist check lets
+    every boolean through to the server that refuses it."""
+    assert isinstance(True, int)
+
+    with pytest.raises(TypeError) as caught:
+        RecordID("person", True)
+
+    assert "bool" in str(caught.value)
+
+
+def test_a_surreal_set_is_refused_despite_being_a_list() -> None:
+    """The same trap one layer along: ``SurrealSet`` subclasses ``list``, and a
+    set is not a record id on the wire."""
+    assert isinstance(SurrealSet([1]), list)
+
+    with pytest.raises(TypeError) as caught:
+        RecordID("person", SurrealSet([1]))
+
+    assert "SurrealSet" in str(caught.value) or "set" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "name", [None, 123, b"person", 1.5, ["person"], Table("person")]
+)
+def test_a_non_string_table_name_is_refused(name: Any) -> None:
+    with pytest.raises(TypeError) as caught:
+        Table(name)
+    assert "Table() name must be a str" in str(caught.value)
+
+    with pytest.raises(TypeError) as caught:
+        RecordID(name, 1)
+    assert "RecordID() table_name must be a str" in str(caught.value)
+
+
+# --------------------------------------------------------------- the messages
+
+
+def test_swapped_arguments_are_named_as_such() -> None:
+    """``RecordID(1, "x")`` is much more often a swap than a wrong type."""
+    with pytest.raises(TypeError) as caught:
+        RecordID(1, "x")  # type: ignore[arg-type]
+
+    assert "arguments look swapped" in str(caught.value)
+    assert "RecordID('x', 1)" in str(caught.value)
+
+
+def test_a_table_passed_as_a_name_says_what_to_pass_instead() -> None:
+    with pytest.raises(TypeError) as caught:
+        Table(Table("person"))  # type: ignore[arg-type]
+
+    assert "table.table_name" in str(caught.value)
+
+
+def test_none_points_at_server_generated_ids() -> None:
+    """Someone passing ``None`` has not made a typo - they have no id yet, and
+    need a different call rather than a different value."""
+    with pytest.raises(TypeError) as caught:
+        RecordID("person", None)
+
+    assert "db.create(Table('person'), data)" in str(caught.value)
+
+
+def test_the_errors_are_type_errors_not_surreal_errors() -> None:
+    """A wrong argument type is a caller mistake, and this SDK raises builtins
+    for those - the ``SurrealError`` tree is for operational failures."""
+    from surrealdb.errors import SurrealError
+
+    for build in (lambda: RecordID("t", None), lambda: Table(None)):
+        with pytest.raises(TypeError) as caught:
+            build()
+        assert not isinstance(caught.value, SurrealError)
+
+
+# --------------------------------------------------- the decode path is exempt
+
+
+def test_the_decoder_accepts_an_id_type_the_constructor_would_refuse() -> None:
+    """The constraint the whole design turns on.
+
+    The CBOR decoder builds a ``RecordID`` for every record read back. If it
+    validated, a future server's new id type would stop the record being
+    *readable* - and because ``tag_decoder`` runs inside the decode of a whole
+    frame, it would take every other row with it. A bad write is recoverable; a
+    record you cannot load is not.
+    """
+    from surrealdb.cbor import CBORTag, dumps
+    from surrealdb.data import cbor
+    from surrealdb.data.types import constants
+
+    # A float id: refused by the constructor, and by the server - but if one
+    # ever arrives, it has to decode.
+    frame = dumps(CBORTag(constants.TAG_RECORD_ID, ["person", 1.5]))
+    decoded = cbor.decode(frame)
+
+    assert isinstance(decoded, RecordID)
+    assert decoded.id == 1.5
+    assert decoded.table_name == "person"
+
+
+def test_the_decoder_accepts_a_table_name_the_constructor_would_refuse() -> None:
+    from surrealdb.cbor import CBORTag, dumps
+    from surrealdb.data import cbor
+    from surrealdb.data.types import constants
+
+    decoded = cbor.decode(dumps(CBORTag(constants.TAG_TABLE_NAME, 123)))
+
+    assert isinstance(decoded, Table)
+    # Held as `Any`: the attribute is annotated `str`, which is true of every
+    # name a server has ever sent and is exactly what `_unchecked` does not
+    # promise.
+    name: Any = decoded.table_name
+    assert name == 123
+
+
+def test_a_decoded_record_id_re_encodes_unchanged() -> None:
+    """Round-tripping a value the constructor would refuse must still work, or
+    the exemption above buys a readable record you cannot write back."""
+    from surrealdb.cbor import CBORTag, dumps
+    from surrealdb.data import cbor
+    from surrealdb.data.types import constants
+
+    frame = dumps(CBORTag(constants.TAG_RECORD_ID, ["person", 1.5]))
+    decoded = cbor.decode(frame)
+
+    assert cbor.decode(cbor.encode(decoded)) == decoded
+
+
+@pytest.mark.parametrize("cls", [RecordID, Table])
+def test_unchecked_sets_the_same_attributes_as_the_constructor(cls: type) -> None:
+    """Two constructors that must stay in step. Compares the instance dict, so
+    adding a field to ``__init__`` and forgetting ``_unchecked`` fails here
+    rather than as an ``AttributeError`` somewhere downstream.
+    """
+    if cls is RecordID:
+        checked: Any = RecordID("person", 1)
+        unchecked: Any = RecordID._unchecked("person", 1)  # pyright: ignore[reportPrivateUsage]
+    else:
+        checked = Table("person")
+        unchecked = Table._unchecked("person")  # pyright: ignore[reportPrivateUsage]
+
+    assert vars(checked).keys() == vars(unchecked).keys()
+    assert vars(checked) == vars(unchecked)
+    assert checked == unchecked
+
+
+# --------------------------------------------------------------- neighbours
+
+
+def test_parse_still_works() -> None:
+    """``RecordID.parse`` always yields a string id, so it is unaffected - but
+    it goes through the constructor, so it would break if the check were wrong.
+    """
+    assert RecordID.parse("person:tobie") == RecordID("person", "tobie")
+    assert RecordID.parse("person:complex:id").id == "complex:id"
+
+
+def test_a_bytes_id_from_the_wire_renders_without_decoding() -> None:
+    """``__str__``'s bytes branch is live because of ``_unchecked``.
+
+    It used to ``.decode()``, which raised ``UnicodeDecodeError`` on anything
+    that was not UTF-8 and - worse - rendered ``b"xy"`` as ``person:xy``, which
+    names a *different* record from the one it holds.
+    """
+    record = RecordID._unchecked("person", b"\xff\xfe")  # pyright: ignore[reportPrivateUsage]
+
+    rendered = str(record)
+
+    assert rendered == "person:b'\\xff\\xfe'"
+    assert str(RecordID._unchecked("person", b"xy")) != str(  # pyright: ignore[reportPrivateUsage]
+        RecordID("person", "xy")
+    )


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`RecordID` and `Table` accepted absolutely anything, and the two halves failed very differently — only one of them was the error-message problem it looked like from the outside.

**`Table` was silently misplacing data.** `Table(None)` was refused by nothing: not the constructor, not the encoder, not the server. `db.insert(Table(None), rows)` **succeeded**, returned a plausible-looking record, and wrote the row to a table literally named `None`. Verified end to end on SurrealDB 2.0.5 and 3.2.3 alike:

```
insert(Table(None), [{"marker": ...}])  -> SUCCEEDED, row returned
SELECT * FROM ⟨None⟩                     -> finds it
INFO FOR DB tables                       -> 'None' is listed
```

The write really happened. It just landed somewhere no query against the intended table would ever look. `Table(123)` failed differently and no better: `TypeError: 'int' object is not iterable`, raised from inside the SDK's identifier escaping, naming neither the argument nor the mistake.

**`RecordID` was the message half.** Every bad id encoded cleanly and came back from the server as `ValidationError: Parse error` — naming neither the argument nor what was wrong with it, for a mistake fully decidable before any I/O. The connection survives (request correlation was fixed in #326/#330), so this half is diagnostics rather than integrity.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

A table name must be a `str`. That is the whole rule — SurrealDB accepts any string, including one that is empty, has spaces, is unicode, starts with a digit, or contains a colon, so only the type can be checked.

A record id must be one of `str`, `int`, `uuid.UUID`, `list`, `tuple`, `dict` or `Range`, now exported as `RecordIdValue`. The accept set is empirical, not from the docs: every candidate was created server-side and read back on live 2.0.5 and 3.2.3 servers.

Three traps, all confirmed against those servers rather than reasoned about:

- **`tuple` has to be in the allowlist.** `RecordID(t, ("a", 1))` round-trips on both servers — cbor2 encodes a tuple as a CBOR array — so omitting it would have silently broken composite-key users. An earlier draft of this change asserted tuples were already broken; that was wrong, and it is the correction that mattered most.
- **`bool` has to be excluded explicitly**, because `isinstance(True, int)` is `True` and the server rejects boolean ids.
- **`SurrealSet` likewise**, since it subclasses `list` and a set is not a record id on the wire.

The allowlist is deliberately **shallow**: a list or dict id is accepted whatever it contains, because `["a", 1.5, None]` round-trips with its types intact even though a bare `1.5` is not a legal id.

### The decode path is exempt, on purpose

`cbor.py` builds a `RecordID` for **every record read back**. Validating there would turn a future server's new id type into an *unreadable record* — and because `tag_decoder` runs inside the decode of a whole frame, it would lose every other row with it. This module has shipped that exact failure twice already (the empty-`Duration` `IndexError`, the set-of-dicts `unhashable type`).

Decoding therefore goes through `RecordID._unchecked` / `Table._unchecked`, which makes the honest consequence explicit rather than glossing it: **the allowlist is not a class invariant.** `.id` stays annotated `Value`, wider than `RecordIdValue`, because narrowing it would describe hand-built ids correctly and every decoded one wrongly. This catches what you construct; it does not promise what `.id` holds.

That is also why three existing tests now build their deliberately-unparseable frames through `_unchecked` — they are about what the *reader* does when the server rejects a frame, so the frame still has to reach the wire.

### Messages

```
RecordID(1, "x")     -> RecordID() table_name must be a str, got int: 1.
                        The arguments look swapped - did you mean RecordID('x', 1)?
RecordID("t", True)  -> RecordID() id must be one of str, int, uuid.UUID, list, tuple,
                        dict or Range, got bool: True. Python's bool is a subclass of
                        int, but SurrealDB has no boolean record id - pass 1 or 0 if you
                        meant the numeric id.
RecordID("t", None)  -> ... SurrealDB has no NONE record id. To have the server generate
                        one, pass the table instead - e.g. db.create(Table('person'), data).
Table(None)          -> Table() name must be a str, got NoneType: None.
```

`TypeError`, not a `SurrealError`: a wrong argument type is a caller mistake, and this SDK deliberately raises builtins for those.

### Breaking changes

- `RecordID(Table("x"), 1)` worked on 2.0.5 (already a parse error on 3.x). Now a `TypeError` everywhere.
- Anything relying on `Table(None)` writing to a table named `None` — which is the bug.
- `RecordID.__str__` renders a bytes id as `t:b'xy'` rather than `t:xy`. That branch is live because of `_unchecked`, and decoding was wrong twice over: it raised `UnicodeDecodeError` on non-UTF-8, and rendered `b"xy"` identically to the *string* id `"xy"`, which is a different record. Fixed rather than deleted.

### Also in this PR

`test_the_websocket_session_survives_every_reentry` asserted `query("RETURN 1")` inside its `with` block. `RETURN 1` touches nothing the session owns, so an unauthenticated replacement socket evaluates it happily — the test stayed green with the socket being swapped underneath it. It now asserts `INFO FOR DB`, which fails with `Specify a namespace to use` without a session. The mutation harness found this; it is the same defect class as the four fixed in #332, in a test that round had reported as fine.

## What is your testing strategy?

Two new test files — `tests/unit_tests/data_types/test_constructor_validation.py` (offline: the accept/reject sets, the messages, the decode-path exemption) and `tests/unit_tests/connections/test_table_name_misplacement.py` (live: asks the *database* whether the row landed in a table named `None`, because the failure mode was a successful-looking write in the wrong place).

Verified with the per-test mutation harness from #332, extended with six new mutations including *"the decoder validates again"* — the trap this design exists to avoid. Each mutation names the tests that must fail, and is checked in file order **and** whole-directory order rather than in isolation:

```
[ok] validation: Table accepts a non-string name again
[ok] validation: RecordID accepts a non-string table name again
[ok] validation: RecordID accepts any id type again
[ok] validation: bool/SurrealSet impostors let through
[ok] validation: tuple dropped from the allowlist
[ok] validation: decoder validates again (the trap)

Every mutation is caught by the specific test written for it, in both orders.
```

All eighteen mutations in the harness pass, including the twelve from earlier rounds.

Full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3**: 1440 passed on 3.x, 1402 passed / 38 skipped on each 2.x. `ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/` and `pyright src/` all clean.

## Is this related to any issues?

Follows #331 and #332. This was the last open API-quality item before 3.0.0.

Found in passing and **not** fixed here: `db.insert(Table("héllo"), rows)` fails with a server parse error while `db.create` into the same table works — `escape_identifier` uses `str.isalnum()`, which is `True` for accented letters, so a unicode table name is inlined unquoted, and `insert` is the one path that inlines rather than binds the target. Confirmed present on `main` before this change, so it is out of scope here and tracked separately.

Also worth knowing: `ci.yml` points ruff at `./src` only, so `tests/` is linted and formatted by nobody — two test files have been sitting unformatted on `main` without CI noticing. Not addressed here to keep this diff to the change at hand.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
