### PR TITLE
Let select() ask for only the fields it needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,27 @@ about still reads back — `RecordID.id` is therefore typed more widely than
 > named `None`. If you have code that builds a table name dynamically, that is
 > the case to check.
 
+#### Selecting only some fields
+
+Pass `fields=` to narrow the projection, so the server sends only what you ask
+for rather than the whole record:
+
+```python
+await db.select(RecordID("person", "tobie"), fields=["name", "email"])
+await db.select(Table("person"), fields=["address.city"])
+```
+
+A dot walks into a nested object. Each segment is escaped separately, so a field
+name containing a space or unicode is quoted correctly and a field list can
+never smuggle SurrealQL into the statement. A field whose name genuinely
+*contains* a dot cannot be spelled this way — use `query()` for that.
+
+`id` is not included unless you ask for it, exactly as in SurrealQL, so a model
+passed to `into=` that declares an `id` field needs `fields=["id", ...]`.
+
+Anything beyond a list of field names — aliases, functions, `WHERE`, `ORDER BY`
+— is a `query()`, not a `select()`.
+
 #### Record ranges
 
 A `RecordID` whose id is a `Range` targets every record in that range, and every

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from types import TracebackType
 from typing import Any, cast, overload
 from uuid import UUID
@@ -22,6 +22,7 @@ from surrealdb.connections.utils_mixin import (
     UtilsMixin,
     build_run_query,
     merge_query_vars,
+    render_projection,
 )
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
@@ -517,27 +518,61 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         self.vars.pop(key, None)
 
     @overload
