### PR TITLE
Release 3.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-beta.8] - 2026-08-21
+
+The release that makes the memory split usable. `surrealdb-memory 1.0.0-beta.1`
+is already on PyPI, but every install path the docs describe - the `[memory]`
+extra and the `surrealdb.memory` import - lives in this package, so until now
+they pointed at nothing.
+
 ### Changed
 
 - **Breaking:** the memory client has moved out of this package. It was
@@ -444,7 +451,8 @@ Follow-up to `3.0.0-alpha.1` that finalises the v3 API surface and fixes a batch
 ### Added
 - Initial stable release of the SurrealDB Python client.
 
-[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.7...HEAD
+[Unreleased]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.8...HEAD
+[3.0.0-beta.8]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.7...v3.0.0-beta.8
 [3.0.0-beta.7]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.6...v3.0.0-beta.7
 [3.0.0-beta.6]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.5...v3.0.0-beta.6
 [3.0.0-beta.5]: https://github.com/surrealdb/surrealdb.py/compare/v3.0.0-beta.4...v3.0.0-beta.5

--- a/embedded/Cargo.lock
+++ b/embedded/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 edition = "2021"
 
 [lib]

--- a/embedded/pyproject.toml
+++ b/embedded/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "surrealdb-embedded"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 description = "SurrealDB embedded database extension for the surrealdb Python SDK"
 authors = [{ name = "SurrealDB" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surrealdb"
-version = "3.0.0-beta.7"
+version = "3.0.0-beta.8"
 description = "SurrealDB python client"
 readme = "README.md"
 authors = [{ name = "SurrealDB" }]
@@ -66,7 +66,7 @@ documentation = "https://surrealdb.com/docs/sdk/python"
 
 [project.optional-dependencies]
 embedded = [
-    "surrealdb-embedded==3.0.0-beta.7",
+    "surrealdb-embedded==3.0.0-beta.8",
 ]
 pydantic = [
     "pydantic>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.0b7"
+version = "3.0.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1666,7 +1666,7 @@ test = [
 
 [[package]]
 name = "surrealdb-embedded"
-version = "3.0.0b7"
+version = "3.0.0b8"
 source = { editable = "embedded" }
 
 [[package]]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`surrealdb-memory 1.0.0-beta.1` is [published](https://pypi.org/project/surrealdb-memory/), but every install path the docs describe lives in *this* package — the `[memory]` extra and the `surrealdb.memory` import both landed after `3.0.0-beta.7`. So against the currently published SDK, all three of these are broken right now:

```
pip install 'surrealdb[memory]'      -> WARNING: surrealdb 3.0.0b7 does not provide the extra 'memory'
from surrealdb.memory import Memory  -> ModuleNotFoundError: No module named 'surrealdb.memory'
```

This is the release that makes the split usable. Until it ships, the README and both CHANGELOGs describe an install that does not work.

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

Moves the version from `3.0.0-beta.7` to `3.0.0-beta.8` in the four places that must stay in lockstep — `pyproject.toml` `version`, the `surrealdb-embedded==` pin in `[project.optional-dependencies].embedded`, `embedded/pyproject.toml` `version`, `embedded/Cargo.toml` `version` — and refreshes both lockfiles. `uv lock` and the cargo refresh moved exactly three version lines between them, with no dependency re-resolution.

Promotes `## [Unreleased]` to `## [3.0.0-beta.8]`, opens a fresh `[Unreleased]`, and adds the compare links. The promoted entry is the memory split, already merged in [#346](https://github.com/surrealdb/surrealdb.py/pull/346).

`Development Status` stays `4 - Beta` in both pyproject files, and the `[memory]` pin is untouched at `>=1.0.0b1`.

## What is your testing strategy?

**The thing this release exists for, verified against real PyPI.** The beta.8 wheel was built and installed *with the extra*, so `surrealdb-memory` was resolved from PyPI rather than from the path dependency the dev environment uses:

```
surrealdb          3.0.0b8
surrealdb-memory   1.0.0b1     <- from PyPI
from surrealdb.memory import Memory -> <class 'surrealdb_memory._client.Memory'>
Memory is surrealdb_memory.Memory -> True
84 names forwarded
```

Note it resolved the *pre-release* addon with no `--pre`, which is the whole reason the extra pins `>=1.0.0b1` and not `>=1.0`: a specifier that does not itself name a pre-release excludes them, and `>=1.0` would have left this resolving to nothing.

**The metadata that actually ships**, read out of the built wheel rather than the source:

```
Name: surrealdb
Version: 3.0.0b8
Classifier: Development Status :: 4 - Beta
Provides-Extra: embedded   Requires-Dist: surrealdb-embedded==3.0.0-beta.8; extra == 'embedded'
Provides-Extra: memory     Requires-Dist: surrealdb-memory>=1.0.0b1; extra == 'memory'
Provides-Extra: pydantic
Requires-Python: >=3.10
```

**The `build.yml` action pins.** Those actions never run on a PR, so a bad `uses:` pin is invisible to CI and only bites halfway through a publish. All 7 resolve.

**Everything else.** 1483 SDK tests and 95 addon tests green, ruff clean, and `git grep` confirms no `3.0.0-beta.7` or `3.0.0b7` reference survives anywhere outside the CHANGELOG's own history.

**One thing to watch on the release itself.** This is the first SDK release since releases became tag-selected, so the `plan` job has to route `v3.0.0-beta.8` down the SDK path and leave the memory client alone. The memory release proved the other branch of that logic — `memory-v1.0.0-beta.1` skipped all six SDK build jobs and both SDK publishes — but the SDK branch has not run yet. On the release run, `Build agent memory package` and `Release surrealdb-memory to PyPI` should both show as **skipped**.

This is a pre-release: `gh release create` needs `--prerelease`, and installs need `--pre`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md)

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md
