### PR TITLE
Release 3.0.0-beta.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         surrealdb-version: ["v2.0.5", "v2.1.9", "v2.2.8", "v2.3.10", "v3.0.5", "nightly"]
     name: Core Tests - Python ${{ matrix.python-version }} - SurrealDB ${{ matrix.surrealdb-version }}
     steps:
@@ -291,7 +291,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: Embedded Tests - Python ${{ matrix.python-version }}
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.7] - 2026-08-15
+
+The surfaces a new user meets before they call a method: the PyPI page, the
+migration table, the export list, and the examples. A pre-stable audit across
+API parity, packaging, error contracts and documentation found nothing that a
+later release could not fix, so this is the cheap half - the things that are
+simply wrong today.
+
+### Added
+
+- The seven usable geometry classes are now exported from `surrealdb`:
+  `GeometryPoint`, `GeometryLine`, `GeometryPolygon`, `GeometryMultiPoint`,
+  `GeometryMultiLine`, `GeometryMultiPolygon` and `GeometryCollection`. The
+  package used to export exactly one geometry name - `Geometry`, the base class -
+  and that is the single one you cannot send: it constructs, then fails at encode
+  time with `cannot encode Geometry`. `Geometry` is still exported, for
+  `isinstance` checks and annotations.
+- Python 3.14 is supported, tested and declared. The pure-Python package needed
+  no change, and the embedded extension is built `abi3-py39`, so the existing
+  wheel already runs on it. Both are now in the CI matrix rather than only in the
+  classifier list.
+
+### Fixed
+
+- The README's migration table illustrated the `query()` return-shape change
+  with `SELECT 1`, which is a parse error on every SurrealDB version. It is now
+  `RETURN 1`, which runs.
+- Four README links were relative. The README is the PyPI long description, and
+  PyPI renders it with no repository around it, so those four 404'd on the
+  project page.
+- Every example declared `surrealdb>=1.0.7`, which resolves to 2.0.0 and cannot
+  import the 3.x code sitting in the same directory. All 21 declarations across
+  the 12 example projects now ask for `>=3.0.0`.
+- The fastapi example could not be imported by following its own README: it
+  annotates `EmailStr` without depending on `pydantic[email]`.
+- The logfire example crashed twice. `logfire.configure(console=True)` raises
+  `'bool' object has no attribute 'span_style'` before any tracing starts, and
+  the example read `query()` in the 2.x shape - one `TypeError`, and a user count
+  that reported `1` for any query because it measured statements rather than rows.
+- Four `xfail` markers described an SDK that no longer exists. Three were waiting
+  on a `Table` round trip that SurrealDB has since fixed, and one asserted that
+  `live()` over HTTP returns a `UUID` when it has raised `UnsupportedFeatureError`
+  since the transports were made consistent. An `xfail` records only *that*
+  something failed, so the last one would have stayed green if `live()` had begun
+  raising `AttributeError` from a typo.
+
 ## [3.0.0-beta.6] - 2026-08-15
 
 One user-visible addition, and a linter that had been switched off without
@@ -337,7 +383,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.6...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.7...HEAD
+[3.0.0-beta.7]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.6...v3.0.0-beta.7
 [3.0.0-beta.6]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.5...v3.0.0-beta.6
 [3.0.0-beta.5]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.4...v3.0.0-beta.5
 [3.0.0-beta.4]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.3...v3.0.0-beta.4

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.7"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.7"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.7"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.7"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Database",
     "Topic :: Database :: Front-Ends",
     "Topic :: Database :: Database Engines/Servers",
