### PR TITLE
Assert what these tests were only hoping for

### DIFF
--- a/tests/unit_tests/connections/live/test_async_http.py
+++ b/tests/unit_tests/connections/live/test_async_http.py
@@ -1,14 +1,38 @@
-from uuid import UUID
+"""``live()`` over HTTP is refused, and says why.
+
+This was an ``xfail`` asserting the *old* behaviour - that `live()` on an HTTP
+connection returned a ``UUID``, marked "live method not implemented for HTTP
+connections". It has been refused with ``UnsupportedFeatureError`` since live
+queries were made consistent across the transports, so the marker described a
+version of the SDK that no longer exists.
+
+Worse, an ``xfail`` only records *that* something failed. This one would have
+stayed green if ``live()`` had started raising ``AttributeError`` from a typo,
+because that is a failure too. The refusal is a documented part of the API, so
+it is asserted directly.
+"""
 
 import pytest
 
 from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.errors import SurrealError, UnsupportedFeatureError
 
 
-@pytest.mark.xfail(reason="live method not implemented for HTTP connections")
-async def test_query(
+async def test_live_is_refused_with_the_reason(
     async_http_connection_with_user: AsyncHttpSurrealConnection,
 ) -> None:
-    outcome = await async_http_connection_with_user.live("user")
-    assert isinstance(outcome, UUID)
-    await async_http_connection_with_user.query("DELETE user;")
+    with pytest.raises(UnsupportedFeatureError, match="WebSocket") as caught:
+        await async_http_connection_with_user.live("user")
+
+    # Catchable through the tree the README tells people to use.
+    assert isinstance(caught.value, SurrealError)
+
+
+async def test_the_connection_still_works_afterwards(
+    async_http_connection_with_user: AsyncHttpSurrealConnection,
+) -> None:
+    """The refusal is local, so it costs the connection nothing."""
+    with pytest.raises(UnsupportedFeatureError):
+        await async_http_connection_with_user.live("user")
+
+    assert await async_http_connection_with_user.query("RETURN 1").first() == 1

--- a/tests/unit_tests/data_types/test_table.py
+++ b/tests/unit_tests/data_types/test_table.py
@@ -143,8 +143,13 @@ async def surrealdb_connection() -> AsyncGenerator[AsyncWsSurrealConnection, Non
 
 
 # Database send+receive tests
+#
+# These were marked `xfail(reason="Waiting for a fix in SurrealDB")`. The fix
+# arrived: all three pass on 2.0.5, 2.3.10 and 3.2.3. An `xfail` that always
+# passes reports `xpassed`, which is not a failure, so the marker was hiding
+# the one thing it should have surfaced - that the round trip now works, and
+# would go unnoticed if it broke again.
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Waiting for a fix in SurrealDB")
 async def test_table_db_roundtrip(surrealdb_connection: Any) -> None:
     """Test sending Table to SurrealDB and receiving it back."""
     table = Table("users")
@@ -157,7 +162,6 @@ async def test_table_db_roundtrip(surrealdb_connection: Any) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Waiting for a fix in SurrealDB")
 async def test_multiple_tables_db_roundtrip(surrealdb_connection: Any) -> None:
     """Test sending multiple Table objects to SurrealDB."""
     tables = {
@@ -176,7 +180,6 @@ async def test_multiple_tables_db_roundtrip(surrealdb_connection: Any) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Waiting for a fix in SurrealDB")
 async def test_table_in_array_db_roundtrip(surrealdb_connection: Any) -> None:
     """Test sending array of Table objects to SurrealDB."""
     tables_array = [


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Four `xfail` markers describe a version of the SDK that no longer exists — and because `xpass` is not a failure, nothing has been saying so. Every test run this week has reported `3 xpassed` and nobody (including me) looked at what they were.

Worth catching before a stable cut, because an `xfail` that can never fail is a test that cannot regress.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

**Three in `test_table.py`** were marked `xfail(reason="Waiting for a fix in SurrealDB")`, waiting on `Table` values round-tripping through the database. The fix arrived — they pass on **2.0.5, 2.3.10 and 3.2.3**. The marker was hiding the one thing it should have surfaced: that the round trip works now, and would go unnoticed if it broke again.

**The fourth** asserted that `live()` on an HTTP connection returns a `UUID`, marked *"live method not implemented for HTTP connections"*. Live queries were made consistent across the transports since, so it raises `UnsupportedFeatureError` naming the reason.

That one is the more interesting case, because an `xfail` only records *that* something failed. It would have stayed green if `live()` had started raising `AttributeError` from a typo. I confirmed that by mutating `live()` to raise exactly that — the replacement assertions fail, the marker did not:

```
FAILED test_live_is_refused_with_the_reason
FAILED test_the_connection_still_works_afterwards
```

The replacement asserts the documented behaviour directly: `UnsupportedFeatureError`, matching `WebSocket`, catchable as `SurrealError`, and the connection still usable afterwards since the refusal is local.

## What is your testing strategy?

Full suite on **SurrealDB 2.0.5, 2.3.10 and 3.2.3**:

```
3.2.3   1600 passed          (was: 1596 passed, 1 xfailed, 3 xpassed)
2.3.10  1466 passed, 38 skipped
2.0.5   1466 passed, 38 skipped
```

No xfails and no xpasses remain anywhere in the suite. `ruff`, `mypy tests/` clean.

## Is this related to any issues?

Found while sweeping for anything that should not be frozen into a stable 3.0.0.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines]

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md
