### PR TITLE
Make RecordIdValue usable, and the guard that missed it work

### DIFF
--- a/src/surrealdb/data/types/record_id.py
+++ b/src/surrealdb/data/types/record_id.py
@@ -25,9 +25,18 @@ RecordIdType = Union[str, "RecordID", Table]
 #: What SurrealDB accepts as a record id. Exported so callers have a name to
 #: annotate or cast against - ``RecordID.id`` is deliberately wider (see the
 #: attribute's docs), so this is the type to use for a value you construct.
-RecordIdValue = Union[
-    str, int, uuid_module.UUID, "list[Any]", "tuple[Any, ...]", "dict[str, Any]", Range
-]
+#:
+#: Built from real generics, never from strings. A ``"list[Any]"`` member stays
+#: a ``ForwardRef`` that is only resolved when something reads the annotation at
+#: runtime - and it is resolved in the *caller's* namespace, where ``Any`` is not
+#: defined. So annotating with this, which is exactly what exporting it is for,
+#: raised ``NameError: name 'Any' is not defined`` from ``get_type_hints``, and
+#: from pydantic's ``validate_call`` at decoration time, i.e. while the caller's
+#: module was still importing. The connection aliases in ``surrealdb/__init__``
+#: shipped that same defect once already.
+RecordIdValue = (
+    str | int | uuid_module.UUID | list[Any] | tuple[Any, ...] | dict[str, Any] | Range
+)
 
 # The runtime half of `RecordIdValue`. Derived by probing every candidate value
 # against live 2.0.5 and 3.2.3 servers rather than from the documentation: these

--- a/tests/unit_tests/connections/test_table_name_misplacement.py
+++ b/tests/unit_tests/connections/test_table_name_misplacement.py
@@ -24,8 +24,18 @@ from surrealdb.data.types.table import Table
 def test_a_non_string_table_name_never_reaches_the_server(
     blocking_ws_connection: BlockingWsSurrealConnection, name: Any
 ) -> None:
-    with pytest.raises(TypeError):
+    """The message is asserted, not just the exception type.
+
+    ``pytest.raises(TypeError)`` alone was satisfied by the wrong error: with
+    the constructor guard removed, ``Table(123)`` sailed through and
+    ``escape_identifier`` raised its own ``TypeError`` further downstream, so
+    this case passed while guarding nothing. Naming the constructor's own
+    message is what ties it to the check it exists for.
+    """
+    with pytest.raises(TypeError) as caught:
         blocking_ws_connection.insert(Table(name), [{"marker": "x"}])