@@ -65,7 +66,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.6",
+    "surrealdb-embedded==3.0.0-beta.7",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b6"
+version = "3.0.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1662,7 +1662,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b6"
+version = "3.0.0b7"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Another beta before the stable cut. This ships the content of [#340](https://github.com/surrealdb/surrealdb.py/pull/340) and [#341](https://github.com/surrealdb/surrealdb.py/pull/341) plus Python 3.14 support, so the pre-stable fixes get a release on PyPI to be exercised against before `3.0.0` freezes anything.

**This must merge after [#340](https://github.com/surrealdb/surrealdb.py/pull/340) and [#341](https://github.com/surrealdb/surrealdb.py/pull/341)** — the CHANGELOG entry here describes their content, and both are green and awaiting review. There is no file overlap, so this branch merges cleanly whichever order they land in, but the tag must not be cut until all three are on main.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Moves the version from `3.0.0-beta.6` to `3.0.0-beta.7` in the four places that must stay in lockstep — `pyproject.toml` `version`, the `surrealdb-embedded==` pin in `[project.optional-dependencies].embedded`, `embedded/pyproject.toml` `version`, and `embedded/Cargo.toml` `version` — and refreshes both lockfiles. `uv lock` and the cargo refresh moved exactly three version lines between them, with no dependency re-resolution.

`Development Status` stays at `4 - Beta` in both pyproject files. It moves to `5 - Production/Stable` in the stable release, not this one.

Promotes `## [Unreleased]` to `## [3.0.0-beta.7]`, opens a fresh `[Unreleased]`, and adds the compare links.

**Python 3.14.** The audit flagged that `requires-python` already permits 3.14 while the classifiers stopped at 3.13. Rather than take that on faith I ran it, and 3.14 works for both packages — so the classifier was under-claiming, not aspirational. Both pyproject files gain `Programming Language :: Python :: 3.14`, and both CI matrices (`test` and `test-embedded`) gain a `3.14` row. The CI rows went in alongside the classifier deliberately: a support claim that nothing tests is exactly the toothless pattern this release has spent its time removing. Shipping it in a beta rather than straight into the stable is the better order anyway.

## What is your testing strategy?

**Python 3.14, the new claim — now confirmed by CI rather than by me.** Locally the suite passes on 3.14.7 (1542 passed, excluding embedded, which needs the extension built), and for the embedded half I installed the *published* `surrealdb-embedded==3.0.0b6` wheel into a 3.14 interpreter and ran a `mem://` round trip, which returned a real record and reported `surrealdb-3.2.4` — the extension is built `abi3-py39`, so the single `cp39`-tagged wheel already covers 3.14. On the previous push of this branch, CI then built the extension from source with maturin for 3.14 and ran the embedded suite green, along with all 6 server majors including nightly. Both halves of the claim are backed by a test, not an inference.

**The metadata that actually ships**, read out of the built wheel rather than the source:

```
Name: surrealdb
Version: 3.0.0b7
Classifier: Development Status :: 4 - Beta
Requires-Dist: surrealdb-embedded==3.0.0-beta.7; extra == 'embedded'
Requires-Python: >=3.10
```

The `==3.0.0-beta.7` pin has to match the PyPI-normalised `3.0.0b7`, so that is checked rather than assumed: `Requirement("surrealdb-embedded==3.0.0-beta.7").specifier.contains(Version("3.0.0b7"), prereleases=True)` is `True`.

**The `build.yml` action pins.** Those actions never run on a PR, so a bad `uses:` pin is invisible to CI and only bites halfway through a publish. All 7 resolve: `PyO3/maturin-action`, `actions/checkout`, `actions/download-artifact`, `actions/setup-python`, `actions/upload-artifact`, `dtolnay/rust-toolchain`, `pypa/gh-action-pypi-publish`.

**Everything else.** Full suite green on the release branch (1595 passed against 3.2.3 — the 3 xpassed are the stale markers #340 removes), ruff clean, and `git grep` confirms no `3.0.0-beta.6` or `3.0.0b6` reference survives anywhere outside the CHANGELOG's own history.

This is a pre-release: `gh release create` needs `--prerelease`, and installs need `--pre`.

One cosmetic note: the branch is still named `tobiemh/release-3.0.0` from when this was cut as the stable. Renaming it would close this PR, so it stayed. Say the word if you would rather have it re-cut as `tobiemh/release-3.0.0-beta.7`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md)

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md