-    async def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    async def select(
+        self, record: RecordID, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> M | None: ...
     @overload
-    async def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    async def select(
+        self, record: Table, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> list[M]: ...
     @overload
-    async def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    async def select(
+        self, record: str, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> M | list[M] | None: ...
     @overload
-    async def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    async def select(
+        self, record: RecordID, *, fields: Sequence[str] | None = None
+    ) -> dict[str, Value] | None: ...
     @overload
-    async def select(self, record: Table) -> list[Value]: ...
+    async def select(
+        self, record: Table, *, fields: Sequence[str] | None = None
+    ) -> list[Value]: ...
     @overload
-    async def select(self, record: str) -> Value: ...
-    async def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+    async def select(
+        self, record: str, *, fields: Sequence[str] | None = None
+    ) -> Value: ...
+    async def select(
+        self,
+        record: RecordIdType,
+        *,
+        fields: Sequence[str] | None = None,
+        into: type[M] | None = None,
+    ) -> Any:
         """Select records.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
         list of records. Pass ``into=Model`` to map each record onto ``Model``.
+
+        ``fields`` narrows the projection, so the server sends only what is
+        asked for rather than the whole record::
+
+            db.select(RecordID("person", "tobie"), fields=["name", "email"])
+            db.select(Table("person"), fields=["address.city"])
+
+        A dot walks into a nested object; each segment is escaped separately, so
+        a name with a space or unicode in it is quoted correctly. A field whose
+        name genuinely contains a dot cannot be spelled this way - use
+        :meth:`query` for that.
+
+        Note that ``id`` is not included unless you ask for it, exactly as in
+        SurrealQL. A model passed to ``into=`` that declares an ``id`` field
+        therefore needs ``fields=["id", ...]``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
-        query = f"SELECT * FROM {resource_ref}"
+        projection = render_projection(fields)
+        query = f"SELECT {projection} FROM {resource_ref}"
 
         response = await self.query_raw(query, variables)
         self.check_response_for_error(response, "select")

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -8,7 +8,7 @@ import uuid
 import warnings
 import weakref
 from asyncio import AbstractEventLoop, Future, Queue, Task
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from types import TracebackType
 from typing import Any, overload
 from uuid import UUID
@@ -26,7 +26,11 @@ from surrealdb.connections.builders import (
     _map_result,
 )
 from surrealdb.connections.url import Url
-from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
+from surrealdb.connections.utils_mixin import (
+    AUTH_FALLBACK_QUERY,
+    UtilsMixin,
+    render_projection,
+)
 from surrealdb.data.cbor import decode
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
@@ -691,6 +695,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -700,6 +705,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: Table,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -709,6 +715,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: str,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -718,6 +725,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> dict[str, Value] | None: ...
@@ -726,6 +734,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: Table,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> list[Value]: ...
@@ -734,6 +743,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: str,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value: ...
@@ -741,6 +751,7 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -750,10 +761,26 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
         list of records. Pass ``into=Model`` to map each record onto ``Model``.
+
+        ``fields`` narrows the projection, so the server sends only what is
+        asked for rather than the whole record::
+
+            db.select(RecordID("person", "tobie"), fields=["name", "email"])
+            db.select(Table("person"), fields=["address.city"])
+
+        A dot walks into a nested object; each segment is escaped separately, so
+        a name with a space or unicode in it is quoted correctly. A field whose
+        name genuinely contains a dot cannot be spelled this way - use
+        :meth:`query` for that.
+
+        Note that ``id`` is not included unless you ask for it, exactly as in
+        SurrealQL. A model passed to ``into=`` that declares an ``id`` field
+        therefore needs ``fields=["id", ...]``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
-        query = f"SELECT * FROM {resource_ref}"
+        projection = render_projection(fields)
+        query = f"SELECT {projection} FROM {resource_ref}"
 
         response = await self.query_raw(
             query, variables, session_id=session_id, txn_id=txn_id

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -1,5 +1,5 @@
 import uuid
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from types import TracebackType
 from typing import Any, overload
 from uuid import UUID
@@ -21,6 +21,7 @@ from surrealdb.connections.utils_mixin import (
     UtilsMixin,
     build_run_query,
     merge_query_vars,
+    render_projection,
 )
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
@@ -469,27 +470,59 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         self.vars.pop(key, None)
 
     @overload
-    def select(self, record: RecordID, *, into: type[M]) -> M | None: ...
+    def select(
+        self, record: RecordID, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> M | None: ...
     @overload
-    def select(self, record: Table, *, into: type[M]) -> list[M]: ...
+    def select(
+        self, record: Table, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> list[M]: ...
     @overload
-    def select(self, record: str, *, into: type[M]) -> M | list[M] | None: ...
+    def select(
+        self, record: str, *, fields: Sequence[str] | None = None, into: type[M]
+    ) -> M | list[M] | None: ...
     @overload
-    def select(self, record: RecordID) -> dict[str, Value] | None: ...
+    def select(
+        self, record: RecordID, *, fields: Sequence[str] | None = None
+    ) -> dict[str, Value] | None: ...
     @overload
-    def select(self, record: Table) -> list[Value]: ...
+    def select(
+        self, record: Table, *, fields: Sequence[str] | None = None
+    ) -> list[Value]: ...
     @overload
-    def select(self, record: str) -> Value: ...
-    def select(self, record: RecordIdType, *, into: type[M] | None = None) -> Any:
+    def select(self, record: str, *, fields: Sequence[str] | None = None) -> Value: ...
+    def select(
+        self,
+        record: RecordIdType,
+        *,
+        fields: Sequence[str] | None = None,
+        into: type[M] | None = None,
+    ) -> Any:
         """Select records eagerly.
 
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
         list of records. Pass ``into=Model`` to map each record onto ``Model``.
+
+        ``fields`` narrows the projection, so the server sends only what is
+        asked for rather than the whole record::
+
+            db.select(RecordID("person", "tobie"), fields=["name", "email"])
+            db.select(Table("person"), fields=["address.city"])
+
+        A dot walks into a nested object; each segment is escaped separately, so
+        a name with a space or unicode in it is quoted correctly. A field whose
+        name genuinely contains a dot cannot be spelled this way - use
+        :meth:`query` for that.
+
+        Note that ``id`` is not included unless you ask for it, exactly as in
+        SurrealQL. A model passed to ``into=`` that declares an ``id`` field
+        therefore needs ``fields=["id", ...]``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
-        query = f"SELECT * FROM {resource_ref}"
+        projection = render_projection(fields)
+        query = f"SELECT {projection} FROM {resource_ref}"
 
         response = self.query_raw(query, variables)
         self.check_response_for_error(response, "select")

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -8,7 +8,7 @@ import threading
 import time
 import uuid
 import weakref
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from types import TracebackType
 from typing import Any, overload
 from uuid import UUID
@@ -29,7 +29,11 @@ from surrealdb.connections.builders import (
 )
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
-from surrealdb.connections.utils_mixin import AUTH_FALLBACK_QUERY, UtilsMixin
+from surrealdb.connections.utils_mixin import (
+    AUTH_FALLBACK_QUERY,
+    UtilsMixin,
+    render_projection,
+)
 from surrealdb.data.types.record_id import RecordID, RecordIdType
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
@@ -450,6 +454,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -459,6 +464,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: Table,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -468,6 +474,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: str,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M],
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -477,6 +484,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordID,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> dict[str, Value] | None: ...
@@ -485,6 +493,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: Table,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> list[Value]: ...
@@ -493,6 +502,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: str,
         *,
+        fields: Sequence[str] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
     ) -> Value: ...
@@ -500,6 +510,7 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         self,
         record: RecordIdType,
         *,
+        fields: Sequence[str] | None = None,
         into: type[M] | None = None,
         session_id: UUID | None = None,
         txn_id: UUID | None = None,
@@ -509,10 +520,26 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         A ``RecordID`` (or ``"table:id"``) returns the record dict, or ``None``
         when it is absent. A ``Table`` (or bare table-name string) returns the
         list of records. Pass ``into=Model`` to map each record onto ``Model``.
+
+        ``fields`` narrows the projection, so the server sends only what is
+        asked for rather than the whole record::
+
+            db.select(RecordID("person", "tobie"), fields=["name", "email"])
+            db.select(Table("person"), fields=["address.city"])
+
+        A dot walks into a nested object; each segment is escaped separately, so
+        a name with a space or unicode in it is quoted correctly. A field whose
+        name genuinely contains a dot cannot be spelled this way - use
+        :meth:`query` for that.
+
+        Note that ``id`` is not included unless you ask for it, exactly as in
+        SurrealQL. A model passed to ``into=`` that declares an ``id`` field
+        therefore needs ``fields=["id", ...]``.
         """
         variables: dict[str, Any] = {}
         resource_ref = self._resource_to_variable(record, variables, "_resource")
-        query = f"SELECT * FROM {resource_ref}"
+        projection = render_projection(fields)
+        query = f"SELECT {projection} FROM {resource_ref}"
 
         response = self.query_raw(
             query, variables, session_id=session_id, txn_id=txn_id

--- a/src/surrealdb/connections/utils_mixin.py
+++ b/src/surrealdb/connections/utils_mixin.py
@@ -8,7 +8,11 @@ from surrealdb.connections.builders import (
     _resource_to_variable,  # pyright: ignore[reportPrivateUsage]
 )
 from surrealdb.data.cbor import decode
-from surrealdb.data.types.record_id import RecordID, RecordIdType
+from surrealdb.data.types.record_id import (
+    RecordID,
+    RecordIdType,
+    escape_identifier,
+)
 from surrealdb.data.types.table import Table
 from surrealdb.errors import (
     ConnectionUnavailableError,
@@ -97,6 +101,67 @@ _UNQUOTABLE = ("`", "\n", "\r")
 # Prefix for the generated argument parameters. Distinctive so it cannot
 # collide with a name someone bound with `let()`.
 _RUN_ARG_PREFIX = "__surreal_run_arg"
+
+
+def render_projection(fields: Sequence[str] | None) -> str:
+    """Render ``select(fields=[...])`` as the projection of a ``SELECT``.
+
+    ``None`` means every field, so the projection is ``*`` and the emitted query
+    is byte-for-byte what it was before this argument existed.
+
+    A field list cannot be parameter-bound - SurrealQL has no ``SELECT $f`` -
+    so it is the one part that has to be inlined, and therefore the one part
+    that has to be escaped. Each name goes through
+    :func:`~surrealdb.data.types.record_id.escape_identifier`, so a field
+    containing a space, unicode, or SurrealQL punctuation is quoted rather than
+    concatenated into the statement.
+
+    **Dots separate path segments and are escaped individually.** Escaping a
+    whole ``"address.city"`` produces ``⟨address.city⟩``, which the server reads
+    as one field of that literal name and answers ``{"address.city": None}`` -
+    a silent null rather than an error, which is the worst way to be wrong.
+    ``⟨address⟩.⟨city⟩`` selects the nested value, so that is what this emits.
+    The cost is that a field whose name genuinely contains a dot cannot be
+    expressed here; use :meth:`query` for that.
+
+    :raises TypeError: if *fields* is a bare string. ``", ".join("name")``
+        yields ``n, a, m, e`` - one projection per character - so a plain
+        string is refused rather than spread, the same way ``run()`` refuses
+        one for its arguments.
+    :raises ValueError: if the list is empty, or a name is empty or has an
+        empty path segment. ``SELECT  FROM t`` and ``SELECT ⟨⟩ FROM t`` are not
+        what any caller meant.
+    """
+    if fields is None:
+        return "*"
+    if isinstance(fields, str):
+        raise TypeError(
+            "select() fields must be a sequence of field names, not a single "
+            f"string - got {fields!r}. Pass [{fields!r}] for one field."
+        )
+    names = list(fields)
+    if not names:
+        raise ValueError(
+            "select() fields must name at least one field; pass fields=None "
+            "(the default) to select them all"
+        )
+
+    rendered: list[str] = []
+    for field in names:
+        if not isinstance(field, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(
+                "select() fields must be strings, got "
+                f"{type(field).__name__}: {field!r}"
+            )
+        if not field:
+            raise ValueError("select() fields cannot contain an empty name")
+        segments = field.split(".")
+        if any(not segment for segment in segments):
+            raise ValueError(
+                f"{field!r} is not a valid field path: it has an empty segment"
+            )
+        rendered.append(".".join(escape_identifier(segment) for segment in segments))
+    return ", ".join(rendered)
 
 
 def build_run_query(

--- a/tests/unit_tests/connections/test_select_fields.py
+++ b/tests/unit_tests/connections/test_select_fields.py
@@ -1,0 +1,242 @@
+"""``select(fields=[...])`` narrows the projection without opening a hole.
+
+The capability was always reachable through ``query("SELECT a, b FROM $r")``;
+what this adds is the discoverable spelling on the method that already binds
+the resource for you, and composes with ``into=``.
+
+A field list is the one part of the statement that cannot be parameter-bound -
+SurrealQL has no ``SELECT $f`` - so it has to be inlined, which is exactly why
+it has to be escaped. Joining the caller's strings straight into the query, as
+the original proposal did, turns a field list into arbitrary SurrealQL:
+
+    ", ".join(["a", "b FROM other; --"])  ->  SELECT a, b FROM other; --
+
+Two escaping traps are covered below because getting either wrong is silent
+rather than loud:
+
+* escaping a whole ``"address.city"`` yields ``⟨address.city⟩``, which the
+  server reads as one field of that literal name and answers with ``None`` -
+  no error, just a null where the value should be;
+* a bare string spreads per character, so ``fields="name"`` would project
+  ``n, a, m, e``. That is the same shape as the ``run("fn::f", "ab")`` bug that
+  called ``f("a", "b")``.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+from surrealdb.connections.utils_mixin import render_projection
+from surrealdb.data.types.record_id import RecordID
+from surrealdb.data.types.table import Table
+
+_SETUP = (
+    'CREATE {t}:1 SET a = 1, b = 2, blob = "not wanted", '
+    'address = {{ city: "Paris", zip: "75001" }}, '
+    "⟨my field⟩ = 3, ⟨héllo⟩ = 4"
+)
+
+
+def _rows(connection: Any) -> str:
+    table = f"fld_{uuid.uuid4().hex[:8]}"
+    connection.query(_SETUP.format(t=table)).execute()
+    return table
+
+
+# --------------------------------------------------------------- the projection
+
+
+def test_only_the_named_fields_come_back(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    row = blocking_ws_connection.select(RecordID(table, 1), fields=["a", "b"])
+
+    assert row == {"a": 1, "b": 2}
+
+
+def test_the_default_is_unchanged(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """``fields=None`` has to emit exactly what it emitted before this existed."""
+    table = _rows(blocking_ws_connection)
+
+    row: Any = blocking_ws_connection.select(RecordID(table, 1))
+
+    assert set(row) == {"a", "b", "blob", "address", "my field", "héllo", "id"}
+    assert render_projection(None) == "*"
+
+
+def test_a_table_target_projects_every_row(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    table = _rows(blocking_ws_connection)
+    blocking_ws_connection.query(f"CREATE {table}:2 SET a = 9, b = 8").execute()
+
+    rows: Any = blocking_ws_connection.select(Table(table), fields=["a"])
+
+    assert sorted(row["a"] for row in rows) == [1, 9]
+    assert all(set(row) == {"a"} for row in rows)
+
+
+def test_id_is_not_included_unless_asked_for(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """Documented, and the thing most likely to surprise an ``into=`` user."""
+    table = _rows(blocking_ws_connection)
+
+    assert "id" not in blocking_ws_connection.select(RecordID(table, 1), fields=["a"])
+    assert "id" in blocking_ws_connection.select(RecordID(table, 1), fields=["id", "a"])
+
+
+def test_it_composes_with_into(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    from dataclasses import dataclass
+
+    @dataclass
+    class Partial:
+        a: int
+        b: int
+
+    table = _rows(blocking_ws_connection)
+
+    row = blocking_ws_connection.select(
+        RecordID(table, 1), fields=["a", "b"], into=Partial
+    )
+
+    assert row == Partial(a=1, b=2)
+
+
+# --------------------------------------------------------------- escaping
+
+
+def test_a_dotted_name_walks_into_the_nested_object(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The trap: escaping the whole string returns ``None`` rather than raising.
+
+    ``⟨address.city⟩`` is a field literally named ``address.city``, which does
+    not exist, so the server answers with a null and nothing anywhere says the
+    projection was misread.
+    """
+    table = _rows(blocking_ws_connection)
+
+    row = blocking_ws_connection.select(RecordID(table, 1), fields=["address.city"])
+
+    assert row == {"address": {"city": "Paris"}}
+    assert render_projection(["address.city"]) == "address.city"
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        pytest.param("my field", 3, id="space"),
+        pytest.param("héllo", 4, id="unicode"),
+    ],
+)
+def test_a_name_needing_quotes_is_quoted(
+    blocking_ws_connection: BlockingWsSurrealConnection, field: str, expected: int
+) -> None:
+    table = _rows(blocking_ws_connection)
+
+    row = blocking_ws_connection.select(RecordID(table, 1), fields=[field])
+
+    assert row == {field: expected}
+
+
+def test_a_field_list_cannot_smuggle_in_surrealql(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """The defect in the original proposal, asserted against a live server.
+
+    Joined raw this reads ``SELECT a, b FROM other_table; --``. Escaped, the
+    whole thing is one (absent) field name, so the statement stays a
+    projection of the table that was asked for.
+    """
+    table = _rows(blocking_ws_connection)
+    hostile = "b FROM other_table; --"
+
+    row: Any = blocking_ws_connection.select(RecordID(table, 1), fields=["a", hostile])
+
+    assert row["a"] == 1
+    assert row[hostile] is None, "the injected text was not treated as a field name"
+    assert "⟨" in render_projection([hostile])
+
+
+# --------------------------------------------------------------- refusals
+
+
+def test_a_bare_string_is_refused_not_spread() -> None:
+    with pytest.raises(TypeError) as caught:
+        render_projection("name")  # pyright: ignore[reportArgumentType]
+
+    assert "not a single string" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        pytest.param([], ValueError, id="empty-list"),
+        pytest.param([""], ValueError, id="empty-name"),
+        pytest.param(["a..b"], ValueError, id="empty-segment"),
+        pytest.param([".a"], ValueError, id="leading-dot"),
+        pytest.param([1], TypeError, id="not-a-string"),
+    ],
+)
+def test_unusable_field_lists_are_refused(
+    fields: Any, expected: type[Exception]
+) -> None:
+    with pytest.raises(expected):
+        render_projection(fields)
+
+
+def test_the_refusal_happens_before_any_io(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+) -> None:
+    """A caller mistake is decided locally, and the connection is untouched."""
+    table = _rows(blocking_ws_connection)
+
+    with pytest.raises(TypeError):
+        blocking_ws_connection.select(RecordID(table, 1), fields="a")  # pyright: ignore[reportArgumentType]
+
+    assert blocking_ws_connection.query("RETURN 1").first() == 1
+
+
+# --------------------------------------------------------------- every transport
+
+
+def test_the_blocking_http_transport_agrees(
+    blocking_http_connection: BlockingHttpSurrealConnection,
+) -> None:
+    table = _rows(blocking_http_connection)
+
+    assert blocking_http_connection.select(RecordID(table, 1), fields=["a"]) == {"a": 1}
+
+
+async def test_the_async_ws_transport_agrees(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    table = f"fld_{uuid.uuid4().hex[:8]}"
+    await async_ws_connection.query(_SETUP.format(t=table)).execute()
+
+    row = await async_ws_connection.select(RecordID(table, 1), fields=["a", "b"])
+
+    assert row == {"a": 1, "b": 2}
+
+
+async def test_the_async_http_transport_agrees(
+    async_http_connection: AsyncHttpSurrealConnection,
+) -> None:
+    table = f"fld_{uuid.uuid4().hex[:8]}"
+    await async_http_connection.query(_SETUP.format(t=table))
+
+    row = await async_http_connection.select(RecordID(table, 1), fields=["b"])
+
+    assert row == {"b": 2}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Picks up the idea in #239 / surrealdb/suggestions#115 — asking `select()` for a subset of fields — and implements it in a shape that can ship.

```python
await db.select(RecordID("person", "tobie"), fields=["name", "email"])
await db.select(Table("person"), fields=["address.city"])
```

The capability was always reachable through `query("SELECT a, b FROM $r", vars={"r": rid})`. What this adds is the spelling on the method that already binds the resource for you and composes with `into=`, so narrowing a projection no longer means dropping to hand-written SurrealQL and rebuilding the target binding yourself.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

A keyword-only `fields: Sequence[str] | None = None` on `select()`, across all four `select()` implementations — so it exists on all six connection classes, since the embedded pair inherit the websocket ones. `fields=None` is the default and emits the same `SELECT * FROM ...` as before, byte for byte.

### Escaping is the whole problem

A field list is the one part of the statement SurrealQL cannot bind — there is no `SELECT $f` — so it has to be inlined, and therefore escaped. Every name goes through `escape_identifier`. Joined raw, as the original proposal did:

```
", ".join(["a", "b FROM other_table; --"])  ->  SELECT a, b FROM other_table; --
```

There's a second, quieter trap. Escaping a whole `"address.city"` gives `⟨address.city⟩`, which the server reads as one field of that literal name and answers `{"address.city": None}` — **a silent null, not an error**. So dots are split and each segment escaped separately, giving `⟨address⟩.⟨city⟩`. I verified both behaviours against a live server before choosing:

| projection | server returns |
| --- | --- |
| `address.city` | `{'address': {'city': 'Paris'}}` |
| `⟨address.city⟩` | `{'address.city': None}` |
| `⟨address⟩.⟨city⟩` | `{'address': {'city': 'Paris'}}` |

The cost is that a field whose name genuinely *contains* a dot cannot be spelled this way. That's documented; `query()` still can.

### Three refusals, each decided before any I/O

- **A bare string** is rejected rather than spread — `", ".join("name")` projects `n, a, m, e`, the same shape as the `run("fn::f", "ab")` bug that called `f("a", "b")`.
- **An empty list**, and **an empty name or path segment**, because `SELECT  FROM t` and `SELECT ⟨⟩ FROM t` are not what anyone meant.

### `id` is not implicit

`fields=["a"]` returns no `id`, exactly as in SurrealQL. That's on every `select()` docstring and in the README, because it's what will surprise an `into=` user whose model declares one — they need `fields=["id", ...]`.

Anything beyond a list of field names — aliases, functions, `WHERE`, `ORDER BY` — remains a `query()`. This is deliberately not the start of a query builder.

## What is your testing strategy?

19 new tests in `tests/unit_tests/connections/test_select_fields.py`, covering the projection, both escaping traps, the refusals, `into=` composition, and all four transports.

Mutation-tested — each mutation names the tests that must fail, checked in file order **and** whole-directory order:

```
[ok] #239's raw join: no escaping at all
[ok] escape the whole name, not per segment
[ok] a bare string is spread again
[ok] empty/malformed field lists accepted
[ok] fields ignored entirely (always SELECT *)

Every mutation is caught by the specific test written for it, in both orders.
```

Full suite against **SurrealDB 2.0.5, 2.3.10 and 3.2.3** — 1595 passed on 3.x, 1461 passed / 38 pre-existing skips on each 2.x. Exercised on all six connection classes directly (blocking/async × ws/http, plus both embedded). `ruff`, `mypy src/`, `mypy tests/`, `pyright src/` clean. Both README examples were run as written.

## Is this related to any issues?

Supersedes #239, and implements surrealdb/suggestions#115.

Relative to #239 this changes four things: a named keyword-only parameter instead of `**kwargs` (which defeated the `py.typed` surface, so `fields=` typos selected everything silently); escaping instead of a raw join; all six connection classes instead of `async_ws` alone; and threading through the `into=` overloads so the typed returns still hold. The `begin()` `isinstance(result, UUID)` branch that #239 also carried has since landed on `main` independently.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
