### PR TITLE
Quote the identifiers SurrealQL will not take bare

### DIFF
--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -85,15 +85,38 @@ def _id_type_error(identifier: Any) -> TypeError:
     )
 
 
+# The characters SurrealQL's parser accepts in a *bare* identifier. ASCII only,
+# and deliberately not `str.isalnum()`: Python calls a letter or digit of *any*
+# script alphanumeric - `é`, `α`, `表`, `таблица`, and the superscript `²` - while
+# SurrealDB's parser rejects every one of them unquoted (verified on 2.0.5,
+# 2.3.10 and 3.2.3). Judging them safe left them unwrapped, so a table with a
+# non-ASCII name could not be inserted into at all: `INSERT INTO héllo` came
+# back ``Parse error: Invalid token `é```, while the same name in ⟨...⟩ works on
+# every version.
+#
+# Emoji and punctuation were never affected - they are symbols, so `isalnum()`
+# already returned False for them and they were already being wrapped.
+_UNQUOTED_IDENTIFIER_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
+_UNQUOTED_IDENTIFIER_ALPHA = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+
 def escape_identifier(identifier: str) -> str:
     """Escape a string identifier for use inside SurrealQL.
 
     Wraps the identifier in ``⟨...⟩`` (with any ``⟩`` inside replaced by
-    ``\\⟩``) when it contains characters outside the safe-identifier
-    subset - i.e. anything other than alphanumerics or underscore, OR
-    a name that is all-digit / all-symbol (no alphabetic char) and would
-    otherwise be ambiguous with a numeric id. Plain identifiers are
-    returned unchanged.
+    ``\\⟩``) unless every character is an ASCII letter, digit or underscore
+    *and* at least one is an ASCII letter - a name that is all-digit or
+    all-underscore is wrapped too, to disambiguate it from a numeric id in
+    SurrealQL's record-id literal syntax.
+
+    Wrapping is always safe: SurrealDB accepts any string inside ``⟨...⟩``,
+    including spaces, unicode and emoji, on every supported version. So the
+    bare form is an optimisation for the common case, and anything the parser
+    might not take unquoted is wrapped rather than guessed at.
 
     Used by :meth:`RecordID.__str__` for record-id rendering and by the
     v3 CRUD builders for ``INSERT`` target inlining (SurrealDB rejects
@@ -103,12 +126,18 @@ def escape_identifier(identifier: str) -> str:
     if not identifier:
         return f"⟨{identifier}⟩"
 
-    has_special_chars = any(not c.isalnum() and c != "_" for c in identifier)
+    unsafe = not _UNQUOTED_IDENTIFIER_CHARS.issuperset(identifier)
+    # A leading digit is not a bare identifier either: the parser has already
+    # committed to reading a number by the time it reaches the letters, so
+    # `1tbl` came back ``Invalid token`` on CREATE and ``Unexpected token `a
+    # number``` on INSERT. It used to pass this function unwrapped, because it
+    # contains letters and every character is alphanumeric.
+    starts_with_digit = identifier[0].isascii() and identifier[0].isdigit()
     # All-digit or all-symbol names need escaping to disambiguate from
     # numeric IDs in SurrealQL's record-id literal syntax.
-    has_no_alpha = not any(c.isalpha() for c in identifier)
+    has_no_alpha = _UNQUOTED_IDENTIFIER_ALPHA.isdisjoint(identifier)
 
-    if has_special_chars or has_no_alpha:
+    if unsafe or starts_with_digit or has_no_alpha:
         escaped = identifier.replace("⟩", "\\⟩")
         return f"⟨{escaped}⟩"
     return identifier
@@ -210,17 +239,25 @@ class RecordID:
         return record
 
     def __str__(self) -> str:
+        # The table half is escaped too. Only the id used to be, so a record in
+        # a table whose name needs quoting rendered as unparseable SurrealQL -
+        # `str(RecordID("héllo", "x"))` gave `héllo:x`, and `RecordID("has
+        # space", "x")` gave `has space:x`. This method's own docstring points
+        # at `str(record_id)` as the way to build query text when binding is not
+        # possible, so it has to hold for every name the server accepts, not
+        # just the ones that need no quoting.
+        table = escape_identifier(self.table_name)
         # Only escape if the identifier is a string
         if isinstance(self.id, str):
-            return f"{self.table_name}:{escape_identifier(self.id)}"
+            return f"{table}:{escape_identifier(self.id)}"
         if isinstance(self.id, bytes):
             # Rendered, not decoded. `_unchecked` means a wire value can still
             # be bytes, so this branch is live - and decoding it was wrong
             # twice over: it raised `UnicodeDecodeError` on anything that was
             # not UTF-8, and it rendered b"xy" as `t:xy`, which is a *different*
             # record from the one it names.
-            return f"{self.table_name}:{self.id!r}"
-        return f"{self.table_name}:{self.id}"
+            return f"{table}:{self.id!r}"
+        return f"{table}:{self.id}"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(table_name={self.table_name}, record_id={self.id!r})"

--- a/tests/unit_tests/connections/test_unicode_identifiers.py
+++ b/tests/unit_tests/connections/test_unicode_identifiers.py
@@ -1,0 +1,150 @@
+"""Table and record-id names the server accepts survive being written.
+
+``db.insert(Table("héllo"), rows)`` failed with ``Parse error: Invalid token
+`é``` while ``db.create`` into the same table worked. ``INSERT`` is the one
+statement whose target the SDK *inlines* rather than binds - SurrealDB rejects
+``INSERT INTO type::table($x)`` - so it is the only operation that depends on
+``escape_identifier`` getting the quoting right, and the only one that broke.
+
+The rule was ``any(not c.isalnum() and c != "_")``. Python calls a letter or
+digit of *any* script alphanumeric - ``é``, ``α``, ``表``, ``таблица``, and the
+superscript ``²`` - while SurrealDB's parser rejects every one of them in a
+bare identifier, so they were judged safe and left unquoted. The same rule
+passed ``1tbl`` through, which the parser also refuses: by the time it reaches
+the letters it has committed to reading a number.
+
+Emoji and punctuation were never affected - they are symbols, so ``isalnum()``
+already returned False and they were already being wrapped. They are covered
+below anyway, as a guard that the new rule did not lose them.
+
+Wrapping in ``⟨...⟩`` works for all of them, on 2.0.5, 2.3.10 and 3.2.3 alike,
+which is why the fix is to quote more rather than to reject anything.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+
+# Every one of these is rejected by the parser unquoted and accepted quoted.
+# `tbl²` is here because `"²".isalnum()` and `"²".isdigit()` are both True in
+# Python, so the old rule mis-classified a digit as well as letters. The last
+# three were already handled correctly and are kept as guards.
+AWKWARD_NAMES = [
+    pytest.param("héllo", id="accented"),
+    pytest.param("表格", id="cjk"),
+    pytest.param("αβγ", id="greek"),
+    pytest.param("таблица", id="cyrillic"),
+    pytest.param("tbl🙂", id="emoji"),
+    pytest.param("tbl²", id="superscript-digit"),
+    pytest.param("has space", id="space"),
+    pytest.param("1tbl", id="leading-digit"),
+    pytest.param("kebab-case", id="hyphen"),
+]
+
+
+def _fresh(name: str) -> str:
+    """A unique table name that keeps the awkward part."""
+    return f"{name}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.parametrize("name", AWKWARD_NAMES)
+def test_insert_into_an_awkward_table_name_round_trips(
+    blocking_ws_connection: BlockingWsSurrealConnection, name: str
+) -> None:
+    """The reported failure, asserted by reading the row back.
+
+    Not just "it did not raise": the point is that the row is retrievable from
+    the table it was aimed at.
+    """
+    table = _fresh(name)
+    marker = uuid.uuid4().hex[:12]
+
+    written = blocking_ws_connection.insert(Table(table), [{"marker": marker}])
+
+    assert isinstance(written, list) and written
+    assert written[0]["id"].table_name == table
+
+    back = blocking_ws_connection.select(Table(table))
+    assert isinstance(back, list)
+    assert [row["marker"] for row in back] == [marker]
+
+
+@pytest.mark.parametrize("name", AWKWARD_NAMES)
+def test_create_and_select_agree_with_insert(
+    blocking_ws_connection: BlockingWsSurrealConnection, name: str
+) -> None:
+    """``create`` always worked because it binds its target. Both spellings of
+    the same intent must now reach the same table."""
+    table = _fresh(name)
+
+    blocking_ws_connection.create(RecordID(table, "a"), {"n": 1})
+    blocking_ws_connection.insert(Table(table), [{"n": 2}])
+
+    rows: Any = blocking_ws_connection.select(Table(table))
+    assert isinstance(rows, list)
+    assert sorted(row["n"] for row in rows) == [1, 2]
+
+
+@pytest.mark.parametrize("name", AWKWARD_NAMES)
+def test_str_of_a_record_id_is_parseable_surrealql(
+    blocking_ws_connection: BlockingWsSurrealConnection, name: str
+) -> None:
+    """``str(record_id)`` is what the docstring recommends for composing query
+    text where binding is impossible, so the server has to accept it.
+
+    The table half was never escaped, only the id, so this produced
+    unparseable text for exactly the names above.
+    """
+    table = _fresh(name)
+    record = RecordID(table, name)
+
+    blocking_ws_connection.query(f"CREATE {record} SET n = 1").execute()
+
+    read = blocking_ws_connection.query(f"SELECT * FROM {record}").first()
+    assert isinstance(read, list) and len(read) == 1
+    assert read[0]["id"] == record
+
+
+def test_a_plain_name_is_still_not_quoted() -> None:
+    """The optimisation the rule exists for - and the pinned rendering that
+    everything else in the SDK depends on."""
+    from surrealdb.data.types.record_id import escape_identifier
+
+    assert escape_identifier("users") == "users"
+    assert escape_identifier("user_table") == "user_table"
+    assert escape_identifier("_private") == "_private"
+    assert str(RecordID("users", "john")) == "users:john"
+
+
+@pytest.mark.parametrize("name", AWKWARD_NAMES)
+def test_the_http_transport_agrees(
+    blocking_http_connection: BlockingHttpSurrealConnection, name: str
+) -> None:
+    table = _fresh(name)
+    marker = uuid.uuid4().hex[:12]
+
+    blocking_http_connection.insert(Table(table), [{"marker": marker}])
+
+    back = blocking_http_connection.select(Table(table))
+    assert isinstance(back, list)
+    assert [row["marker"] for row in back] == [marker]
+
+
+async def test_the_async_transport_agrees(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    table = _fresh("héllo")
+    marker = uuid.uuid4().hex[:12]
+
+    await async_ws_connection.insert(Table(table), [{"marker": marker}])
+
+    back = await async_ws_connection.select(Table(table))
+    assert isinstance(back, list)
+    assert [row["marker"] for row in back] == [marker]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`db.insert(Table("héllo"), [{"m": 1}])` failed while `db.create(Table("héllo"), {"m": 1})` into the same table succeeded:

```
ValidationError: Parse error: Invalid token `é`
 --> [1:14]
  |
1 | INSERT INTO héllo $_data
```

`INSERT` is the one statement whose target the SDK *inlines* rather than binds — SurrealDB rejects `INSERT INTO type::table($x)`, as `_InsertState._build` notes — so it is the only operation that depends on `escape_identifier` getting the quoting right, and the only one that broke.

The rule was `any(not c.isalnum() and c != "_")`. Python calls a letter or digit of **any** script alphanumeric, so `é`, `α`, `表格`, `таблица` and the superscript `²` were judged safe and left unwrapped — and SurrealDB's parser refuses every one of them bare.

Not a regression: present on `main` at fbae10d.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Bases the unquoted-safe subset on ASCII rather than on `str.isalnum()`. Measured against live 2.0.5, 2.3.10 and 3.2.3 servers, every one of these fails unquoted and works inside `⟨...⟩`:

| name | `CREATE`/`INSERT` bare | inside `⟨...⟩` |
| --- | --- | --- |
| `héllo`, `αβγ`, `таблица`, `表格` | `Invalid token` | ok |
| `tbl²` | `Invalid token` | ok |
| `1tbl` | `Unexpected token 'a number'` | ok |

Wrapping is always safe — SurrealDB accepts any string inside `⟨...⟩` on every supported version — so the bare form is an optimisation for the common case, and anything the parser might not take is now wrapped rather than guessed at.

Three facets of the one defect:

1. **`isalnum()` → ASCII.** The grammar is exactly `[A-Za-z_][A-Za-z0-9_]*`, confirmed by probing `abc`, `_abc`, `__abc`, `a1`, `_1`, `a_`, `abc1` (all accepted bare) against `1abc`, `9`, `1_2` (all rejected).
2. **A leading digit is wrapped.** `1tbl` used to pass through — it contains letters and every character is alphanumeric — but the parser has committed to reading a number by the time it reaches them.
3. **`__str__` escapes the table half too.** Only the id ever was, so `str(RecordID("héllo", "x"))` gave `héllo:x` and `RecordID("has space", "x")` gave `has space:x` — unparseable. `RecordID`'s own docstring points at `str(record_id)` as the way to build query text where binding is impossible, so it has to hold for every name the server accepts.

**Emoji and punctuation were never affected.** They are symbols, so `isalnum()` already returned False and they were already being wrapped. My first draft of this PR claimed otherwise in a comment and a docstring; the mutation harness caught it, and both are corrected.

Plain identifiers are unchanged: `users`, `user_table` and `_private` are still emitted bare, and the pinned `escape_identifier` contract in `test_record_id.py` is untouched — all 399 existing data-type tests pass without modification.

## What is your testing strategy?

New `tests/unit_tests/connections/test_unicode_identifiers.py` (38 tests): inserts into a table with each awkward name and **reads the row back**, checks `create` and `insert` reach the same table, and round-trips `str(record_id)` through the server as query text. Covers the blocking WS, blocking HTTP and async WS transports.

Mutation-tested per the request — each mutation names the tests that must fail, checked in file order **and** whole-directory order:

```
[ok] the isalnum() rule is back (non-ASCII judged safe)
[ok] a leading digit is judged safe again
[ok] __str__ stops escaping the table half
[ok] escaping is disabled entirely (the pinned contract)

Every mutation is caught by the specific test written for it, in both orders.
```

Full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3** — 1426 passed on 3.x (three consecutive clean runs), 1388 passed / 38 pre-existing skips on each 2.x. `ruff`, `mypy src/`, `mypy tests/` clean.

One thing worth knowing for anyone reproducing locally: a long-lived `memory` server accumulates tables across runs, and past ~1500 tables in one database the suite starts failing in fixture setup with `Transaction conflict: Write conflict`. I hit that mid-verification and it is unrelated to this change — the same code passed cleanly on a fresh server three times running. Restart the server if you see it.

## Is this related to any issues?

Found while working on #333 (constructor validation), which is where `Table("héllo")` first got exercised. Independent of it — this branches from `main` — though both touch `record_id.py`, so whichever merges second may need a trivial rebase.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
