### PR TITLE
Lint what was never being linted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,20 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      # `./src ./tests` - both. Pointing ruff at `./src` alone meant the test
+      # suite was linted and formatted by nothing, and it had accumulated
+      # unused imports, unused variables, `type(x) == y` comparisons and two
+      # files the formatter would have rewritten.
       - name: Run ruff checks
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4
         with:
-          src: "./src"
+          src: "./src ./tests"
           version-file: "uv.lock"
 
       - name: Run ruff format checks
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4
         with:
-          src: "./src"
+          src: "./src ./tests"
           version-file: "uv.lock"
           args: "format --check --diff"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,53 @@ include = [
 # `.md` files, which reflows the hand-aligned examples in our docs (notably
 # `src/surrealdb/spectron/README.md`, which sits under the `./src` path CI
 # checks). Docs prose is not formatter-owned.
-exclude = ["src/surrealdb/__init__.py", "*.md"]
+#
+# `src/surrealdb/__init__.py` used to be excluded here as well. That was
+# collateral from the markdown fix rather than a decision about the file, and it
+# exempted the package's own entry point - the most-read module in the project -
+# from both the linter and the formatter.
+exclude = ["*.md"]
 
 [tool.ruff.lint]
+# Setting `select` *replaces* ruff's default of `["E4", "E7", "E9", "F"]`, so
+# the previous `["I", "UP"]` silently turned pyflakes off: unused imports,
+# unused variables and undefined names were not being checked anywhere. The
+# defaults are named explicitly below so that cannot happen again by omission.
 select = [
-    "I",  # isort
-    "UP", # pyupgrade
+    "E4",  # pycodestyle: imports
+    "E7",  # pycodestyle: statements
+    "E9",  # pycodestyle: runtime errors
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "PIE", # flake8-pie
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific
 ]
+ignore = [
+    # `⟨...⟩` is SurrealQL's identifier-escape syntax and `α`, `é`, `表格` are
+    # test data for it, so "did you mean the ASCII lookalike?" is exactly
+    # backwards here - the point of those characters is that they are not ASCII.
+    "RUF002", # ambiguous unicode in a docstring
+    "RUF003", # ambiguous unicode in a comment
+    # `__all__` is grouped by category with section comments (connections, data
+    # types, the error tree). Alphabetical order would scatter those groups for
+    # no reader's benefit.
+    "RUF022", # `__all__` is not sorted
+    # `assert 0 == len(x)` reads fine and there are ~90 of them in the tests.
+    # Rewriting every one is churn with no defect behind it.
+    "SIM300", # yoda condition
+]
+
+[tool.ruff.lint.per-file-ignores]
+# `src/surrealdb/cbor/` is a vendored copy of cbor2, carrying local changes for
+# SurrealDB's tags. Restyling it to this project's taste would make every future
+# diff against upstream unreadable for no behavioural gain, so the opinionated
+# families are off there. The ones that catch actual defects - pyflakes,
+# pycodestyle, import order, pyupgrade - still apply, and it passes them.
+"src/surrealdb/cbor/**/*.py" = ["B", "C4", "PIE", "SIM", "RUF"]
 
 # --------------------------------------------------
 # mypy

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -1,18 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
-
-_EMBEDDED_AVAILABLE = False
-try:
-    from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection
-    from surrealdb.connections.blocking_embedded import BlockingEmbeddedSurrealConnection
-    _EMBEDDED_AVAILABLE = True  # pyright: ignore[reportConstantRedefinition]
-except ImportError:
-    pass
-
-if TYPE_CHECKING:
-    from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection as AsyncEmbeddedSurrealConnection
-    from surrealdb.connections.blocking_embedded import BlockingEmbeddedSurrealConnection as BlockingEmbeddedSurrealConnection
+from typing import TYPE_CHECKING, Any
 
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.async_ws import (
@@ -41,12 +29,12 @@ from surrealdb.data.types.duration import Duration
 from surrealdb.data.types.geometry import Geometry
 from surrealdb.data.types.null import Null, NullType
 from surrealdb.data.types.range import Bound, BoundExcluded, BoundIncluded, Range
-from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.record_id import (
     RecordID,
     RecordIdValue,
     escape_identifier,
 )
+from surrealdb.data.types.set import SurrealSet
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     AlreadyExistsDetailKind,
@@ -85,6 +73,31 @@ from surrealdb.errors import (
     ValidationError,
 )
 from surrealdb.types import Tokens, Value
+
+# The optional native engine. Probed here, *below* the imports above, rather
+# than at the top of the module: a `try`/`except ImportError` is a statement, so
+# everything following it counts as an import after code (`E402`) - which is
+# what kept this file exempt from the linter entirely. Nothing above depends on
+# the probe, and the probe's own modules import what they need themselves, so
+# the order is free.
+_EMBEDDED_AVAILABLE = False
+try:
+    from surrealdb.connections.async_embedded import AsyncEmbeddedSurrealConnection
+    from surrealdb.connections.blocking_embedded import (
+        BlockingEmbeddedSurrealConnection,
+    )
+
+    _EMBEDDED_AVAILABLE = True  # pyright: ignore[reportConstantRedefinition]
+except ImportError:
+    pass
+
+if TYPE_CHECKING:
+    from surrealdb.connections.async_embedded import (
+        AsyncEmbeddedSurrealConnection as AsyncEmbeddedSurrealConnection,
+    )
+    from surrealdb.connections.blocking_embedded import (
+        BlockingEmbeddedSurrealConnection as BlockingEmbeddedSurrealConnection,
+    )
 
 # Names that only exist when the optional native engine is installed
 # (``pip install surrealdb[embedded]``). They are pruned from ``__all__`` below
@@ -184,7 +197,13 @@ __all__ = [
     "SurrealDBMethodError",
 ]
 
-_EMBEDDED_SCHEMES = (UrlScheme.MEM, UrlScheme.MEMORY, UrlScheme.FILE, UrlScheme.SURREALKV, UrlScheme.SURREALKV_VERSIONED)
+_EMBEDDED_SCHEMES = (
+    UrlScheme.MEM,
+    UrlScheme.MEMORY,
+    UrlScheme.FILE,
+    UrlScheme.SURREALKV,
+    UrlScheme.SURREALKV_VERSIONED,
+)
 
 # Type aliases for the connection objects the factory functions return. The
 # ``Surreal``/``AsyncSurreal`` names are factory *functions*, so they cannot be
@@ -205,37 +224,22 @@ _EMBEDDED_SCHEMES = (UrlScheme.MEM, UrlScheme.MEMORY, UrlScheme.FILE, UrlScheme.
 # Without the extra the embedded classes do not exist, and neither can an
 # embedded connection: ``Surreal("mem://")`` raises ``UnsupportedEngineError``.
 # The union says so rather than naming a class that is not there.
-if TYPE_CHECKING:
-    AsyncSurrealConnection = Union[
-        AsyncWsSurrealConnection,
-        AsyncHttpSurrealConnection,
-        AsyncEmbeddedSurrealConnection,
-    ]
-    BlockingSurrealConnection = Union[
-        BlockingWsSurrealConnection,
-        BlockingHttpSurrealConnection,
-        BlockingEmbeddedSurrealConnection,
-    ]
-elif _EMBEDDED_AVAILABLE:
-    AsyncSurrealConnection = Union[
-        AsyncWsSurrealConnection,
-        AsyncHttpSurrealConnection,
-        AsyncEmbeddedSurrealConnection,
-    ]
-    BlockingSurrealConnection = Union[
-        BlockingWsSurrealConnection,
-        BlockingHttpSurrealConnection,
-        BlockingEmbeddedSurrealConnection,
-    ]
+if TYPE_CHECKING or _EMBEDDED_AVAILABLE:
+    AsyncSurrealConnection = (
+        AsyncWsSurrealConnection
+        | AsyncHttpSurrealConnection
+        | AsyncEmbeddedSurrealConnection
+    )
+    BlockingSurrealConnection = (
+        BlockingWsSurrealConnection
+        | BlockingHttpSurrealConnection
+        | BlockingEmbeddedSurrealConnection
+    )
 else:
-    AsyncSurrealConnection = Union[
-        AsyncWsSurrealConnection,
-        AsyncHttpSurrealConnection,
-    ]
-    BlockingSurrealConnection = Union[
-        BlockingWsSurrealConnection,
-        BlockingHttpSurrealConnection,
-    ]
+    AsyncSurrealConnection = AsyncWsSurrealConnection | AsyncHttpSurrealConnection
+    BlockingSurrealConnection = (
+        BlockingWsSurrealConnection | BlockingHttpSurrealConnection
+    )
 
 
 def Surreal(

--- a/src/surrealdb/connections/async_embedded.py
+++ b/src/surrealdb/connections/async_embedded.py
@@ -60,7 +60,7 @@ class AsyncEmbeddedSurrealConnection(AsyncWsSurrealConnection):
         self.id: str = str(uuid.uuid4())
         self.namespace: str | None = None
         self.database: str | None = None
-        self.vars: dict[str, Any] = dict()
+        self.vars: dict[str, Any] = {}
 
         # Embedded database handle
         with mapped_engine_errors("opening the database"):

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -75,7 +75,7 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.id: str = str(uuid.uuid4())
         self.namespace: str | None = None
         self.database: str | None = None
-        self.vars: dict[str, Value] = dict()
+        self.vars: dict[str, Value] = {}
         self._session: aiohttp.ClientSession | None = None
 
     async def _send(

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -341,9 +341,8 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
 
         try:
             if response_id := response.get("id"):
-                if fut := self.qry.get(response_id):
-                    if not fut.done():
-                        fut.set_result(response)
+                if (fut := self.qry.get(response_id)) and not fut.done():
+                    fut.set_result(response)
             elif response_result := response.get("result"):
                 live_id = str(response_result["id"])
                 for queue in self.live_queues.get(live_id, []):
@@ -1402,8 +1401,15 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         recv_task = getattr(self, "recv_task", None)
         if socket is None and recv_task is None:
             return
-        try:
-            warnings.warn(
+        # `try`/`except`, not `contextlib.suppress`: this runs in a destructor,
+        # and at interpreter shutdown a module-global lookup can already have
+        # been torn down - which is the same reason the body below is defensive
+        # at all. `BlockingWsSurrealConnection.__del__` is written the same way.
+        # No `stacklevel` either: the "caller" of a destructor is whatever
+        # happened to drop the last reference, so pointing at it misattributes
+        # the warning. `source=self` is what identifies the leaked connection.
+        try:  # noqa: SIM105
+            warnings.warn(  # noqa: B028 - see the comment above
                 f"unclosed connection to {getattr(self, 'raw_url', '?')} - "
                 "await close(), or use `async with`",
                 ResourceWarning,

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -52,7 +52,7 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.id: str = str(uuid.uuid4())
         self.namespace: str | None = None
         self.database: str | None = None
-        self.vars: dict[str, Value] = dict()
+        self.vars: dict[str, Value] = {}
         self.session: requests.Session | None = None
 
     def _send(

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -1339,7 +1339,10 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         connection = getattr(self, "socket", None)
         if connection is None:
             return
-        try:
+        # `try`/`except`, not `contextlib.suppress`: a module-global lookup in a
+        # destructor can fail at interpreter shutdown, which is the very case
+        # this is defending against.
+        try:  # noqa: SIM105
             connection.close_socket()
         except Exception:
             # Interpreter shutdown can pull what this needs out from under us,

--- a/src/surrealdb/connections/builders.py
+++ b/src/surrealdb/connections/builders.py
@@ -243,9 +243,7 @@ def _is_single_record_operation(resource: RecordIdType) -> bool:
         # Rejected by `_resource_to_variable` before it can be executed; the
         # answer here only has to be defined, not meaningful.
         return False
-    if ":" in resource and ".." not in resource:
-        return True
-    return False
+    return bool(":" in resource and ".." not in resource)
 
 
 def _check_response(response: dict[str, Any], op_name: str) -> list[dict[str, Any]]:
@@ -543,7 +541,7 @@ def _map_to_class(cls: type[T], values: list[Any] | Mapping[str, Any]) -> T:
             f"query().into({cls.__name__}) expects {len(param_names)} statement "
             f"results to match constructor parameters, got {len(values)}"
         )
-    kwargs = {name: value for name, value in zip(param_names, values, strict=True)}
+    kwargs = dict(zip(param_names, values, strict=True))
     return cls(**kwargs)
 
 

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -249,7 +249,7 @@ class UtilsMixin:
 
     @staticmethod
     def check_response_for_result(response: dict[str, Any], process: str) -> None:
-        if "result" not in response.keys():
+        if "result" not in response:
             raise SurrealError(f"no result {process}: {response}")
 
     @staticmethod

--- a/src/surrealdb/data/types/geometry.py
+++ b/src/surrealdb/data/types/geometry.py
@@ -53,14 +53,12 @@ class Geometry:
         """
         Returns the coordinates of the geometry. Should be implemented by subclasses.
         """
-        pass
 
     @staticmethod
     def parse_coordinates(coordinates: Any) -> Any:
         """
         Parses a list of coordinates into a specific geometry type. Should be implemented by subclasses.
         """
-        pass
 
     def __hash__(self) -> int:
         """
@@ -143,7 +141,7 @@ class GeometryLine(Geometry):
         """
         The constructor for the GeometryLine class.
         """
-        self.geometry_points = [point1, point2] + list(other_points)
+        self.geometry_points = [point1, point2, *list(other_points)]
 
     def get_coordinates(self) -> list[tuple[float, float]]:
         """
@@ -240,7 +238,7 @@ class GeometryPolygon(Geometry):
         Raises:
             ValueError: If any ring is not properly closed (first point != last point) or has fewer than 4 points.
         """
-        all_rings = [exterior_ring] + list(interior_rings)
+        all_rings = [exterior_ring, *list(interior_rings)]
 
         # Validate all rings
         for i, ring in enumerate(all_rings):

--- a/src/surrealdb/data/types/range.py
+++ b/src/surrealdb/data/types/range.py
@@ -18,7 +18,6 @@ class Bound:
         """
         Initializes a generic bound.
         """
-        pass
 
     def __eq__(self, other: object) -> bool:
         """

--- a/src/surrealdb/data/utils.py
+++ b/src/surrealdb/data/utils.py
@@ -7,9 +7,7 @@ from surrealdb.data.types.table import Table
 
 
 def process_record(record: RecordIdType) -> RecordID | Table:
-    if isinstance(record, RecordID):
-        return record
-    elif isinstance(record, Table):
+    if isinstance(record, (RecordID, Table)):
         return record
     else:
         if ":" in record:

--- a/src/surrealdb/request_message/descriptors/cbor_ws.py
+++ b/src/surrealdb/request_message/descriptors/cbor_ws.py
@@ -372,7 +372,7 @@ class WsCborDescriptor:
         data = {
             "id": obj.id,
             "method": obj.method.value,
-            "params": [obj.kwargs.get("query"), obj.kwargs.get("params", dict())],
+            "params": [obj.kwargs.get("query"), obj.kwargs.get("params", {})],
         }
         _inject_session_txn(data, obj)
         _validate_payload(data, obj.method)
@@ -438,7 +438,7 @@ class WsCborDescriptor:
             "method": obj.method.value,
             "params": [
                 process_record(cast(RecordIdType, obj.kwargs.get("record_id"))),
-                obj.kwargs.get("data", dict()),
+                obj.kwargs.get("data", {}),
             ],
         }
         _inject_session_txn(data, obj)
@@ -451,7 +451,7 @@ class WsCborDescriptor:
             "method": obj.method.value,
             "params": [
                 process_record(cast(RecordIdType, obj.kwargs.get("record_id"))),
-                obj.kwargs.get("data", dict()),
+                obj.kwargs.get("data", {}),
             ],
         }
         _inject_session_txn(data, obj)
@@ -488,7 +488,7 @@ class WsCborDescriptor:
             "method": obj.method.value,
             "params": [
                 process_record(cast(RecordIdType, obj.kwargs.get("record_id"))),
-                obj.kwargs.get("data", dict()),
+                obj.kwargs.get("data", {}),
             ],
         }
         _inject_session_txn(data, obj)

--- a/src/surrealdb/request_message/sql_adapter.py
+++ b/src/surrealdb/request_message/sql_adapter.py
@@ -55,9 +55,7 @@ class SqlAdapter:
         with open(file_path) as file:
             raw_buffer = file.read().split("\n")
             for i in raw_buffer:
-                if i == "":
-                    pass
-                elif i[0:2] == "--":
+                if i == "" or i[0:2] == "--":
                     pass
                 else:
                     buffer.append(i)

--- a/src/surrealdb/spectron/_transport.py
+++ b/src/surrealdb/spectron/_transport.py
@@ -34,7 +34,7 @@ def _resolve_endpoint(endpoint: str | None) -> str:
 
 
 def _build_url(endpoint: str, path: str) -> str:
-    if path.startswith("http://") or path.startswith("https://"):
+    if path.startswith(("http://", "https://")):
         return path
     return endpoint.rstrip("/") + "/" + path.lstrip("/")
 
@@ -364,7 +364,7 @@ class AsyncTransport(_BaseTransport):
 
             if status >= 400:
                 body_bytes = await response.read()
-                headers_dict = {k: v for k, v in response.headers.items()}
+                headers_dict = dict(response.headers.items())
                 response.release()
                 body = _decode_json(body_bytes)
                 raise error_from_response(status, body, headers_dict)

--- a/tests/spectron/test_async_namespaces.py
+++ b/tests/spectron/test_async_namespaces.py
@@ -79,17 +79,19 @@ async def test_async_consolidate_and_audit() -> None:
             return web.json_response({"rows": []}, status=200)
         return _unexpected(request)
 
-    async with _serve(handler) as server:
-        async with AsyncSpectron(
+    async with (
+        _serve(handler) as server,
+        AsyncSpectron(
             context=CONTEXT,
             endpoint=str(server.make_url("/")),
             api_key=API_KEY,
-        ) as c:
-            res = await c.consolidate(dry_run=True)
-            assert isinstance(res, ConsolidateResponse)
-            assert res.dry_run is True
-            audit = await c.audit(kind="decision")
-            assert isinstance(audit, AuditResponse)
+        ) as c,
+    ):
+        res = await c.consolidate(dry_run=True)
+        assert isinstance(res, ConsolidateResponse)
+        assert res.dry_run is True
+        audit = await c.audit(kind="decision")
+        assert isinstance(audit, AuditResponse)
 
     assert seen == [
         ("POST", f"{ROOT}/consolidate", {}),
@@ -123,21 +125,23 @@ async def test_async_namespaces_and_bare_array() -> None:
             )
         return _unexpected(request)
 
-    async with _serve(handler) as server:
-        async with AsyncSpectron(
+    async with (
+        _serve(handler) as server,
+        AsyncSpectron(
             context=CONTEXT,
             endpoint=str(server.make_url("/")),
             api_key=API_KEY,
-        ) as c:
-            sess = await c.sessions.create()
-            assert isinstance(sess, Session)
-            traces = await c.traces.list()
-            assert isinstance(traces, TraceListResponse)
-            doc = await c.documents.get("doc:1")
-            assert isinstance(doc, Document)
-            keys = await c.keys.list()
-            assert isinstance(keys, list)
-            assert isinstance(keys[0], KeyDetail)
+        ) as c,
+    ):
+        sess = await c.sessions.create()
+        assert isinstance(sess, Session)
+        traces = await c.traces.list()
+        assert isinstance(traces, TraceListResponse)
+        doc = await c.documents.get("doc:1")
+        assert isinstance(doc, Document)
+        keys = await c.keys.list()
+        assert isinstance(keys, list)
+        assert isinstance(keys[0], KeyDetail)
 
     assert seen == [
         ("POST", f"{ROOT}/sessions"),
@@ -159,11 +163,13 @@ async def test_async_fetch_raw_bytes() -> None:
             )
         return _unexpected(request)
 
-    async with _serve(handler) as server:
-        async with AsyncSpectron(
+    async with (
+        _serve(handler) as server,
+        AsyncSpectron(
             context=CONTEXT,
             endpoint=str(server.make_url("/")),
             api_key=API_KEY,
-        ) as c:
-            data = await c.documents.fetch_raw("doc:1")
-            assert data == b"%PDF data"
+        ) as c,
+    ):
+        data = await c.documents.fetch_raw("doc:1")
+        assert data == b"%PDF data"

--- a/tests/spectron/test_async_transport.py
+++ b/tests/spectron/test_async_transport.py
@@ -64,19 +64,21 @@ async def test_async_get_sends_bearer_header() -> None:
         _record(calls, request)
         return web.json_response({"ok": True}, status=200)
 
-    async with _serve(handler) as base:
-        async with AsyncTransport(endpoint=base, api_key=API_KEY) as t:
-            body = await t.get("/api/v1/x/health")
-            assert body == {"ok": True}
-            assert len(calls) == 1
-            assert calls[0].method == "GET"
-            assert calls[0].path == "/api/v1/x/health"
-            sent_headers = calls[0].headers
-            assert sent_headers["Authorization"] == f"Bearer {API_KEY}"
-            # Header lookups here are case-insensitive, so these two also rule
-            # out any other spelling of the legacy API-key header.
-            assert "X-API-Key" not in sent_headers
-            assert "x-api-key" not in sent_headers
+    async with (
+        _serve(handler) as base,
+        AsyncTransport(endpoint=base, api_key=API_KEY) as t,
+    ):
+        body = await t.get("/api/v1/x/health")
+        assert body == {"ok": True}
+        assert len(calls) == 1
+        assert calls[0].method == "GET"
+        assert calls[0].path == "/api/v1/x/health"
+        sent_headers = calls[0].headers
+        assert sent_headers["Authorization"] == f"Bearer {API_KEY}"
+        # Header lookups here are case-insensitive, so these two also rule
+        # out any other spelling of the legacy API-key header.
+        assert "X-API-Key" not in sent_headers
+        assert "x-api-key" not in sent_headers
 
 
 @pytest.mark.asyncio
@@ -100,12 +102,14 @@ async def test_async_get_retries_on_5xx(monkeypatch: pytest.MonkeyPatch) -> None
         status, payload = responses[len(calls) - 1]
         return web.json_response(payload, status=status)
 
-    async with _serve(handler) as base:
-        async with AsyncTransport(endpoint=base, api_key=API_KEY) as t:
-            body = await t.get("/api/v1/x/y")
-            assert body == {"ok": True}
-            assert len(calls) == 3
-            assert [c.path for c in calls] == ["/api/v1/x/y"] * 3
+    async with (
+        _serve(handler) as base,
+        AsyncTransport(endpoint=base, api_key=API_KEY) as t,
+    ):
+        body = await t.get("/api/v1/x/y")
+        assert body == {"ok": True}
+        assert len(calls) == 3
+        assert [c.path for c in calls] == ["/api/v1/x/y"] * 3
 
 
 @pytest.mark.asyncio
@@ -121,10 +125,12 @@ async def test_async_post_does_not_retry(monkeypatch: pytest.MonkeyPatch) -> Non
         _record(calls, request)
         return web.json_response({"message": "down"}, status=503)
 
-    async with _serve(handler) as base:
-        async with AsyncTransport(endpoint=base, api_key=API_KEY) as t:
-            with pytest.raises(SpectronAPIError):
-                await t.post("/api/v1/x/z", json={})
+    async with (
+        _serve(handler) as base,
+        AsyncTransport(endpoint=base, api_key=API_KEY) as t,
+    ):
+        with pytest.raises(SpectronAPIError):
+            await t.post("/api/v1/x/z", json={})
         # A plain POST is not idempotent, so a 5xx must surface immediately
         # rather than being retried.
         assert len(calls) == 1
@@ -147,18 +153,20 @@ async def test_async_idempotent_post_retries(monkeypatch: pytest.MonkeyPatch) ->
         status, payload = responses[len(calls) - 1]
         return web.json_response(payload, status=status)
 
-    async with _serve(handler) as base:
-        async with AsyncTransport(endpoint=base, api_key=API_KEY) as t:
-            body = await t.request(
-                "POST",
-                "/api/v1/x/facts",
-                json={"text": "hi"},
-                idempotent=True,
-            )
-            assert body == {"ok": True}
-            assert len(calls) == 2
-            assert [c.method for c in calls] == ["POST", "POST"]
-            assert [c.path for c in calls] == ["/api/v1/x/facts"] * 2
+    async with (
+        _serve(handler) as base,
+        AsyncTransport(endpoint=base, api_key=API_KEY) as t,
+    ):
+        body = await t.request(
+            "POST",
+            "/api/v1/x/facts",
+            json={"text": "hi"},
+            idempotent=True,
+        )
+        assert body == {"ok": True}
+        assert len(calls) == 2
+        assert [c.method for c in calls] == ["POST", "POST"]
+        assert [c.path for c in calls] == ["/api/v1/x/facts"] * 2
 
 
 @pytest.mark.asyncio
@@ -169,10 +177,12 @@ async def test_async_404_maps_to_not_found() -> None:
         _record(calls, request)
         return web.json_response({"message": "gone"}, status=404)
 
-    async with _serve(handler) as base:
-        async with AsyncTransport(endpoint=base, api_key=API_KEY) as t:
-            with pytest.raises(SpectronNotFoundError):
-                await t.get("/api/v1/x/missing")
+    async with (
+        _serve(handler) as base,
+        AsyncTransport(endpoint=base, api_key=API_KEY) as t,
+    ):
+        with pytest.raises(SpectronNotFoundError):
+            await t.get("/api/v1/x/missing")
         assert len(calls) == 1
         assert calls[0].method == "GET"
         assert calls[0].path == "/api/v1/x/missing"

--- a/tests/unit_tests/connections/authenticate/test_async_ws.py
+++ b/tests/unit_tests/connections/authenticate/test_async_ws.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 
 

--- a/tests/unit_tests/connections/authenticate/test_failed_auth_recovery.py
+++ b/tests/unit_tests/connections/authenticate/test_failed_auth_recovery.py
@@ -22,6 +22,7 @@ from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.errors import SurrealError
 
 # Rejected by the request schema, before any socket is touched.
 MALFORMED_TOKEN = "not-a-real-token"
@@ -100,7 +101,7 @@ def test_blocking_http_survives_a_rejected_token(
     )
     good_token = connection.token
 
-    with pytest.raises(Exception):
+    with pytest.raises((ValueError, SurrealError)):
         connection.authenticate(bad_token)
 
     assert connection.token == good_token, "the rejected token was adopted anyway"
@@ -123,7 +124,7 @@ async def test_async_http_survives_a_rejected_token(
     )
     good_token = connection.token
 
-    with pytest.raises(Exception):
+    with pytest.raises((ValueError, SurrealError)):
         await connection.authenticate(bad_token)
 
     assert connection.token == good_token, "the rejected token was adopted anyway"
@@ -138,7 +139,7 @@ def test_blocking_http_recovers_from_an_unauthenticated_start(
     """A brand-new connection whose first act fails is still usable."""
     connection = BlockingHttpSurrealConnection(connection_params["url"])
 
-    with pytest.raises(Exception):
+    with pytest.raises((ValueError, SurrealError)):
         connection.authenticate(FORGED_TOKEN)
 
     assert connection.token is None
@@ -166,7 +167,7 @@ def test_blocking_ws_survives_a_rejected_token(
         )
         good_token = connection.token
 
-        with pytest.raises(Exception):
+        with pytest.raises((ValueError, SurrealError)):
             connection.authenticate(bad_token)
 
         assert connection.token == good_token
@@ -188,7 +189,7 @@ async def test_async_ws_survives_a_rejected_token(
         )
         good_token = connection.token
 
-        with pytest.raises(Exception):
+        with pytest.raises((ValueError, SurrealError)):
             await connection.authenticate(bad_token)
 
         assert connection.token == good_token

--- a/tests/unit_tests/connections/batch_async/test_async_ws.py
+++ b/tests/unit_tests/connections/batch_async/test_async_ws.py
@@ -27,7 +27,7 @@ async def test_batch(async_ws_connection: AsyncWsSurrealConnection) -> None:
                 tg.create_task(
                     async_ws_connection.query(
                         f"RETURN sleep({sleep_fn}($d)) or $p**2",
-                        dict(d=10 if num % 2 else 0, p=num),
+                        {"d": 10 if num % 2 else 0, "p": num},
                     ).first()
                 )
                 for num in range(5)

--- a/tests/unit_tests/connections/bearer_v3/conftest.py
+++ b/tests/unit_tests/connections/bearer_v3/conftest.py
@@ -11,20 +11,18 @@ from typing import Any
 
 import pytest
 
-pytestmark = pytest.mark.surrealdb_v3
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+pytestmark = pytest.mark.surrealdb_v3
 
 
 def _is_surrealdb_v3(version_str: str) -> bool:
     version_str = (version_str or "").strip().lower()
     if not version_str:
         return False
-    if version_str.startswith("3.") or version_str.startswith("v3."):
+    if version_str.startswith(("3.", "v3.")):
         return True
-    if "surrealdb-3." in version_str:
-        return True
-    return False
+    return "surrealdb-3." in version_str
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit_tests/connections/bearer_v3/test_bearer_record_blocking_ws.py
+++ b/tests/unit_tests/connections/bearer_v3/test_bearer_record_blocking_ws.py
@@ -11,6 +11,7 @@ Mirrors behavior documented in surrealdb.go contrib/testenv:
 import pytest
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.errors import SurrealError
 from surrealdb.types import Tokens
 
 
@@ -105,7 +106,7 @@ def test_bearer_record_signin_token_not_usable_with_authenticate(
         conn2 = BlockingWsSurrealConnection(url)
         try:
             conn2.use(namespace=namespace, database=database_name)
-            with pytest.raises(Exception):
+            with pytest.raises(SurrealError):
                 conn2.authenticate(tokens.access)
         finally:
             if conn2.socket:

--- a/tests/unit_tests/connections/bearer_v3/test_bearer_user_blocking_ws.py
+++ b/tests/unit_tests/connections/bearer_v3/test_bearer_user_blocking_ws.py
@@ -11,6 +11,7 @@ Mirrors behavior documented in surrealdb.go contrib/testenv:
 import pytest
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.errors import SurrealError
 from surrealdb.types import Tokens
 
 
@@ -100,7 +101,7 @@ def test_bearer_signin_token_not_usable_with_authenticate(
         conn2 = BlockingWsSurrealConnection(url)
         try:
             conn2.use(namespace=namespace, database=database_name)
-            with pytest.raises(Exception):
+            with pytest.raises(SurrealError):
                 conn2.authenticate(tokens.access)
         finally:
             if conn2.socket:

--- a/tests/unit_tests/connections/conftest.py
+++ b/tests/unit_tests/connections/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import socket
 from collections.abc import AsyncGenerator, Generator
 from typing import Any
@@ -94,12 +95,9 @@ async def async_ws_connection(
         await connection.query(_DEFINE_TABLES)
         yield connection
     finally:
-        # Ensure connection is always closed
-        try:
+        # Ensure connection is always closed; ignore cleanup failures
+        with contextlib.suppress(Exception):
             await connection.close()
-        except Exception:
-            # Ignore any exceptions during cleanup
-            pass
 
 
 @pytest.fixture
@@ -117,10 +115,8 @@ async def async_ws_connection_secondary(
         await connection.query(_DEFINE_TABLES)
         yield connection
     finally:
-        try:
+        with contextlib.suppress(Exception):
             await connection.close()
-        except Exception:
-            pass
 
 
 @pytest.fixture

--- a/tests/unit_tests/connections/delete/test_async_http.py
+++ b/tests/unit_tests/connections/delete/test_async_http.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection

--- a/tests/unit_tests/connections/delete/test_async_ws.py
+++ b/tests/unit_tests/connections/delete/test_async_ws.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection

--- a/tests/unit_tests/connections/delete/test_blocking_ws.py
+++ b/tests/unit_tests/connections/delete/test_blocking_ws.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection

--- a/tests/unit_tests/connections/embedded/conftest.py
+++ b/tests/unit_tests/connections/embedded/conftest.py
@@ -4,4 +4,3 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def _require_surrealdb_server() -> None:
     """Embedded tests don't need a SurrealDB server."""
-    pass

--- a/tests/unit_tests/connections/embedded/test_blocking_embedded.py
+++ b/tests/unit_tests/connections/embedded/test_blocking_embedded.py
@@ -1,7 +1,5 @@
 """Tests for BlockingEmbeddedSurrealConnection."""
 
-import pytest
-
 from surrealdb import Surreal
 
 

--- a/tests/unit_tests/connections/info/test_async_http.py
+++ b/tests/unit_tests/connections/info/test_async_http.py
@@ -1,12 +1,8 @@
-from typing import Any
-
-import pytest
-
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 
 
 async def test_info(async_http_connection: AsyncHttpSurrealConnection) -> None:
-    outcome = await async_http_connection.info()
+    await async_http_connection.info()
     # info() can return None or a dict with user info
     # Just verify the method doesn't raise an exception
     assert True  # If we get here, the method worked

--- a/tests/unit_tests/connections/info/test_async_ws.py
+++ b/tests/unit_tests/connections/info/test_async_ws.py
@@ -1,12 +1,8 @@
-from typing import Any
-
-import pytest
-
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 
 
 async def test_info(async_ws_connection: AsyncWsSurrealConnection) -> None:
-    outcome = await async_ws_connection.info()
+    await async_ws_connection.info()
     # info() can return None or a dict with user info
     # Just verify the method doesn't raise an exception
     assert True  # If we get here, the method worked

--- a/tests/unit_tests/connections/info/test_block_ws.py
+++ b/tests/unit_tests/connections/info/test_block_ws.py
@@ -1,12 +1,8 @@
-from typing import Any
-
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 
 def test_info(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
-    outcome = blocking_ws_connection.info()
+    blocking_ws_connection.info()
     # info() can return None or a dict with user info
     # Just verify the method doesn't raise an exception
     assert True  # If we get here, the method worked

--- a/tests/unit_tests/connections/info/test_blocking_http.py
+++ b/tests/unit_tests/connections/info/test_blocking_http.py
@@ -1,12 +1,8 @@
-from typing import Any
-
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 
 
 def test_info(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
-    outcome = blocking_http_connection.info()
+    blocking_http_connection.info()
     # info() can return None or a dict with user info
     # Just verify the method doesn't raise an exception
     assert True  # If we get here, the method worked

--- a/tests/unit_tests/connections/insert/test_blocking_http.py
+++ b/tests/unit_tests/connections/insert/test_blocking_http.py
@@ -4,7 +4,6 @@ import pytest
 
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.data.types.record_id import RecordID
-from surrealdb.data.types.table import Table
 from surrealdb.types import Value
 
 

--- a/tests/unit_tests/connections/invalidate/test_async_http.py
+++ b/tests/unit_tests/connections/invalidate/test_async_http.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import AsyncIterator
 from typing import cast
 

--- a/tests/unit_tests/connections/invalidate/test_async_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_async_ws.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import AsyncIterator
 from typing import cast
 

--- a/tests/unit_tests/connections/invalidate/test_blocking_http.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_http.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Iterator
 from typing import cast
 

--- a/tests/unit_tests/connections/invalidate/test_blocking_ws.py
+++ b/tests/unit_tests/connections/invalidate/test_blocking_ws.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Iterator
 from typing import cast
 

--- a/tests/unit_tests/connections/let/test_blocking_http.py
+++ b/tests/unit_tests/connections/let/test_blocking_http.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 
 

--- a/tests/unit_tests/connections/let/test_blocking_ws.py
+++ b/tests/unit_tests/connections/let/test_blocking_ws.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 

--- a/tests/unit_tests/connections/live/test_async_ws.py
+++ b/tests/unit_tests/connections/live/test_async_ws.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 
-import pytest
-
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 
 

--- a/tests/unit_tests/connections/live/test_blocking_ws.py
+++ b/tests/unit_tests/connections/live/test_blocking_ws.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 

--- a/tests/unit_tests/connections/query/test_blocking_http.py
+++ b/tests/unit_tests/connections/query/test_blocking_http.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.data.types.record_id import RecordID
 

--- a/tests/unit_tests/connections/query/test_blocking_ws.py
+++ b/tests/unit_tests/connections/query/test_blocking_ws.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 from surrealdb.data.types.record_id import RecordID
 

--- a/tests/unit_tests/connections/session_txn/conftest.py
+++ b/tests/unit_tests/connections/session_txn/conftest.py
@@ -7,6 +7,8 @@ docker-compose profile v3). They are skipped when the server version is not 3.x
 or when session-scoped create/query return empty.
 """
 
+import contextlib
+
 import pytest
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
@@ -18,11 +20,9 @@ def _is_surrealdb_v3(version_str: str) -> bool:
     version_str = (version_str or "").strip().lower()
     if not version_str:
         return False
-    if version_str.startswith("3.") or version_str.startswith("v3."):
+    if version_str.startswith(("3.", "v3.")):
         return True
-    if "surrealdb-3." in version_str:
-        return True
-    return False
+    return "surrealdb-3." in version_str
 
 
 @pytest.fixture(autouse=True)
@@ -64,13 +64,11 @@ def session_txn_requires_v3(
             # per-statement list, so the row check below would never see a dict.
             session.create("session_txn_probe:check", {"probe": True})
             result = session.query("SELECT * FROM session_txn_probe;").first()
-        except Exception as exc:  # noqa: BLE001 - capture for skip decision
+        except Exception as exc:
             probe_error = exc
     finally:
-        try:
+        with contextlib.suppress(Exception):
             session.close_session()
-        except Exception:
-            pass
         blocking_ws_connection.query(
             "REMOVE TABLE IF EXISTS session_txn_probe;"
         ).execute()

--- a/tests/unit_tests/connections/signup/test_blocking_http.py
+++ b/tests/unit_tests/connections/signup/test_blocking_http.py
@@ -4,8 +4,6 @@ from typing import Any
 import pytest
 
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
-from surrealdb.request_message.message import RequestMessage
-from surrealdb.request_message.methods import RequestMethod
 from surrealdb.types import Value
 
 

--- a/tests/unit_tests/connections/signup/test_blocking_ws.py
+++ b/tests/unit_tests/connections/signup/test_blocking_ws.py
@@ -4,8 +4,6 @@ from typing import Any
 import pytest
 
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
-from surrealdb.request_message.message import RequestMessage
-from surrealdb.request_message.methods import RequestMethod
 from surrealdb.types import Value
 
 

--- a/tests/unit_tests/connections/subscribe_live/test_delivery.py
+++ b/tests/unit_tests/connections/subscribe_live/test_delivery.py
@@ -80,7 +80,7 @@ def _next_within(subscription: Any, deadline: float = _DEADLINE) -> dict[str, An
     def pull() -> None:
         try:
             received.append(next(subscription))
-        except BaseException as error:  # noqa: BLE001 - re-raised below
+        except BaseException as error:
             failed.append(error)
 
     reader = threading.Thread(target=pull, daemon=True)

--- a/tests/unit_tests/connections/test_async_ws_lifetime.py
+++ b/tests/unit_tests/connections/test_async_ws_lifetime.py
@@ -148,7 +148,7 @@ async def test_a_dropped_connection_is_collected(
 async def test_dropping_a_connection_releases_its_tasks_and_socket(
     connection_params: dict[str, Any],
 ) -> None:
-    before = {task for task in asyncio.all_tasks()}
+    before = set(asyncio.all_tasks())
     connection = await _signed_in(connection_params)
     socket = connection.socket
 

--- a/tests/unit_tests/connections/test_connect_races.py
+++ b/tests/unit_tests/connections/test_connect_races.py
@@ -18,6 +18,7 @@ over a shared connection - not of a stress test.
 """
 
 import asyncio
+import contextlib
 import threading
 from typing import Any
 
@@ -75,10 +76,8 @@ def test_blocking_connect_opens_one_socket_for_concurrent_callers(
     finally:
         connection.close()
         for socket in opened:
-            try:
+            with contextlib.suppress(Exception):
                 socket.close_socket()
-            except Exception:
-                pass
 
 
 async def test_async_connect_opens_one_socket_for_concurrent_callers(

--- a/tests/unit_tests/connections/test_connection_constructor.py
+++ b/tests/unit_tests/connections/test_connection_constructor.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from surrealdb import (
@@ -31,13 +29,13 @@ def test_data() -> dict[str, list[str]]:
 
 def test_blocking___init__(test_data: dict[str, list[str]]) -> None:
     outcome = Surreal("ws://localhost:5000")
-    assert type(outcome) == BlockingWsSurrealConnection
+    assert type(outcome) is BlockingWsSurrealConnection
     outcome = Surreal("http://localhost:5000")
-    assert type(outcome) == BlockingHttpSurrealConnection
+    assert type(outcome) is BlockingHttpSurrealConnection
 
 
 def test_async___init__(test_data: dict[str, list[str]]) -> None:
     outcome = AsyncSurreal("ws://localhost:5000")
-    assert type(outcome) == AsyncWsSurrealConnection
+    assert type(outcome) is AsyncWsSurrealConnection
     outcome = AsyncSurreal("http://localhost:5000")
-    assert type(outcome) == AsyncHttpSurrealConnection
+    assert type(outcome) is AsyncHttpSurrealConnection

--- a/tests/unit_tests/connections/test_duration_and_range_wire.py
+++ b/tests/unit_tests/connections/test_duration_and_range_wire.py
@@ -79,7 +79,7 @@ def test_the_sdk_and_the_server_agree_on_invalid_durations(
     SurrealDB started accepting one of these, and the SDK would be wrong in the
     other direction.
     """
-    with pytest.raises(Exception, match="(?i)cast|convert|invalid"):
+    with pytest.raises(Exception, match=r"(?i)cast|convert|invalid"):
         blocking_ws_connection.query("RETURN <duration>$text;", {"text": text}).first()
 
     with pytest.raises(InvalidDurationError):

--- a/tests/unit_tests/connections/test_nul_byte_errors.py
+++ b/tests/unit_tests/connections/test_nul_byte_errors.py
@@ -14,8 +14,6 @@ from outside the documented tree.
 
 from typing import Any
 
-import pytest
-
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
@@ -38,7 +36,7 @@ def test_blocking_ws_nul_byte(
 ) -> None:
     try:
         blocking_ws_connection.create("nul_probe", NUL_DATA)
-    except Exception as error:  # noqa: BLE001 - the type is what is under test
+    except Exception as error:
         _assert_typed(error)
 
 
@@ -47,7 +45,7 @@ def test_blocking_http_nul_byte(
 ) -> None:
     try:
         blocking_http_connection.create("nul_probe", NUL_DATA)
-    except Exception as error:  # noqa: BLE001
+    except Exception as error:
         _assert_typed(error)
 
 
@@ -56,7 +54,7 @@ async def test_async_ws_nul_byte(
 ) -> None:
     try:
         await async_ws_connection.create("nul_probe", NUL_DATA)
-    except Exception as error:  # noqa: BLE001
+    except Exception as error:
         _assert_typed(error)
 
 
@@ -65,7 +63,7 @@ async def test_async_http_nul_byte(
 ) -> None:
     try:
         await async_http_connection.create("nul_probe", NUL_DATA)
-    except Exception as error:  # noqa: BLE001
+    except Exception as error:
         _assert_typed(error)
 
 

--- a/tests/unit_tests/connections/test_null_round_trip.py
+++ b/tests/unit_tests/connections/test_null_round_trip.py
@@ -214,7 +214,7 @@ def test_null_is_rejected_by_an_option_field(
         f"DEFINE FIELD age ON {OPTION_TABLE} TYPE option<int>;"
     ).execute()
 
-    with pytest.raises(Exception, match="(?i)coerce|expected"):
+    with pytest.raises(Exception, match=r"(?i)coerce|expected"):
         blocking_ws_connection.create(OPTION_TABLE, {"age": Null})
 
 

--- a/tests/unit_tests/connections/test_ws_protocol_errors.py
+++ b/tests/unit_tests/connections/test_ws_protocol_errors.py
@@ -31,7 +31,7 @@ def _within_budget(call: Any) -> tuple[str, Any]:
             outcome["r"] = ("returned", call())
         except SurrealError as error:
             outcome["r"] = ("surreal-error", error)
-        except Exception as error:  # noqa: BLE001 - reporting, not handling
+        except Exception as error:
             outcome["r"] = ("leaked", error)
 
     worker = threading.Thread(target=run, daemon=True)

--- a/tests/unit_tests/connections/transport_errors/test_transport_errors.py
+++ b/tests/unit_tests/connections/transport_errors/test_transport_errors.py
@@ -337,9 +337,8 @@ def test_blocking_ws_unreachable_host_raises_connection_unavailable() -> None:
 def test_blocking_ws_context_manager_unreachable_host_raises() -> None:
     connection = BlockingWsSurrealConnection(f"ws://127.0.0.1:{_closed_port()}")
 
-    with pytest.raises(ConnectionUnavailableError):
-        with connection:
-            pass
+    with pytest.raises(ConnectionUnavailableError), connection:
+        pass
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/connections/unset/test_blocking_http.py
+++ b/tests/unit_tests/connections/unset/test_blocking_http.py
@@ -1,7 +1,5 @@
 from typing import cast
 
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 
 

--- a/tests/unit_tests/connections/unset/test_blocking_ws.py
+++ b/tests/unit_tests/connections/unset/test_blocking_ws.py
@@ -1,7 +1,5 @@
 from typing import cast
 
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 

--- a/tests/unit_tests/connections/upsert/test_async_http.py
+++ b/tests/unit_tests/connections/upsert/test_async_http.py
@@ -124,7 +124,7 @@ async def test_upsert_table(
 ) -> None:
     table = Table("user")
     record_id = RecordID("user", "tobie")
-    first_outcome = await async_http_connection.upsert(table, existing_data)
+    await async_http_connection.upsert(table, existing_data)
     result = await async_http_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
@@ -138,7 +138,7 @@ async def test_upsert_table_with_data(
     setup_user: None,
 ) -> None:
     table = Table("user")
-    record_id = RecordID("user", "tobie")
+    RecordID("user", "tobie")
     outcome = await async_http_connection.upsert(table, upsert_data)
     # At least one record should match the upserted data
     assert any(

--- a/tests/unit_tests/connections/upsert/test_async_ws.py
+++ b/tests/unit_tests/connections/upsert/test_async_ws.py
@@ -124,7 +124,7 @@ async def test_upsert_table(
 ) -> None:
     table = Table("user")
     record_id = RecordID("user", "tobie")
-    first_outcome = await async_ws_connection.upsert(table, existing_data)
+    await async_ws_connection.upsert(table, existing_data)
     result = await async_ws_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
@@ -138,7 +138,7 @@ async def test_upsert_table_with_data(
     setup_user: None,
 ) -> None:
     table = Table("user")
-    record_id = RecordID("user", "tobie")
+    RecordID("user", "tobie")
     outcome = await async_ws_connection.upsert(table, upsert_data)
     # At least one record should match the upserted data
     assert any(

--- a/tests/unit_tests/connections/upsert/test_blocking_http.py
+++ b/tests/unit_tests/connections/upsert/test_blocking_http.py
@@ -119,7 +119,7 @@ def test_upsert_table(
 ) -> None:
     table = Table("user")
     record_id = RecordID("user", "tobie")
-    first_outcome = blocking_http_connection.upsert(table, existing_data)
+    blocking_http_connection.upsert(table, existing_data)
     result = blocking_http_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
@@ -132,7 +132,7 @@ def test_upsert_table_with_data(
     setup_user: None,
 ) -> None:
     table = Table("user")
-    record_id = RecordID("user", "tobie")
+    RecordID("user", "tobie")
     outcome = blocking_http_connection.upsert(table, upsert_data)
     # At least one record should match the upserted data
     assert any(

--- a/tests/unit_tests/connections/upsert/test_blocking_ws.py
+++ b/tests/unit_tests/connections/upsert/test_blocking_ws.py
@@ -119,7 +119,7 @@ def test_upsert_table(
 ) -> None:
     table = Table("user")
     record_id = RecordID("user", "tobie")
-    first_outcome = blocking_ws_connection.upsert(table, existing_data)
+    blocking_ws_connection.upsert(table, existing_data)
     result = blocking_ws_connection.query("SELECT * FROM user;").first()
     # SurrealDB may create a new record or not, depending on version
     assert any(r["id"] == record_id for r in result)
@@ -132,7 +132,7 @@ def test_upsert_table_with_data(
     setup_user: None,
 ) -> None:
     table = Table("user")
-    record_id = RecordID("user", "tobie")
+    RecordID("user", "tobie")
     outcome = blocking_ws_connection.upsert(table, upsert_data)
     # At least one record should match the upserted data
     assert any(

--- a/tests/unit_tests/connections/v3_api/test_run.py
+++ b/tests/unit_tests/connections/v3_api/test_run.py
@@ -15,9 +15,7 @@ async def _async_setup(
     async_ws_connection: AsyncWsSurrealConnection,
 ) -> AsyncGenerator[None, None]:
     await async_ws_connection.query(
-        "DEFINE FUNCTION OVERWRITE fn::add($a: int, $b: int) {"
-        "    RETURN $a + $b;"
-        "}"
+        "DEFINE FUNCTION OVERWRITE fn::add($a: int, $b: int) {    RETURN $a + $b;}"
     )
     yield
     await async_ws_connection.query("REMOVE FUNCTION fn::add;")

--- a/tests/unit_tests/connections/version/test_async_http.py
+++ b/tests/unit_tests/connections/version/test_async_http.py
@@ -5,4 +5,4 @@ from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 
 @pytest.mark.asyncio
 async def test_version(async_http_connection: AsyncHttpSurrealConnection) -> None:
-    assert str == type(await async_http_connection.version())
+    assert isinstance(await async_http_connection.version(), str)

--- a/tests/unit_tests/connections/version/test_async_ws.py
+++ b/tests/unit_tests/connections/version/test_async_ws.py
@@ -5,4 +5,4 @@ from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 
 @pytest.mark.asyncio
 async def test_version(async_ws_connection: AsyncWsSurrealConnection) -> None:
-    assert str == type(await async_ws_connection.version())
+    assert isinstance(await async_ws_connection.version(), str)

--- a/tests/unit_tests/connections/version/test_blocking_http.py
+++ b/tests/unit_tests/connections/version/test_blocking_http.py
@@ -1,7 +1,5 @@
-import pytest
-
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 
 
 def test_version(blocking_http_connection: BlockingHttpSurrealConnection) -> None:
-    assert str == type(blocking_http_connection.version())
+    assert isinstance(blocking_http_connection.version(), str)

--- a/tests/unit_tests/connections/version/test_blocking_ws.py
+++ b/tests/unit_tests/connections/version/test_blocking_ws.py
@@ -1,7 +1,5 @@
-import pytest
-
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 
 
 def test_version(blocking_ws_connection: BlockingWsSurrealConnection) -> None:
-    assert str == type(blocking_ws_connection.version())
+    assert isinstance(blocking_ws_connection.version(), str)

--- a/tests/unit_tests/data_types/test_duration.py
+++ b/tests/unit_tests/data_types/test_duration.py
@@ -328,7 +328,9 @@ def test_zero_duration_decodes_from_an_empty_array() -> None:
     a zero duration raised ``IndexError`` and destroyed the whole response -
     not just that field. Ordinary expressions produce one.
     """
-    assert cbor.decode(dumps(CBORTag(constants.TAG_DURATION_COMPACT, []))) == Duration(0)
+    assert cbor.decode(dumps(CBORTag(constants.TAG_DURATION_COMPACT, []))) == Duration(
+        0
+    )
 
     # And it still round-trips through the SDK's own encoder.
     assert cbor.decode(cbor.encode(Duration(0))) == Duration(0)

--- a/tests/unit_tests/data_types/test_geometry.py
+++ b/tests/unit_tests/data_types/test_geometry.py
@@ -516,7 +516,7 @@ async def test_geometry_point_class_methods() -> None:
     assert p2.latitude == -20.0
     p3 = GeometryPoint(10.0, -20.0)
     assert p2 == p3
-    assert not p2 == GeometryPoint(0.0, 0.0)
+    assert p2 != GeometryPoint(0.0, 0.0)
 
 
 @pytest.mark.asyncio
@@ -591,7 +591,7 @@ async def test_geometry_line_class_methods() -> None:
     line2 = GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(1.0, 1.0))
     assert line == line2
     line3 = GeometryLine(GeometryPoint(0.0, 0.0), GeometryPoint(2.0, 2.0))
-    assert not line == line3
+    assert line != line3
 
 
 @pytest.mark.asyncio
@@ -757,7 +757,7 @@ async def test_geometry_polygon_validation() -> None:
     """Test that polygon validation catches invalid rings."""
     # Test 1: Ring not closed (first != last point)
     with pytest.raises(
-        InvalidGeometryError, match="first point.*must equal last point"
+        InvalidGeometryError, match=r"first point.*must equal last point"
     ):
         unclosed_ring = GeometryLine(
             GeometryPoint(0.0, 0.0),
@@ -785,7 +785,7 @@ async def test_geometry_polygon_validation() -> None:
         GeometryPoint(0.0, 0.0),
     )
 
-    with pytest.raises(InvalidGeometryError, match="Invalid interior.*ring"):
+    with pytest.raises(InvalidGeometryError, match=r"Invalid interior.*ring"):
         invalid_hole = GeometryLine(
             GeometryPoint(2.0, 2.0),
             GeometryPoint(4.0, 2.0),

--- a/tests/unit_tests/data_types/test_none.py
+++ b/tests/unit_tests/data_types/test_none.py
@@ -111,7 +111,7 @@ async def test_none(surrealdb_connection: Any) -> None:
     record_check = RecordID(table_name="person", identifier="john")
     assert record_check == outcome["id"]
     assert "John" == outcome["name"]
-    assert None == outcome.get("age")
+    assert None is outcome.get("age")
 
     outcome = await surrealdb_connection.create(
         "person:dave", {"name": "Dave", "age": 34}

--- a/tests/unit_tests/data_types/test_record_id.py
+++ b/tests/unit_tests/data_types/test_record_id.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 

--- a/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
+++ b/tests/unit_tests/request_message/descriptors/test_cbor_ws.py
@@ -16,14 +16,14 @@ def test_use_pass() -> None:
 def test_use_fail() -> None:
     message = RequestMessage(RequestMethod.USE, namespace="ns", database=1)
     with pytest.raises(ValueError) as context:
-        message.WS_CBOR_DESCRIPTOR
+        _ = message.WS_CBOR_DESCRIPTOR
     assert (
         "Invalid schema for Cbor WS encoding for use: params.1: Input should be a valid string"
         == str(context.value)
     )
     message = RequestMessage(RequestMethod.USE, namespace="ns")
     with pytest.raises(ValueError) as context:
-        message.WS_CBOR_DESCRIPTOR
+        _ = message.WS_CBOR_DESCRIPTOR
     assert (
         "Invalid schema for Cbor WS encoding for use: params.1: Input should be a valid string"
         == str(context.value)

--- a/tests/unit_tests/request_message/test_adapter.py
+++ b/tests/unit_tests/request_message/test_adapter.py
@@ -1,7 +1,4 @@
 import os
-from typing import Any
-
-import pytest
 
 from surrealdb.request_message.sql_adapter import SqlAdapter
 

--- a/tests/unit_tests/request_message/test_request_message.py
+++ b/tests/unit_tests/request_message/test_request_message.py
@@ -1,7 +1,3 @@
-from typing import Any
-
-import pytest
-
 from surrealdb.request_message.message import RequestMessage
 from surrealdb.request_message.methods import RequestMethod
 

--- a/tests/unit_tests/test_http_auth_header.py
+++ b/tests/unit_tests/test_http_auth_header.py
@@ -18,6 +18,7 @@ from surrealdb.connections import blocking_http
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.data.cbor import encode
+from surrealdb.errors import SurrealError
 
 HTTP_URL = "http://localhost:8000"
 GOOD_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.Zm9vYmFyYmF6"
@@ -93,7 +94,7 @@ def test_a_failed_send_leaves_the_held_token_alone(
     connection = BlockingHttpSurrealConnection(HTTP_URL)
     connection.token = OTHER_TOKEN
 
-    with pytest.raises(Exception):
+    with pytest.raises(SurrealError):
         connection.authenticate(GOOD_TOKEN)
 
     assert connection.token == OTHER_TOKEN

--- a/tests/unit_tests/test_init_functions.py
+++ b/tests/unit_tests/test_init_functions.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from surrealdb import AsyncSurreal, Surreal
@@ -7,7 +5,6 @@ from surrealdb.connections.async_http import AsyncHttpSurrealConnection
 from surrealdb.connections.async_ws import AsyncWsSurrealConnection
 from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
 from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
-from surrealdb.connections.url import UrlScheme
 from surrealdb.errors import SurrealError, UnsupportedEngineError
 
 
@@ -115,7 +112,7 @@ def test_all_names_are_importable() -> None:
 def test_star_import_succeeds() -> None:
     """``from surrealdb import *`` works whatever is installed."""
     namespace: dict[str, object] = {}
-    exec("from surrealdb import *", namespace)  # noqa: S102
+    exec("from surrealdb import *", namespace)
 
     assert "Surreal" in namespace
     assert "AsyncSurreal" in namespace

--- a/tests/unit_tests/test_public_annotations_resolve.py
+++ b/tests/unit_tests/test_public_annotations_resolve.py
@@ -160,10 +160,10 @@ def test_every_exported_alias_can_actually_annotate() -> None:
             continue  # not a generic alias, nothing to resolve
 
         scope = dict(namespace)
-        exec(f"def _handler(value: {name}) -> None: ...", scope)  # noqa: S102
+        exec(f"def _handler(value: {name}) -> None: ...", scope)
         try:
             typing.get_type_hints(scope["_handler"], globalns=scope)
-        except Exception as error:  # noqa: BLE001 - reporting, not handling
+        except Exception as error:
             failures.append(f"{name}: {type(error).__name__}: {error}")
 
     assert not failures, "aliases that cannot be used to annotate: " + "; ".join(

--- a/tests/unit_tests/test_tokens.py
+++ b/tests/unit_tests/test_tokens.py
@@ -1,5 +1,3 @@
-import pytest
-
 from surrealdb.types import Tokens, parse_auth_result
 
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`select` in the ruff config **replaces** ruff's default of `["E4", "E7", "E9", "F"]`. Setting it to `["I", "UP"]` therefore turned pyflakes off, project-wide. Nothing has been checking for unused imports, unused variables or undefined names.

Turning the default set back on found **42 unused imports and 12 unused variables**.

Two more holes sat next to it:

- **`src/surrealdb/__init__.py` was excluded from ruff entirely.** The comment above `exclude` explains the `*.md` entry but not that one — it reads as collateral from the markdown fix rather than a decision about the file. It exempted the package's own entry point, the most-read module in the project, from both the linter and the formatter.
- **CI pointed ruff at `./src` alone**, so `tests/` was linted and formatted by nothing. Two test files have been sitting unformatted on `main` without CI noticing.

This supersedes #234, which was aimed at the same problem from the other end — fixing the findings without widening the config that was hiding them — and has since been overtaken by the 3.0.0 rewrite.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Selects the pyflakes/pycodestyle defaults plus `B`, `C4`, `PIE`, `SIM` and `RUF`, lifts the `__init__.py` exclusion, and points CI at `./src ./tests`.

Four rules are ignored, each with a reason in the config rather than a blanket quieting:

| rule | why |
| --- | --- |
| `RUF002` / `RUF003` | flags `⟨...⟩`, `α`, `表格` — that is SurrealQL's escape syntax and the test data for it. "Did you mean the ASCII lookalike?" is exactly backwards. |
| `RUF022` | `__all__` is grouped by category with section comments; alphabetical order scatters them. |
| `SIM300` | ninety yoda conditions in tests, no defect behind any of them. |

The vendored `src/surrealdb/cbor/` tree keeps the correctness rules and drops the stylistic ones, so a future diff against upstream cbor2 stays readable.

**The entry point now imports before it probes for the optional engine.** A `try`/`except ImportError` is a statement, so every import after it counted as `E402` — which is what made excluding the file look reasonable in the first place. Nothing above the probe depends on it. Its connection aliases also move from `Union[...]` to `|`, which has a side benefit: `isinstance(db, BlockingSurrealConnection)` now works instead of raising.

### Two things in the fallout worth a reviewer's eye

**Eight `pytest.raises(Exception)` are narrowed to what the code actually raises**, so they no longer pass on an `AttributeError` from a typo. The auth-recovery tests become `(ValueError, SurrealError)` — matching the two rejection paths that file's own docstring describes: a non-JWT token refused by the request schema, and a bad-signature token refused by the server. I confirmed both against a live server rather than guessing.

**Eight `type(x) == y` become `is`, deliberately not `isinstance`.** The embedded connections subclass the websocket ones, so `isinstance` would accept the wrong class in exactly the test that exists to tell `Surreal("ws://")` from `Surreal("memory")` apart.

### Two autofixes reverted as regressions

Ruff rewrote both `__del__` methods' `try`/`except` into `contextlib.suppress` — a module-global lookup in a destructor, which is the precise thing those blocks defend against at interpreter shutdown, and which the sibling `blocking_ws.__del__` comment already spells out. It also added a `stacklevel` to a destructor's `ResourceWarning`, where the "caller" is whatever happened to drop the last reference, so pointing at it misattributes the warning. Both are back, with `noqa` and the reason.

## What is your testing strategy?

`ruff check`, `ruff format --check`, `mypy src/`, `mypy tests/`, `pyright src/` all clean over **both** `src` and `tests`.

Suite on Python 3.10 (1576 passed) and 3.11 (1427, run the way CI's Core Tests legs do). The entry point was restructured, so its public surface is asserted directly rather than assumed:

```
__all__ entries: 72
all importable : True
alias members  : 3
get_type_hints : ok
Surreal(ws)    : BlockingWsSurrealConnection
Surreal(memory): BlockingEmbeddedSurrealConnection
```

One self-inflicted scare worth recording: a regex I used to rewrite the `type(x) == y` assertions matched non-greedily and produced `isinstance(conn.version(, str))` in four files. Ruff caught it as `invalid-syntax` immediately — which is itself a small argument for this PR, since those four files were previously unlinted.

## Is this related to any issues?

Supersedes #234.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