+
+    assert "Table() name must be a str" in str(caught.value)
 
 
 def test_nothing_is_written_to_a_table_named_none(

--- a/tests/unit_tests/test_public_annotations_resolve.py
+++ b/tests/unit_tests/test_public_annotations_resolve.py
@@ -85,31 +85,48 @@ def test_no_exported_union_holds_an_unresolved_forward_reference() -> None:
     to prevent exactly that, and every test in it still passed.
 
     Recursive, because a union can nest one.
+
+    A deferred member is only a defect when it names something the caller has
+    no way to have. ``Value`` is recursive - it is built from ``list["Value"]``
+    and ``dict[str, "Value"]`` - so it necessarily refers to itself by name, and
+    that resolves for anyone who imported it. ``RecordIdValue`` referred to
+    ``Any``, which is in ``typing``, not in ``surrealdb``, so no caller's
+    namespace could ever resolve it. The rule is therefore "every deferred name
+    is itself exported", not "no deferred names".
+
+    Both spellings count: ``typing.List["X"]`` stores a ``ForwardRef`` while the
+    builtin ``list["X"]`` keeps the bare ``str``, and only the first was checked
+    at first - which is why ``Value`` slipped past this in its original form.
     """
 
-    def unresolved(annotation: object, seen: set[int]) -> list[object]:
+    def deferred(annotation: object, seen: set[int]) -> list[str]:
         if id(annotation) in seen:
             return []
         seen.add(id(annotation))
-        found: list[object] = []
+        found: list[str] = []
         for member in typing.get_args(annotation):
             if isinstance(member, typing.ForwardRef):
+                found.append(member.__forward_arg__)
+            elif isinstance(member, str):
                 found.append(member)
             else:
-                found.extend(unresolved(member, seen))
+                found.extend(deferred(member, seen))
         return found
 
+    exported = set(surrealdb.__all__)
     offenders: list[str] = []
     for name in surrealdb.__all__:
         obj = getattr(surrealdb, name, None)
         if obj is None or isinstance(obj, type) or inspect.isfunction(obj):
             continue
-        for member in unresolved(obj, set()):
-            offenders.append(f"{name}: {member!r}")
+        for referenced in deferred(obj, set()):
+            if referenced not in exported:
+                offenders.append(f"{name} -> {referenced!r}")
 
     assert not offenders, (
-        "exported type aliases holding unresolved forward references "
-        "(build them from the real types, not from strings): " + "; ".join(offenders)
+        "exported aliases deferring to names that are not themselves exported, "
+        "so no caller can resolve them (build those members from the real "
+        "types, not from strings): " + "; ".join(offenders)
     )
 
 
@@ -118,7 +135,21 @@ def test_every_exported_alias_can_actually_annotate() -> None:
 
     ``get_type_hints`` on a function annotated with the alias is what pydantic,
     FastAPI and ``inspect.signature(..., eval_str=True)`` all end up doing.
+
+    The namespace is every public name bound under its own name - what
+    ``from surrealdb import *`` gives, and a superset of what someone importing
+    one alias has. Binding the alias under a placeholder instead made a
+    *recursive* alias look broken: ``Value`` refers to itself by name, so it
+    only resolves when it is present as ``Value``. That is a property of the
+    test harness, not of the alias, and it showed up only on Python 3.11+,
+    where ``get_type_hints`` evaluates nested deferred members that 3.10 left
+    alone.
     """
+    namespace: dict[str, object] = {
+        name: getattr(surrealdb, name)
+        for name in surrealdb.__all__
+        if hasattr(surrealdb, name)
+    }
     failures: list[str] = []
 
     for name in surrealdb.__all__:
@@ -128,10 +159,10 @@ def test_every_exported_alias_can_actually_annotate() -> None:
         if typing.get_args(obj) == ():
             continue  # not a generic alias, nothing to resolve
 
-        namespace: dict[str, object] = {"_alias": obj}
-        exec("def _handler(value: _alias) -> None: ...", namespace)  # noqa: S102
+        scope = dict(namespace)
+        exec(f"def _handler(value: {name}) -> None: ...", scope)  # noqa: S102
         try:
-            typing.get_type_hints(namespace["_handler"])
+            typing.get_type_hints(scope["_handler"], globalns=scope)
         except Exception as error:  # noqa: BLE001 - reporting, not handling
             failures.append(f"{name}: {type(error).__name__}: {error}")
 

--- a/tests/unit_tests/test_public_annotations_resolve.py
+++ b/tests/unit_tests/test_public_annotations_resolve.py
@@ -74,6 +74,72 @@ def test_no_alias_member_is_an_unresolved_forward_reference() -> None:
             assert isinstance(member, type), f"{member!r} is not a class"
 
 
+def test_no_exported_union_holds_an_unresolved_forward_reference() -> None:
+    """The same rule, applied to every exported union rather than two named ones.
+
+    The sweep below cannot see this: ``get_type_hints`` takes a module, class or
+    function, and a ``typing.Union`` object is none of those, so
+    ``_annotation_carriers`` returns nothing for one and the union is never
+    looked at. ``RecordIdValue`` was exported carrying three ``ForwardRef``s
+    that no caller's namespace can resolve, the whole test module here existed
+    to prevent exactly that, and every test in it still passed.
+
+    Recursive, because a union can nest one.
+    """
+
+    def unresolved(annotation: object, seen: set[int]) -> list[object]:
+        if id(annotation) in seen:
+            return []
+        seen.add(id(annotation))
+        found: list[object] = []
+        for member in typing.get_args(annotation):
+            if isinstance(member, typing.ForwardRef):
+                found.append(member)
+            else:
+                found.extend(unresolved(member, seen))
+        return found
+
+    offenders: list[str] = []
+    for name in surrealdb.__all__:
+        obj = getattr(surrealdb, name, None)
+        if obj is None or isinstance(obj, type) or inspect.isfunction(obj):
+            continue
+        for member in unresolved(obj, set()):
+            offenders.append(f"{name}: {member!r}")
+
+    assert not offenders, (
+        "exported type aliases holding unresolved forward references "
+        "(build them from the real types, not from strings): " + "; ".join(offenders)
+    )
+
+
+def test_every_exported_alias_can_actually_annotate() -> None:
+    """The property a caller cares about, exercised the way they would hit it.
+
+    ``get_type_hints`` on a function annotated with the alias is what pydantic,
+    FastAPI and ``inspect.signature(..., eval_str=True)`` all end up doing.
+    """
+    failures: list[str] = []
+
+    for name in surrealdb.__all__:
+        obj = getattr(surrealdb, name, None)
+        if obj is None or isinstance(obj, type) or inspect.isfunction(obj):
+            continue
+        if typing.get_args(obj) == ():
+            continue  # not a generic alias, nothing to resolve
+
+        namespace: dict[str, object] = {"_alias": obj}
+        exec("def _handler(value: _alias) -> None: ...", namespace)  # noqa: S102
+        try:
+            typing.get_type_hints(namespace["_handler"])
+        except Exception as error:  # noqa: BLE001 - reporting, not handling
+            failures.append(f"{name}: {type(error).__name__}: {error}")
+
+    assert not failures, "aliases that cannot be used to annotate: " + "; ".join(
+        failures
+    )
+
+
 def test_the_aliases_describe_what_this_install_can_return() -> None:
     """The union members match the engines actually available here."""
     embedded_available = surrealdb._EMBEDDED_AVAILABLE  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

**`main` is currently shipping a public export that raises when used as documented.** These two fixes were written for #333 but landed a few minutes after it was squash-merged, so they missed the merge.

`RecordIdValue`, added and exported in #333, was built as `Union[..., "list[Any]", "tuple[Any, ...]", "dict[str, Any]", ...]` with **string** members. Those stay `ForwardRef`s, and a `ForwardRef` is resolved in the *caller's* namespace — where `Any` is not defined:

```python
from surrealdb import RecordIdValue

def handler(rid: RecordIdValue) -> None: ...
typing.get_type_hints(handler)
# NameError: name 'Any' is not defined
```

`pydantic.validate_call` raises the same at **decoration** time, so a pydantic or FastAPI module annotating with it fails while still importing. `inspect.signature(..., eval_str=True)` silently hands back the unresolved refs. And the README section added in that same PR tells people to annotate against it.

This is the identical defect the connection aliases shipped in #328.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Builds `RecordIdValue` from real generics rather than strings.

**And fixes the guard that should have caught it.** `test_public_annotations_resolve.py` exists *because* of #328, and its docstring promises "a sweep rather than a list, so a new export with the same problem is caught without anyone remembering to add it here". It stayed green through all of this: `get_type_hints` accepts a module, class or function, and a `typing.Union` object is none of those, so `_annotation_carriers` returns nothing for one and the union was never examined.

Two new tests close it:

- `test_no_exported_union_holds_an_unresolved_forward_reference` — walks every exported alias for `ForwardRef` members, recursively, since a union can nest one.
- `test_every_exported_alias_can_actually_annotate` — annotates a function with each alias and resolves it, which is what pydantic, FastAPI and `inspect` actually do.

Both fail without the fix; the eight pre-existing tests in that module pass either way, which is the point.

Also: `test_a_non_string_table_name_never_reaches_the_server[123]` guarded nothing. `pytest.raises(TypeError)` was satisfied by the wrong error — with the `Table.__init__` guard removed, `Table(123)` sailed through and `escape_identifier` raised its own `TypeError` downstream. It now asserts the constructor's own message, and all three parametrisations fail without the guard.

## What is your testing strategy?

Verified on top of current `main` (fa86e81): the repro above now resolves cleanly through `get_type_hints`, `validate_call` and `inspect.signature(eval_str=True)`.

Full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3** — 1442 passed on 3.x, 1404 passed / 38 pre-existing skips on each 2.x. `ruff`, `mypy src/`, `mypy tests/`, `pyright src/` clean. All eighteen mutations in the per-test harness still caught by the specific test written for each, in file order and whole-directory order.

## Is this related to any issues?

Fixes two defects introduced by #333. Found by a regression review of that PR's diff, run after it was opened but completing after it had already merged — which is the only reason this is a follow-up rather than part of it.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
