### PR TITLE
Release 3.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.6] - 2026-08-15
+
+One user-visible addition, and a linter that had been switched off without
+anyone noticing.
+
+### Added
+
+- `select(fields=[...])` narrows the projection, so the server sends only the
+  fields asked for rather than the whole record - on all six connection classes.
+  The capability was always reachable through `query("SELECT a, b FROM $r")`;
+  this is the spelling on the method that already binds the resource for you and
+  composes with `into=`. A dot walks into a nested object, and each segment is
+  escaped separately: escaping a whole `"address.city"` would ask for a field of
+  that literal name, which the server answers with a null rather than an error.
+  A field list cannot be parameter-bound - SurrealQL has no `SELECT $f` - so it
+  is the one part that must be inlined, and every name is escaped on the way in.
+  `id` is not included unless you ask for it, exactly as in SurrealQL, so a model
+  passed to `into=` that declares one needs `fields=["id", ...]`. `fields=None`
+  is the default and emits the same statement as before.
+
+### Fixed
+
+- The linter had been checking almost nothing. `select` in the ruff config
+  *replaces* ruff's defaults rather than adding to them, so setting it to
+  `["I", "UP"]` turned pyflakes off across the whole project - nothing had been
+  checking for unused imports, unused variables or undefined names. Turning the
+  defaults back on and adding bugbear, comprehensions, pie, simplify and the
+  ruff-specific rules found 42 unused imports and 12 unused variables. Two other
+  blind spots went with it: `src/surrealdb/__init__.py` was excluded from ruff
+  entirely, and CI pointed it at `./src` alone, so the test suite was linted and
+  formatted by nothing. No behaviour changes, but eight `pytest.raises(Exception)`
+  are now narrowed to what the code actually raises, so they no longer pass on an
+  unrelated `AttributeError`.
+
+
 ## [3.0.0-beta.5] - 2026-08-15
 
 The second review pass over the 3.0.0 surface, and the first that verified its
@@ -302,7 +337,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.5...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.6...HEAD
+[3.0.0-beta.6]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.5...v3.0.0-beta.6
 [3.0.0-beta.5]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.4...v3.0.0-beta.5
 [3.0.0-beta.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.3...v3.0.0-beta.4
 [3.0.0-beta.3]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.2...v3.0.0-beta.3

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.5"
+version = "3.0.0-beta.6"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.5"
+version = "3.0.0-beta.6"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.5"
+version = "3.0.0-beta.6"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.5"
+version = "3.0.0-beta.6"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -65,7 +65,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.5",
+    "surrealdb-embedded==3.0.0-beta.6",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b5"
+version = "3.0.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1662,7 +1662,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b5"
+version = "3.0.0b6"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Release 3.0.0-beta.6, one day after beta.5.

Two things have landed since: `select(fields=[...])` (#338), which is the only user-visible change, and the ruff config fix (#337), which found that pyflakes had been switched off project-wide.

Still a beta for the same reason as last time — the embedded authentication change shipped in beta.5 alters engine behaviour rather than SDK behaviour, and it has had roughly a day in the wild. That is what these betas are buying.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

*(Metadata only — the code it releases is already merged.)*

## What does this change do?

The four version sites that must stay in lockstep, both lockfiles, and the CHANGELOG.

| | |
| --- | --- |
| `pyproject.toml` `version` | `3.0.0-beta.6` |
| `pyproject.toml` `surrealdb-embedded==` pin | `3.0.0-beta.6` |
| `embedded/pyproject.toml` `version` | `3.0.0-beta.6` |
| `embedded/Cargo.toml` `version` | `3.0.0-beta.6` |
| `uv.lock`, `embedded/Cargo.lock` | refreshed |

`Development Status` stays `4 - Beta` in both pyprojects; it moves to `5 - Production/Stable` at 3.0.0.

## What is your testing strategy?

Built both wheels and installed them into a clean Python 3.12 virtualenv with no `./src` on `PYTHONPATH` — 1499 passed at `3.0.0b6` / `3.0.0b6`.

Then checked beta.6's own feature is really in the artifact rather than only in the source tree:

```
fields=[a,b]           -> {'a': 1, 'b': 2}
fields=[address.city]  -> {'address': {'city': 'Paris'}}
bare string refused    -> ok
```

Also re-checked the two things that only bite mid-release: the `==3.0.0-beta.6` pin normalises to PyPI's `3.0.0b6`, and all seven of `build.yml`'s action pins resolve — that workflow never runs on a PR, so a bad pin is invisible to CI.

Full suite on `main` before the bump: 1595 on 3.2.3, and #338 was verified against 2.0.5 and 2.3.10 as well.

## Is this related to any issues?

Releases #337 and #338.

**After merge**: `git tag v3.0.0-beta.6` + push, then `gh release create v3.0.0-beta.6 --title v3.0.0-beta.6 --prerelease` with notes from the CHANGELOG section. `--prerelease` keeps it off the "latest" pointer; publishing the release is what triggers `build.yml` to push both packages to PyPI. Installing needs `--pre`.

I have not tagged or released — that publishes to PyPI irreversibly. Say the word and I'll run it.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
