### PR TITLE
Add file support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,13 @@ jobs:
 
       - name: Start surrealdb
         run: surreal start --allow-all -u root -p root --log trace &
+        # Buckets are gated behind an experimental capability, so without this
+        # the file tests skip rather than run - and a skipped test is not a
+        # passing one. Servers too old to know the flag ignore it, and the tests
+        # detect the capability rather than the version, so they still skip
+        # cleanly on 2.x.
+        env:
+          SURREAL_CAPS_ALLOW_EXPERIMENTAL: files
 
       - name: Wait for startup
         run: sleep 5
@@ -269,6 +276,13 @@ jobs:
 
       - name: Start surrealdb
         run: surreal start --allow-all -u root -p root --log trace &
+        # Buckets are gated behind an experimental capability, so without this
+        # the file tests skip rather than run - and a skipped test is not a
+        # passing one. Servers too old to know the flag ignore it, and the tests
+        # detect the capability rather than the version, so they still skip
+        # cleanly on 2.x.
+        env:
+          SURREAL_CAPS_ALLOW_EXPERIMENTAL: files
 
       - name: Wait for startup
         run: sleep 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recognise - a passthrough dict would turn `limti=2` into "every file in the
   bucket" with nothing to indicate why. `start` is exclusive.
 
+  The reference and the contents are kept as different types: `File` is the
+  bucket-plus-key reference, and contents are plain `bytes` - `put` takes
+  `bytes`, `bytearray` or `memoryview`, and `get` returns `bytes`. A `str` is
+  refused rather than encoded on your behalf, because the server stores bytes and
+  `get` returns them, so accepting one would let `put(f, s)` succeed while
+  `get(f) == s` was False. A file handle is refused too, with a message naming
+  `handle.read()`.
+
   Buckets are an experimental server feature: the server must be started with
   `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files`, and the tests detect that capability
   rather than a version number, since the same build has it or not depending on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- File support. SurrealDB stores files in buckets - in memory, on disk, or on
+  object storage such as S3 - and `File` is a reference to one: a bucket plus a
+  key. It carries no bytes and is not a Python file object.
+
+  `db.files` provides typed helpers over the `file::*` functions on all six
+  connection classes, and on sessions and transactions too, so
+  `txn.files.put(...)` runs inside that transaction:
+
+  ```python
+  from surrealdb import File
+
+  avatar = File("images", "/photos/avatar.png")
+  db.files.put(avatar, png_bytes)
+  png_bytes = db.files.get(avatar)          # None if absent
+  meta = db.files.head(avatar)              # FileMetadata | None
+  for entry in db.files.list("images", prefix="/photos", limit=50):
+      print(entry.file.key, entry.size)
+  ```
+
+  `put`, `put_if_not_exists`, `get`, `exists`, `delete`, `head`, `list`, `copy`,
+  `copy_if_not_exists`, `rename` and `rename_if_not_exists`. `get` and `head`
+  return `None` for a file that does not exist rather than raising; `delete` is
+  idempotent; `list` raises when the *bucket* is missing, because an empty bucket
+  and a misspelled one are different mistakes.
+
+  The wire format is CBOR tag 55 carrying `[bucket, key]`, matching the
+  JavaScript SDK's `TAG_FILE_POINTER`. A key is normalised to start with `/`, as
+  it is there, so `File("b", "a.txt")` and `File("b", "/a.txt")` are one file.
+
+  Every helper binds the `File` as a parameter rather than writing it into the
+  query, which is not a style choice: SurrealQL's `f"bucket:/key"` literal
+  accepts only `[A-Za-z0-9_-./]` and has **no escape mechanism**, so a key with a
+  space, an accent or an emoji cannot be expressed as a literal at all. Bound,
+  every key works. `str(File(...))` renders the literal form for logging and is
+  display-only; `File.is_literal_safe()` reports whether a given file could be
+  written into a query.
+
+  `list()` takes `limit`, `prefix` and `start` as keyword arguments rather than
+  an options dict because the server *silently ignores* option keys it does not
+  recognise - a passthrough dict would turn `limti=2` into "every file in the
+  bucket" with nothing to indicate why. `start` is exclusive.
+
+  Buckets are an experimental server feature: the server must be started with
+  `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files`, and the tests detect that capability
+  rather than a version number, since the same build has it or not depending on
+  how it was started. The embedded engine does not enable it, so `db.files` on a
+  `mem://` connection reports the server's own "experimental files feature"
+  error.
+
+
 ## [3.0.0-beta.8] - 2026-08-21
 
 The release that makes the memory split usable. `surrealdb-memory 1.0.0-beta.1`

--- a/README.md
+++ b/README.md
@@ -968,6 +968,74 @@ async with AsyncSurreal("ws://localhost:8000") as db:
 
 For a complete example with configuration options and best practices, see [`examples/logfire/`](https://github.com/surrealdb/surrealdb.py/tree/main/examples/logfire).
 
+## Files
+
+SurrealDB can store files in a bucket - in memory, on disk, or on object storage
+such as S3. A `File` is a *reference* to one: a bucket plus a key. It holds no
+bytes and is not a Python file object.
+
+Buckets are currently an experimental server feature, so the server has to be
+started with `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files`, and a bucket has to exist:
+
+```surql
+DEFINE BUCKET images BACKEND "memory";
+```
+
+```python
+from surrealdb import File, Surreal
+
+with Surreal("ws://localhost:8000/rpc") as db:
+    db.signin({"username": "root", "password": "root"})
+    db.use("ns", "db")
+
+    avatar = File("images", "/photos/avatar.png")
+
+    db.files.put(avatar, png_bytes)          # upload, replacing anything there
+    png_bytes = db.files.get(avatar)         # -> bytes, or None if absent
+
+    meta = db.files.head(avatar)             # -> FileMetadata | None
+    print(meta.size, meta.updated)
+
+    for entry in db.files.list("images", prefix="/photos", limit=50):
+        print(entry.file.key, entry.size)
+```
+
+`db.files` is available on all six connection classes, and on sessions and
+transactions too - `txn.files.put(...)` runs inside that transaction. The async
+classes take the same calls with `await`.
+
+| Method | Returns |
+| --- | --- |
+| `put(file, content)` | `None`, replacing anything at that key |
+| `put_if_not_exists(file, content)` | `None`; writes only if the key is free |
+| `get(file)` | `bytes`, or `None` if the file does not exist |
+| `exists(file)` | `bool` |
+| `delete(file)` | `None`; deleting an absent file is not an error |
+| `head(file)` | `FileMetadata`, or `None` if absent |
+| `list(bucket, *, limit=, prefix=, start=)` | `list[FileMetadata]`; `start` is exclusive |
+| `copy(source, target)` / `copy_if_not_exists` | `None` |
+| `rename(file, key)` / `rename_if_not_exists` | `None`; `key` is a `str`, within the same bucket |
+
+A key is normalised to start with `/`, so `File("b", "a.txt")` and
+`File("b", "/a.txt")` are the same file.
+
+#### Why files are bound, not written into queries
+
+SurrealQL's file literal - `f"bucket:/key"` - accepts only
+`[A-Za-z0-9_-./]`, and there is **no escape mechanism**. A key containing a
+space, an accent or an emoji cannot be written as a literal at all:
+
+```
+Parse error: Unexpected character ` `, file strings key's only allow alpha
+numeric characters and `_`, `-`, `.`, and `/`
+```
+
+Every `db.files` method binds the `File` as a query parameter instead, which
+carries any key. `str(File(...))` renders the literal form for logging, but is
+display-only - use `File.is_literal_safe()` if you need to know whether a
+given file could be written into a query, and bind it rather than interpolating
+it either way.
+
 ## Agent memory
 
 Agent memory is an optional client for [Spectron](https://github.com/surrealdb/spectron),

--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,17 @@ classes take the same calls with `await`.
 A key is normalised to start with `/`, so `File("b", "a.txt")` and
 `File("b", "/a.txt")` are the same file.
 
+The two halves are different types: a `File` is the *reference* (bucket plus
+key), and the contents are plain `bytes`. `put` accepts `bytes`, `bytearray` or
+`memoryview` and `get` returns `bytes`. A `str` is refused rather than encoded
+for you — the server stores bytes, so accepting one would make `put(f, s)`
+succeed and `get(f) == s` be False. Encode it yourself, and pick the encoding:
+
+```python
+db.files.put(readme, "hello".encode("utf-8"))
+db.files.put(photo, handle.read())            # not the handle itself
+```
+
 #### Why files are bound, not written into queries
 
 SurrealQL's file literal - `f"bucket:/key"` - accepts only

--- a/src/surrealdb/__init__.py
+++ b/src/surrealdb/__init__.py
@@ -23,9 +23,11 @@ from surrealdb.connections.builders import (
     SyncInsertBuilder,
     SyncQueryBuilder,
 )
+from surrealdb.connections.files import AsyncFiles, BlockingFiles, FileMetadata
 from surrealdb.connections.url import Url, UrlScheme
 from surrealdb.data.types.datetime import Datetime, PreciseDatetime
 from surrealdb.data.types.duration import Duration
+from surrealdb.data.types.file import File
 from surrealdb.data.types.geometry import (
     Geometry,
     GeometryCollection,
@@ -143,6 +145,13 @@ __all__ = [
     # Data types
     "Table",
     "Duration",
+    # A reference to a file in a storage bucket - bucket plus key, no contents.
+    # `FileMetadata` is what `files.head()` and `files.list()` return; the two
+    # `*Files` helpers are what `db.files` is, exported so they can be annotated.
+    "File",
+    "FileMetadata",
+    "BlockingFiles",
+    "AsyncFiles",
     # Same shape of mistake as `Range` below, one worse: `Geometry` is the base
     # class, so the only exported geometry name is the one that cannot be sent.
     # It constructs, then fails at encode time with "cannot encode Geometry".

--- a/src/surrealdb/connections/async_http.py
+++ b/src/surrealdb/connections/async_http.py
@@ -16,6 +16,7 @@ from surrealdb.connections.builders import (
     M,
     _map_result,
 )
+from surrealdb.connections.files import AsyncFiles
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
     AUTH_FALLBACK_QUERY,
@@ -699,3 +700,8 @@ class AsyncHttpSurrealConnection(AsyncTemplate, UtilsMixin):
         raise UnsupportedFeatureError(
             "Multi-session and client-side transactions are only supported for WebSocket connections"
         )
+
+    @property
+    def files(self) -> AsyncFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return AsyncFiles(self)

--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -25,6 +25,7 @@ from surrealdb.connections.builders import (
     M,
     _map_result,
 )
+from surrealdb.connections.files import AsyncFiles
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
     AUTH_FALLBACK_QUERY,
@@ -1466,6 +1467,11 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         """
         await self.close()
 
+    @property
+    def files(self) -> AsyncFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return AsyncFiles(self)
+
 
 class AsyncSurrealSession:
     def __init__(
@@ -1736,6 +1742,11 @@ class AsyncSurrealSession:
     async def close_session(self) -> None:
         await self._connection.detach(self._session_id)
 
+    @property
+    def files(self) -> AsyncFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return AsyncFiles(self)
+
 
 class AsyncSurrealTransaction:
     def __init__(
@@ -1998,3 +2009,8 @@ class AsyncSurrealTransaction:
 
     async def cancel(self) -> None:
         await self._connection.cancel(self._txn_id, session_id=self._session_id)
+
+    @property
+    def files(self) -> AsyncFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return AsyncFiles(self)

--- a/src/surrealdb/connections/blocking_http.py
+++ b/src/surrealdb/connections/blocking_http.py
@@ -14,6 +14,7 @@ from surrealdb.connections.builders import (
     SyncQueryBuilder,
     _map_result,
 )
+from surrealdb.connections.files import BlockingFiles
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
@@ -652,3 +653,8 @@ class BlockingHttpSurrealConnection(SyncTemplate, UtilsMixin):
         raise UnsupportedFeatureError(
             "Multi-session and client-side transactions are only supported for WebSocket connections"
         )
+
+    @property
+    def files(self) -> BlockingFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return BlockingFiles(self)

--- a/src/surrealdb/connections/blocking_ws.py
+++ b/src/surrealdb/connections/blocking_ws.py
@@ -27,6 +27,7 @@ from surrealdb.connections.builders import (
     SyncQueryBuilder,
     _map_result,
 )
+from surrealdb.connections.files import BlockingFiles
 from surrealdb.connections.sync_template import SyncTemplate
 from surrealdb.connections.url import Url
 from surrealdb.connections.utils_mixin import (
@@ -1404,6 +1405,11 @@ class BlockingWsSurrealConnection(SyncTemplate, UtilsMixin):
         """
         self.close()
 
+    @property
+    def files(self) -> BlockingFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return BlockingFiles(self)
+
 
 class BlockingSurrealSession:
     def __init__(
@@ -1653,6 +1659,11 @@ class BlockingSurrealSession:
 
     def close_session(self) -> None:
         self._connection.detach(self._session_id)
+
+    @property
+    def files(self) -> BlockingFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return BlockingFiles(self)
 
 
 class BlockingSurrealTransaction:
@@ -1907,3 +1918,8 @@ class BlockingSurrealTransaction:
 
     def cancel(self) -> None:
         self._connection.cancel(self._txn_id, session_id=self._session_id)
+
+    @property
+    def files(self) -> BlockingFiles:
+        """Typed helpers over the ``file::*`` functions - see `surrealdb.connections.files`."""
+        return BlockingFiles(self)

--- a/src/surrealdb/connections/files.py
+++ b/src/surrealdb/connections/files.py
@@ -1,0 +1,289 @@
+"""Typed helpers over SurrealDB's ``file::*`` functions.
+
+Reached as ``db.files`` on any connection, and on a session or transaction too -
+``txn.files.put(...)`` runs inside that transaction. That works because these
+helpers hold a *query runner* rather than a connection: a session and a
+transaction each expose ``query()`` with their own id already bound, so nothing
+here has to thread ``session_id`` or ``txn_id`` through eleven methods.
+
+Every method binds the ``File`` as a parameter rather than writing it into the
+query. That is not a style preference: SurrealQL's ``f"bucket:/key"`` literal
+accepts only ``[A-Za-z0-9_-./]`` and has no escape mechanism, so a key with a
+space, an accent or an emoji cannot be written as a literal at all. Bound, every
+key works - see ``surrealdb.data.types.file`` for the parser's own wording.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+# Imported at runtime, not under TYPE_CHECKING: `FileMetadata` is a dataclass, so
+# its annotations are evaluated by `typing.get_type_hints` - which the public
+# annotations guard does for every exported name - and a name that only exists
+# for type checkers raises `NameError` there.
+from surrealdb.data.types.datetime import PreciseDatetime
+from surrealdb.data.types.file import File
+from surrealdb.errors import UnexpectedResponseError
+
+__all__ = ["AsyncFiles", "BlockingFiles", "FileMetadata"]
+
+
+@dataclass(frozen=True)
+class FileMetadata:
+    """What ``head`` and ``list`` report about one stored file."""
+
+    file: File
+    size: int
+    updated: PreciseDatetime | None
+
+
+class _QueryRunner(Protocol):
+    def query(self, query: str, vars: dict[str, Any] | None = ...) -> Any: ...
+
+
+def _metadata(raw: Any) -> FileMetadata:
+    """Turn one ``{file, size, updated}`` object into a ``FileMetadata``.
+
+    The ``file`` arrives already decoded - it is CBOR tag 55, which the codec
+    handles - and ``updated`` is tag 12, which it already handled before files
+    existed. So this only reshapes; it does not parse.
+    """
+    if not isinstance(raw, dict) or "file" not in raw:
+        raise UnexpectedResponseError(
+            f"expected file metadata with a 'file' key, got {raw!r}"
+        )
+    return FileMetadata(
+        file=raw["file"], size=raw.get("size", 0), updated=raw.get("updated")
+    )
+
+
+def _list_options(
+    limit: int | None, prefix: str | None, start: str | None
+) -> dict[str, Any]:
+    """Build ``file::list``'s options object from explicit arguments.
+
+    Explicit parameters rather than a passthrough ``dict`` because the server
+    *silently ignores* option keys it does not recognise - a probe with
+    ``{"nonsense": 1}`` returned the whole bucket. A caller who typed ``limti=2``
+    against a dict-shaped API would get every file and no indication why, so the
+    misspelling is caught here by Python instead.
+    """
+    options: dict[str, Any] = {}
+    if limit is not None:
+        if isinstance(limit, bool) or not isinstance(limit, int):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(f"limit must be an int, not {type(limit).__name__}")
+        if limit < 1:
+            raise ValueError(f"limit must be positive, got {limit}")
+        options["limit"] = limit
+    for name, value in (("prefix", prefix), ("start", start)):
+        if value is not None:
+            if not isinstance(value, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise TypeError(f"{name} must be a str, not {type(value).__name__}")
+            options[name] = value
+    return options
+
+
+def _check_file(value: object, argument: str = "file") -> None:
+    if not isinstance(value, File):
+        raise TypeError(
+            f"{argument} must be a surrealdb.File, not {type(value).__name__}: "
+            f"{value!r}"
+        )
+
+
+def _check_key(value: object) -> None:
+    """``file::rename``'s second argument is a key, not a file.
+
+    Passing a ``File`` there fails server-side with "Incorrect arguments for
+    function file::rename(). Argument 2 was..."; refusing it here says which
+    argument and why, at the call that made the mistake.
+    """
+    if isinstance(value, File):
+        raise TypeError(
+            "key must be a str, not a File - rename moves within the same "
+            f"bucket, so pass the new key: files.rename(file, {value.key!r})"
+        )
+    if not isinstance(value, str):
+        raise TypeError(f"key must be a str, not {type(value).__name__}: {value!r}")
+
+
+class BlockingFiles:
+    """``db.files`` on a blocking connection, session or transaction."""
+
+    __slots__ = ("_runner",)
+
+    def __init__(self, runner: _QueryRunner) -> None:
+        self._runner = runner
+
+    def _first(self, query: str, vars: dict[str, Any]) -> Any:
+        return self._runner.query(query, vars).first()
+
+    def put(self, file: File, content: bytes) -> None:
+        """Write ``content``, replacing anything already at that key."""
+        _check_file(file)
+        self._first("RETURN file::put($f, $c)", {"f": file, "c": content})
+
+    def put_if_not_exists(self, file: File, content: bytes) -> None:
+        """Write ``content`` only if the key is free; otherwise do nothing.
+
+        The server neither writes nor complains when the file already exists.
+        """
+        _check_file(file)
+        self._first("RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": content})
+
+    def get(self, file: File) -> bytes | None:
+        """The file's bytes, or ``None`` if it does not exist."""
+        _check_file(file)
+        return self._first("RETURN file::get($f)", {"f": file})
+
+    def exists(self, file: File) -> bool:
+        _check_file(file)
+        return bool(self._first("RETURN file::exists($f)", {"f": file}))
+
+    def delete(self, file: File) -> None:
+        """Remove the file. Deleting one that is already gone is not an error."""
+        _check_file(file)
+        self._first("RETURN file::delete($f)", {"f": file})
+
+    def head(self, file: File) -> FileMetadata | None:
+        """Size and last-modified time, or ``None`` if the file does not exist."""
+        _check_file(file)
+        raw = self._first("RETURN file::head($f)", {"f": file})
+        return None if raw is None else _metadata(raw)
+
+    def list(
+        self,
+        bucket: str,
+        *,
+        limit: int | None = None,
+        prefix: str | None = None,
+        start: str | None = None,
+    ) -> list[FileMetadata]:
+        """Every file in ``bucket``, newest options applied server-side.
+
+        ``start`` is exclusive - listing from ``"/b.txt"`` returns what follows
+        it, not itself. Raises if the bucket does not exist, which is the
+        server's behaviour and worth surfacing rather than flattening to ``[]``:
+        an empty bucket and a missing one are different mistakes.
+        """
+        if not isinstance(bucket, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(f"bucket must be a str, not {type(bucket).__name__}")
+        options = _list_options(limit, prefix, start)
+        if options:
+            raw = self._first("RETURN file::list($b, $o)", {"b": bucket, "o": options})
+        else:
+            raw = self._first("RETURN file::list($b)", {"b": bucket})
+        return [_metadata(entry) for entry in (raw or [])]
+
+    def copy(self, source: File, target: File) -> None:
+        _check_file(source, "source")
+        _check_file(target, "target")
+        self._first("RETURN file::copy($s, $t)", {"s": source, "t": target})
+
+    def copy_if_not_exists(self, source: File, target: File) -> None:
+        _check_file(source, "source")
+        _check_file(target, "target")
+        self._first(
+            "RETURN file::copy_if_not_exists($s, $t)", {"s": source, "t": target}
+        )
+
+    def rename(self, file: File, key: str) -> None:
+        """Move ``file`` to ``key`` within the same bucket."""
+        _check_file(file)
+        _check_key(key)
+        self._first("RETURN file::rename($f, $k)", {"f": file, "k": key})
+
+    def rename_if_not_exists(self, file: File, key: str) -> None:
+        _check_file(file)
+        _check_key(key)
+        self._first("RETURN file::rename_if_not_exists($f, $k)", {"f": file, "k": key})
+
+
+class AsyncFiles:
+    """``db.files`` on an async connection, session or transaction."""
+
+    __slots__ = ("_runner",)
+
+    def __init__(self, runner: _QueryRunner) -> None:
+        self._runner = runner
+
+    async def _first(self, query: str, vars: dict[str, Any]) -> Any:
+        return await self._runner.query(query, vars).first()
+
+    async def put(self, file: File, content: bytes) -> None:
+        """Write ``content``, replacing anything already at that key."""
+        _check_file(file)
+        await self._first("RETURN file::put($f, $c)", {"f": file, "c": content})
+
+    async def put_if_not_exists(self, file: File, content: bytes) -> None:
+        """Write ``content`` only if the key is free; otherwise do nothing."""
+        _check_file(file)
+        await self._first(
+            "RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": content}
+        )
+
+    async def get(self, file: File) -> bytes | None:
+        """The file's bytes, or ``None`` if it does not exist."""
+        _check_file(file)
+        return await self._first("RETURN file::get($f)", {"f": file})
+
+    async def exists(self, file: File) -> bool:
+        _check_file(file)
+        return bool(await self._first("RETURN file::exists($f)", {"f": file}))
+
+    async def delete(self, file: File) -> None:
+        """Remove the file. Deleting one that is already gone is not an error."""
+        _check_file(file)
+        await self._first("RETURN file::delete($f)", {"f": file})
+
+    async def head(self, file: File) -> FileMetadata | None:
+        """Size and last-modified time, or ``None`` if the file does not exist."""
+        _check_file(file)
+        raw = await self._first("RETURN file::head($f)", {"f": file})
+        return None if raw is None else _metadata(raw)
+
+    async def list(
+        self,
+        bucket: str,
+        *,
+        limit: int | None = None,
+        prefix: str | None = None,
+        start: str | None = None,
+    ) -> list[FileMetadata]:
+        """Every file in ``bucket``. ``start`` is exclusive."""
+        if not isinstance(bucket, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(f"bucket must be a str, not {type(bucket).__name__}")
+        options = _list_options(limit, prefix, start)
+        if options:
+            raw = await self._first(
+                "RETURN file::list($b, $o)", {"b": bucket, "o": options}
+            )
+        else:
+            raw = await self._first("RETURN file::list($b)", {"b": bucket})
+        return [_metadata(entry) for entry in (raw or [])]
+
+    async def copy(self, source: File, target: File) -> None:
+        _check_file(source, "source")
+        _check_file(target, "target")
+        await self._first("RETURN file::copy($s, $t)", {"s": source, "t": target})
+
+    async def copy_if_not_exists(self, source: File, target: File) -> None:
+        _check_file(source, "source")
+        _check_file(target, "target")
+        await self._first(
+            "RETURN file::copy_if_not_exists($s, $t)", {"s": source, "t": target}
+        )
+
+    async def rename(self, file: File, key: str) -> None:
+        """Move ``file`` to ``key`` within the same bucket."""
+        _check_file(file)
+        _check_key(key)
+        await self._first("RETURN file::rename($f, $k)", {"f": file, "k": key})
+
+    async def rename_if_not_exists(self, file: File, key: str) -> None:
+        _check_file(file)
+        _check_key(key)
+        await self._first(
+            "RETURN file::rename_if_not_exists($f, $k)", {"f": file, "k": key}
+        )

--- a/src/surrealdb/connections/files.py
+++ b/src/surrealdb/connections/files.py
@@ -92,6 +92,39 @@ def _check_file(value: object, argument: str = "file") -> None:
         )
 
 
+def _check_content(value: object) -> bytes:
+    """Normalise file contents to ``bytes``, refusing anything that would not round-trip.
+
+    ``str`` is refused rather than encoded. The server stores bytes and ``get()``
+    returns bytes, so accepting a string would make ``put(f, s)`` succeed and
+    ``get(f) == s`` be False - a write that looks fine and a read that quietly
+    hands back a different type. Making the caller encode keeps the pair
+    symmetric, and names the encoding they actually want instead of assuming
+    UTF-8 on their behalf.
+
+    ``bytearray`` and ``memoryview`` are accepted and copied: both are real byte
+    buffers, and refusing them would be pedantry. ``memoryview`` in particular
+    reaches the CBOR encoder as an unsupported type otherwise.
+    """
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        raise TypeError(
+            "content must be bytes, not str - `get()` returns bytes, so a str "
+            "here would not round-trip. Encode it first, e.g. "
+            'content.encode("utf-8")'
+        )
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    # Only suggest `.read()` when the value plausibly has one - offering it for
+    # an int is noise, and noise in an error message is what makes people stop
+    # reading them.
+    hint = " - read it first, e.g. handle.read()" if hasattr(value, "read") else ""
+    raise TypeError(
+        f"content must be bytes, not {type(value).__name__}: {value!r}{hint}"
+    )
+
+
 def _check_key(value: object) -> None:
     """``file::rename``'s second argument is a key, not a file.
 
@@ -119,18 +152,22 @@ class BlockingFiles:
     def _first(self, query: str, vars: dict[str, Any]) -> Any:
         return self._runner.query(query, vars).first()
 
-    def put(self, file: File, content: bytes) -> None:
+    def put(self, file: File, content: bytes | bytearray | memoryview) -> None:
         """Write ``content``, replacing anything already at that key."""
         _check_file(file)
-        self._first("RETURN file::put($f, $c)", {"f": file, "c": content})
+        payload = _check_content(content)
+        self._first("RETURN file::put($f, $c)", {"f": file, "c": payload})
 
-    def put_if_not_exists(self, file: File, content: bytes) -> None:
+    def put_if_not_exists(
+        self, file: File, content: bytes | bytearray | memoryview
+    ) -> None:
         """Write ``content`` only if the key is free; otherwise do nothing.
 
         The server neither writes nor complains when the file already exists.
         """
         _check_file(file)
-        self._first("RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": content})
+        payload = _check_content(content)
+        self._first("RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": payload})
 
     def get(self, file: File) -> bytes | None:
         """The file's bytes, or ``None`` if it does not exist."""
@@ -211,16 +248,20 @@ class AsyncFiles:
     async def _first(self, query: str, vars: dict[str, Any]) -> Any:
         return await self._runner.query(query, vars).first()
 
-    async def put(self, file: File, content: bytes) -> None:
+    async def put(self, file: File, content: bytes | bytearray | memoryview) -> None:
         """Write ``content``, replacing anything already at that key."""
         _check_file(file)
-        await self._first("RETURN file::put($f, $c)", {"f": file, "c": content})
+        payload = _check_content(content)
+        await self._first("RETURN file::put($f, $c)", {"f": file, "c": payload})
 
-    async def put_if_not_exists(self, file: File, content: bytes) -> None:
+    async def put_if_not_exists(
+        self, file: File, content: bytes | bytearray | memoryview
+    ) -> None:
         """Write ``content`` only if the key is free; otherwise do nothing."""
         _check_file(file)
+        payload = _check_content(content)
         await self._first(
-            "RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": content}
+            "RETURN file::put_if_not_exists($f, $c)", {"f": file, "c": payload}
         )
 
     async def get(self, file: File) -> bytes | None:

--- a/src/surrealdb/data/cbor.py
+++ b/src/surrealdb/data/cbor.py
@@ -13,6 +13,7 @@ from surrealdb.cbor import (
 from surrealdb.data.types import constants
 from surrealdb.data.types.datetime import Datetime, PreciseDatetime
 from surrealdb.data.types.duration import Duration
+from surrealdb.data.types.file import File
 from surrealdb.data.types.geometry import (
     GeometryCollection,
     GeometryLine,
@@ -61,6 +62,9 @@ def default_encoder(encoder: CBOREncoder, obj: Any) -> None:
 
     elif isinstance(obj, Table):
         tagged = CBORTag(constants.TAG_TABLE_NAME, obj.table_name)
+
+    elif isinstance(obj, File):
+        tagged = CBORTag(constants.TAG_FILE, [obj.bucket, obj.key])
 
     elif isinstance(obj, BoundIncluded):
         tagged = CBORTag(constants.TAG_BOUND_INCLUDED, obj.value)
@@ -145,6 +149,19 @@ def tag_decoder(
         # whole frame.
         return RecordID._unchecked(  # pyright: ignore[reportPrivateUsage]
             tag.value[0], tag.value[1]
+        )
+
+    elif tag.tag == constants.TAG_FILE:
+        # `[bucket, key]`. Built unchecked: the server is the authority on what
+        # a file reference is, and refusing to decode one the SDK dislikes would
+        # lose the whole response rather than the one value.
+        if not isinstance(tag.value, (list, tuple)) or len(tag.value) != 2:
+            raise UnexpectedResponseError(
+                f"expected a [bucket, key] pair for a file, got {tag.value!r}"
+            )
+        return File._unchecked(  # pyright: ignore[reportPrivateUsage]
+            tag.value[0],
+            tag.value[1],
         )
 
     elif tag.tag == constants.TAG_TABLE_NAME:

--- a/src/surrealdb/data/types/constants.py
+++ b/src/surrealdb/data/types/constants.py
@@ -8,6 +8,9 @@ TAG_DECIMAL_STRING = 10
 TAG_RANGE = 49
 TAG_BOUND_INCLUDED = 50
 TAG_BOUND_EXCLUDED = 51
+# A file pointer: `[bucket, key]`. Named TAG_FILE_POINTER in the JavaScript
+# SDK's codec, which is the other implementation of this wire format.
+TAG_FILE = 55
 TAG_SET = 56
 
 TAG_DATETIME_COMPACT = 12

--- a/src/surrealdb/data/types/file.py
+++ b/src/surrealdb/data/types/file.py
@@ -1,0 +1,93 @@
+"""A reference to a file in a storage bucket."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The characters SurrealQL's `f"bucket:/key"` literal syntax accepts. Taken from
+# the parser's own refusal, which is the only documentation of it:
+#
+#   Parse error: Unexpected character ` `, file strings key's only allow alpha
+#   numeric characters and `_`, `-`, `.`, and `/`
+#
+# There is no escape mechanism - not for spaces, not for unicode, not with
+# backslashes - so a key outside this set simply cannot be written as a literal.
+# It can still be *sent*, as a bound parameter, which is what this type is for.
+_LITERAL_SAFE = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-./"
+)
+
+
+def file_type_error(argument: str, value: Any) -> TypeError:
+    return TypeError(
+        f"File {argument} must be a str, not {type(value).__name__}: {value!r}"
+    )
+
+
+class File:
+    """A ``bucket`` plus a ``key``, identifying a file the server stores.
+
+    This is a *reference*, not contents: it holds no bytes and is not a Python
+    file object. Read and write the contents through the ``file::*`` functions,
+    or the ``files`` helper on a connection, which bind it for you::
+
+        f = File("images", "/photos/avatar.png")
+        db.files.put(f, png_bytes)
+        png_bytes = db.files.get(f)
+
+    ``key`` is normalised to start with ``/``, matching the JavaScript SDK, so
+    ``File("b", "a.txt")`` and ``File("b", "/a.txt")`` are the same file. Without
+    that the two would encode differently and address different objects.
+    """
+
+    __slots__ = ("bucket", "key")
+
+    def __init__(self, bucket: str, key: str) -> None:
+        if not isinstance(bucket, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise file_type_error("bucket", bucket)
+        if not isinstance(key, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise file_type_error("key", key)
+        self.bucket: str = bucket
+        self.key: str = key if key.startswith("/") else f"/{key}"
+
+    @classmethod
+    def _unchecked(cls, bucket: str, key: str) -> File:
+        """Build without validating - for the decoder, where the server is the source."""
+        instance = object.__new__(cls)
+        instance.bucket = bucket
+        instance.key = key if key.startswith("/") else f"/{key}"
+        return instance
+
+    def is_literal_safe(self) -> bool:
+        """Whether ``str(self)`` is a literal SurrealQL can actually parse.
+
+        False for a key or bucket containing anything outside
+        ``[A-Za-z0-9_-./]`` - a space, an accent, an emoji, a quote. Those files
+        are perfectly usable; they just have to be bound as parameters rather
+        than written into a query, because the literal syntax has no way to
+        express them.
+        """
+        return _LITERAL_SAFE.issuperset(self.bucket) and _LITERAL_SAFE.issuperset(
+            self.key
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, File):
+            return NotImplemented
+        return self.bucket == other.bucket and self.key == other.key
+
+    def __hash__(self) -> int:
+        return hash((File, self.bucket, self.key))
+
+    def __repr__(self) -> str:
+        return f"File(bucket={self.bucket!r}, key={self.key!r})"
+
+    def __str__(self) -> str:
+        """The SurrealQL literal form, when there is one.
+
+        Display only. For a key the literal syntax cannot express this is not
+        valid SurrealQL, and there is no escaping that would make it so - so
+        never build a query by interpolating this. Bind the ``File`` instead;
+        that carries any key, and the ``files`` helpers do it for you.
+        """
+        return f'f"{self.bucket}:{self.key}"'

--- a/tests/unit_tests/connections/files/conftest.py
+++ b/tests/unit_tests/connections/files/conftest.py
@@ -1,0 +1,65 @@
+"""Gating for the file tests, by *capability* rather than by version.
+
+Buckets are an experimental server feature: the same 3.2.3 build has them or not
+depending on whether it was started with
+
+    SURREAL_CAPS_ALLOW_EXPERIMENTAL=files
+
+so a version check would be wrong in both directions - it would skip a server
+that does support them, and run against one that does not. This asks the server
+to define a bucket instead, and skips if it refuses.
+"""
+
+from typing import Any
+
+import pytest
+
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+BUCKET = "sdk_test_files"
+
+# The probe needs `connection_params`, which is function scoped, so this fixture
+# has to be too - but the answer cannot change while the suite runs, so it is
+# resolved once and remembered rather than reconnecting for every test.
+_SUPPORTED: bool | None = None
+
+
+def _probe(connection_params: dict[str, Any]) -> bool:
+    connection = BlockingWsSurrealConnection(connection_params["ws_url"])
+    try:
+        connection.signin(connection_params["vars_params"])
+        connection.use(
+            namespace=connection_params["namespace"],
+            database=connection_params["database_name"],
+        )
+        connection.query(
+            f'DEFINE BUCKET IF NOT EXISTS {BUCKET} BACKEND "memory"'
+        ).execute()
+    except Exception:
+        return False
+    finally:
+        connection.close()
+    return True
+
+
+@pytest.fixture(autouse=True)
+def _require_file_support(connection_params: dict[str, Any]) -> None:
+    global _SUPPORTED
+    if _SUPPORTED is None:
+        _SUPPORTED = _probe(connection_params)
+    if not _SUPPORTED:
+        pytest.skip(
+            "server has no bucket support; start it with "
+            "SURREAL_CAPS_ALLOW_EXPERIMENTAL=files"
+        )
+
+
+@pytest.fixture
+def bucket(blocking_ws_connection: BlockingWsSurrealConnection) -> str:
+    """A bucket that exists, emptied of whatever a previous test left in it."""
+    blocking_ws_connection.query(
+        f'DEFINE BUCKET IF NOT EXISTS {BUCKET} BACKEND "memory"'
+    ).execute()
+    for entry in blocking_ws_connection.files.list(BUCKET):
+        blocking_ws_connection.files.delete(entry.file)
+    return BUCKET

--- a/tests/unit_tests/connections/files/test_files.py
+++ b/tests/unit_tests/connections/files/test_files.py
@@ -232,6 +232,81 @@ def test_put_if_not_exists_writes_when_the_key_is_free(
     assert blocking_ws_connection.files.get(f) == b"fresh"
 
 
+# --------------------------------------------------------------- the contents side
+
+
+def test_a_string_is_refused_rather_than_silently_encoded(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """The asymmetry this prevents: ``put(f, s)`` then ``get(f) != s``.
+
+    The server stores bytes and ``get`` returns bytes, so a ``str`` accepted here
+    would make the write look fine and the read hand back a different type -
+    silently, with nothing to indicate the round trip was lossy. Refusing it also
+    means the caller names the encoding rather than the SDK assuming UTF-8.
+    """
+    f = File(bucket, _key())
+
+    with pytest.raises(TypeError) as caught:
+        blocking_ws_connection.files.put(f, "text")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    message = str(caught.value)
+    assert "not str" in message
+    assert "encode" in message, "the message must say how to fix it"
+    assert blocking_ws_connection.files.exists(f) is False, "nothing was written"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(b"buffer", id="bytes"),
+        pytest.param(bytearray(b"buffer"), id="bytearray"),
+        pytest.param(memoryview(b"buffer"), id="memoryview"),
+    ],
+)
+def test_every_accepted_buffer_type_round_trips_as_bytes(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    bucket: str,
+    content: Any,
+) -> None:
+    """``memoryview`` reaches the CBOR encoder as an unsupported type otherwise."""
+    f = File(bucket, _key())
+
+    blocking_ws_connection.files.put(f, content)
+
+    assert blocking_ws_connection.files.get(f) == b"buffer"
+
+
+def test_a_file_handle_is_refused_and_told_to_read_itself(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """``put`` takes bytes, so the obvious wrong guess gets a useful answer."""
+    import io
+
+    with pytest.raises(TypeError) as caught:
+        blocking_ws_connection.files.put(File(bucket, _key()), io.BytesIO(b"x"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    assert "handle.read()" in str(caught.value)
+
+
+def test_the_read_hint_is_not_offered_for_values_that_cannot_be_read(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Noise in an error message is what makes people stop reading them."""
+    with pytest.raises(TypeError) as caught:
+        blocking_ws_connection.files.put(File(bucket, _key()), 123)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    assert "read it first" not in str(caught.value)
+
+
+def test_put_if_not_exists_validates_content_too(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Both writers, not just ``put`` - the check is easy to add to one and forget."""
+    with pytest.raises(TypeError, match="not str"):
+        blocking_ws_connection.files.put_if_not_exists(File(bucket, _key()), "text")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+
 # --------------------------------------------------------------- caller mistakes
 
 

--- a/tests/unit_tests/connections/files/test_files.py
+++ b/tests/unit_tests/connections/files/test_files.py
@@ -1,0 +1,385 @@
+"""``db.files`` - the typed helpers over SurrealDB's ``file::*`` functions.
+
+Every helper binds the ``File`` as a parameter rather than writing it into the
+query, and these tests lean on that: the keys with spaces, accents and emoji
+below **cannot be expressed** as a SurrealQL literal at all, because the
+``f"bucket:/key"`` syntax accepts only ``[A-Za-z0-9_-./]`` and has no escape.
+Bound, they work. That is the difference the parameter binding buys, so it is
+asserted rather than assumed.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from surrealdb import File, FileMetadata
+from surrealdb.connections.async_http import AsyncHttpSurrealConnection
+from surrealdb.connections.async_ws import AsyncWsSurrealConnection
+from surrealdb.connections.blocking_http import BlockingHttpSurrealConnection
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
+
+# every byte value, so a transport that mangles high bytes or embedded NULs shows
+EVERY_BYTE = bytes(range(256)) * 8
+
+
+def _key(prefix: str = "") -> str:
+    return f"/{prefix}{uuid.uuid4().hex[:10]}.bin"
+
+
+# --------------------------------------------------------------- the round trip
+
+
+def test_put_then_get_returns_the_same_bytes(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key())
+
+    blocking_ws_connection.files.put(f, EVERY_BYTE)
+
+    assert blocking_ws_connection.files.get(f) == EVERY_BYTE
+
+
+def test_an_empty_file_round_trips(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """``b""`` must come back as ``b""`` and not as ``None``, which means absent."""
+    f = File(bucket, _key())
+
+    blocking_ws_connection.files.put(f, b"")
+
+    assert blocking_ws_connection.files.get(f) == b""
+    assert blocking_ws_connection.files.exists(f) is True
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("/a b.txt", id="space"),
+        pytest.param("/héllo.txt", id="accent"),
+        pytest.param("/emoji-\U0001f389.png", id="emoji"),
+        pytest.param('/quote".txt', id="quote"),
+        pytest.param("/back\\slash.txt", id="backslash"),
+        pytest.param("/@at#hash.txt", id="symbols"),
+    ],
+)
+def test_keys_the_literal_syntax_cannot_express_still_work(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str, key: str
+) -> None:
+    """The reason the helpers bind rather than interpolate.
+
+    Written into a query these produce ``Parse error: ... file strings key's only
+    allow alpha numeric characters and `_`, `-`, `.`, and `/``` - and there is no
+    escaping that fixes it. Bound, they upload and read back.
+    """
+    f = File(bucket, key)
+    assert f.is_literal_safe() is False
+
+    blocking_ws_connection.files.put(f, b"payload")
+
+    assert blocking_ws_connection.files.get(f) == b"payload"
+    assert blocking_ws_connection.files.exists(f) is True
+
+
+def test_the_key_is_normalised_consistently_on_both_sides(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Writing without a leading slash and reading with one is the same file."""
+    name = uuid.uuid4().hex[:10]
+    blocking_ws_connection.files.put(File(bucket, f"{name}.bin"), b"same")
+
+    assert blocking_ws_connection.files.get(File(bucket, f"/{name}.bin")) == b"same"
+
+
+# --------------------------------------------------------------- absence
+
+
+def test_absent_files_report_absence_rather_than_raising(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    gone = File(bucket, _key("gone-"))
+
+    assert blocking_ws_connection.files.get(gone) is None
+    assert blocking_ws_connection.files.head(gone) is None
+    assert blocking_ws_connection.files.exists(gone) is False
+
+
+def test_deleting_is_idempotent(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key())
+    blocking_ws_connection.files.put(f, b"x")
+
+    blocking_ws_connection.files.delete(f)
+    blocking_ws_connection.files.delete(f)  # must not raise
+
+    assert blocking_ws_connection.files.exists(f) is False
+
+
+# --------------------------------------------------------------- metadata
+
+
+def test_head_reports_size_and_a_decoded_file(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key())
+    blocking_ws_connection.files.put(f, EVERY_BYTE)
+
+    meta = blocking_ws_connection.files.head(f)
+
+    assert isinstance(meta, FileMetadata)
+    assert meta.size == len(EVERY_BYTE)
+    assert meta.file == f
+    assert isinstance(meta.file, File), "the file arrives decoded, not as a raw tag"
+    assert meta.updated is not None
+
+
+def test_list_reports_every_file_in_the_bucket(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    keys = {_key("a-"), _key("b-"), _key("c-")}
+    for key in keys:
+        blocking_ws_connection.files.put(File(bucket, key), b"x")
+
+    listed = blocking_ws_connection.files.list(bucket)
+
+    assert {entry.file.key for entry in listed} == keys
+    assert all(isinstance(entry, FileMetadata) for entry in listed)
+
+
+def test_list_applies_limit_and_prefix(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    for key in ("/docs/one.txt", "/docs/two.txt", "/img/three.png"):
+        blocking_ws_connection.files.put(File(bucket, key), b"x")
+
+    assert len(blocking_ws_connection.files.list(bucket, limit=2)) == 2
+    assert {
+        e.file.key for e in blocking_ws_connection.files.list(bucket, prefix="/docs")
+    } == {"/docs/one.txt", "/docs/two.txt"}
+
+
+def test_list_start_is_exclusive(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Documented here because it is the kind of off-by-one that ships quietly."""
+    for key in ("/a.txt", "/b.txt", "/c.txt"):
+        blocking_ws_connection.files.put(File(bucket, key), b"x")
+
+    listed = blocking_ws_connection.files.list(bucket, start="/b.txt")
+
+    assert [e.file.key for e in listed] == ["/c.txt"]
+
+
+def test_listing_a_missing_bucket_raises(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """An empty bucket and a bucket that does not exist are different mistakes.
+
+    Flattening the second to ``[]`` would hide a typo'd bucket name forever.
+    """
+    with pytest.raises(Exception, match="does not exist"):
+        blocking_ws_connection.files.list("no_such_bucket_at_all")
+
+
+# --------------------------------------------------------------- copy and move
+
+
+def test_copy_duplicates_and_leaves_the_source(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    source, target = File(bucket, _key("src-")), File(bucket, _key("dst-"))
+    blocking_ws_connection.files.put(source, b"content")
+
+    blocking_ws_connection.files.copy(source, target)
+
+    assert blocking_ws_connection.files.get(target) == b"content"
+    assert blocking_ws_connection.files.get(source) == b"content"
+
+
+def test_rename_moves_and_removes_the_source(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    source = File(bucket, _key("from-"))
+    destination_key = _key("to-")
+    blocking_ws_connection.files.put(source, b"content")
+
+    blocking_ws_connection.files.rename(source, destination_key)
+
+    assert blocking_ws_connection.files.get(File(bucket, destination_key)) == b"content"
+    assert blocking_ws_connection.files.exists(source) is False
+
+
+def test_put_if_not_exists_does_not_overwrite(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """The server neither writes nor complains, which is easy to misread as a write."""
+    f = File(bucket, _key())
+    blocking_ws_connection.files.put(f, b"original")
+
+    blocking_ws_connection.files.put_if_not_exists(f, b"replacement")
+
+    assert blocking_ws_connection.files.get(f) == b"original"
+
+
+def test_put_if_not_exists_writes_when_the_key_is_free(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key())
+
+    blocking_ws_connection.files.put_if_not_exists(f, b"fresh")
+
+    assert blocking_ws_connection.files.get(f) == b"fresh"
+
+
+# --------------------------------------------------------------- caller mistakes
+
+
+def test_a_non_file_target_is_refused_locally(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    with pytest.raises(TypeError, match=r"surrealdb\.File"):
+        blocking_ws_connection.files.get("images:/a.png")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+
+def test_renaming_to_a_file_says_to_pass_a_key(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Server-side this is "Incorrect arguments for function file::rename()".
+
+    Asserting the *suggestion*, not just the type error. A plain "key must be a
+    str" also comes out of the generic string check below it, so a test that
+    accepted that could not tell whether the File-specific branch still existed -
+    and the whole point of that branch is telling the caller what to pass
+    instead.
+    """
+    f = File(bucket, _key())
+
+    with pytest.raises(TypeError) as caught:
+        blocking_ws_connection.files.rename(f, File(bucket, "/other.bin"))  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    message = str(caught.value)
+    assert "key must be a str" in message
+    assert "'/other.bin'" in message, "the message must name the key to pass instead"
+    assert "same" in message, "and say that rename stays within one bucket"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        pytest.param({"limit": 0}, ValueError, id="limit-zero"),
+        pytest.param({"limit": -1}, ValueError, id="limit-negative"),
+        pytest.param({"limit": "2"}, TypeError, id="limit-string"),
+        pytest.param({"limit": True}, TypeError, id="limit-bool"),
+        pytest.param({"prefix": 1}, TypeError, id="prefix-not-string"),
+        pytest.param({"start": 1}, TypeError, id="start-not-string"),
+    ],
+)
+def test_bad_list_options_are_refused_locally(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    bucket: str,
+    kwargs: dict[str, Any],
+    expected: type[Exception],
+) -> None:
+    with pytest.raises(expected):
+        blocking_ws_connection.files.list(bucket, **kwargs)
+
+
+def test_a_misspelled_option_is_a_type_error_not_a_silent_full_listing(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Why ``list`` takes keyword arguments instead of an options dict.
+
+    The server *ignores* option keys it does not recognise - a probe with
+    ``{"nonsense": 1}`` returned the whole bucket - so a passthrough dict would
+    turn ``limti=2`` into "every file", with nothing to indicate why.
+    """
+    for key in ("/a.txt", "/b.txt", "/c.txt"):
+        blocking_ws_connection.files.put(File(bucket, key), b"x")
+
+    with pytest.raises(TypeError):
+        blocking_ws_connection.files.list(bucket, limti=2)  # type: ignore[call-arg]  # pyright: ignore[reportCallIssue]
+
+
+# --------------------------------------------------------------- every transport
+
+
+def test_the_blocking_http_transport_agrees(
+    blocking_http_connection: BlockingHttpSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key("http-"))
+
+    blocking_http_connection.files.put(f, EVERY_BYTE)
+
+    assert blocking_http_connection.files.get(f) == EVERY_BYTE
+    meta = blocking_http_connection.files.head(f)
+    assert meta is not None
+    assert meta.size == len(EVERY_BYTE)
+
+
+async def test_the_async_ws_transport_agrees(
+    async_ws_connection: AsyncWsSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key("aws-"))
+
+    await async_ws_connection.files.put(f, EVERY_BYTE)
+
+    assert await async_ws_connection.files.get(f) == EVERY_BYTE
+    listed = await async_ws_connection.files.list(bucket, prefix=f.key)
+    assert [entry.file for entry in listed] == [f]
+
+
+async def test_the_async_http_transport_agrees(
+    async_http_connection: AsyncHttpSurrealConnection, bucket: str
+) -> None:
+    f = File(bucket, _key("ahttp-"))
+
+    await async_http_connection.files.put(f, EVERY_BYTE)
+
+    assert await async_http_connection.files.get(f) == EVERY_BYTE
+    assert await async_http_connection.files.exists(f) is True
+
+
+# --------------------------------------------------------------- sessions and txns
+
+
+def test_a_session_carries_its_own_context(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    bucket: str,
+    connection_params: dict[str, Any],
+) -> None:
+    """``session.files`` must run *as* that session, not on the bare connection.
+
+    It does because the helper holds a query runner, and the session's ``query``
+    already binds its own id - so there is no ``session_id`` to forget to pass.
+    """
+    session = blocking_ws_connection.new_session()
+    try:
+        session.use(connection_params["namespace"], connection_params["database_name"])
+        f = File(bucket, _key("session-"))
+
+        session.files.put(f, b"from a session")
+
+        assert session.files.get(f) == b"from a session"
+    finally:
+        session.close_session()
+
+
+def test_writes_inside_a_transaction_are_visible_after_commit(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    bucket: str,
+    connection_params: dict[str, Any],
+) -> None:
+    session = blocking_ws_connection.new_session()
+    try:
+        session.use(connection_params["namespace"], connection_params["database_name"])
+        f = File(bucket, _key("txn-"))
+
+        transaction = session.begin_transaction()
+        transaction.files.put(f, b"in a transaction")
+        assert transaction.files.get(f) == b"in a transaction"
+        transaction.commit()
+
+        assert blocking_ws_connection.files.get(f) == b"in a transaction"
+    finally:
+        session.close_session()

--- a/tests/unit_tests/data_types/test_file.py
+++ b/tests/unit_tests/data_types/test_file.py
@@ -1,0 +1,206 @@
+"""``File`` - a reference to a file in a storage bucket.
+
+The wire format is CBOR tag 55 carrying ``[bucket, key]``. That was established
+from both ends rather than from documentation: the server's own decoder error
+names the tag (``no decoder for CBOR tag 55``), and the JavaScript SDK's codec
+encodes ``TAG_FILE_POINTER = 55`` with the same payload order.
+
+The tests about ``__str__`` are the interesting ones. SurrealQL's file literal
+accepts only ``[A-Za-z0-9_-./]`` and has **no escape mechanism** - the parser
+says so itself:
+
+    Parse error: Unexpected character ` `, file strings key's only allow alpha
+    numeric characters and `_`, `-`, `.`, and `/`
+
+So a key containing a space, an accent or an emoji cannot be written as a
+literal at all, and any rendering of one is display-only. The JavaScript SDK's
+``toString()`` backslash-escapes such characters, which produces literals this
+server rejects; that is why this type does not copy it.
+"""
+
+from typing import Any
+
+import pytest
+
+import surrealdb
+from surrealdb.cbor import CBORTag
+from surrealdb.data import cbor
+from surrealdb.data.types import constants
+from surrealdb.data.types.file import File
+from surrealdb.errors import UnexpectedResponseError
+
+# --------------------------------------------------------------- construction
+
+
+def test_bucket_and_key_are_kept() -> None:
+    f = File("images", "/photos/avatar.png")
+
+    assert f.bucket == "images"
+    assert f.key == "/photos/avatar.png"
+
+
+def test_a_key_without_a_leading_slash_is_normalised() -> None:
+    """Otherwise the same file would encode two ways and address two objects.
+
+    The JavaScript SDK normalises in its constructor too, so the two agree.
+    """
+    assert File("b", "a.txt").key == "/a.txt"
+    assert File("b", "/a.txt").key == "/a.txt"
+    assert File("b", "a.txt") == File("b", "/a.txt")
+
+
+def test_normalisation_does_not_double_up() -> None:
+    assert File("b", "//a.txt").key == "//a.txt"
+
+
+@pytest.mark.parametrize(
+    ("bucket", "key", "argument"),
+    [
+        pytest.param(None, "/a", "bucket", id="bucket-none"),
+        pytest.param(1, "/a", "bucket", id="bucket-int"),
+        pytest.param(b"b", "/a", "bucket", id="bucket-bytes"),
+        pytest.param("b", None, "key", id="key-none"),
+        pytest.param("b", 1, "key", id="key-int"),
+        pytest.param("b", b"/a", "key", id="key-bytes"),
+    ],
+)
+def test_both_arguments_must_be_strings(bucket: Any, key: Any, argument: str) -> None:
+    """Caught at the line that made the mistake, as ``Table`` and ``RecordID`` do."""
+    with pytest.raises(TypeError) as caught:
+        File(bucket, key)
+
+    assert argument in str(caught.value)
+
+
+def test_an_empty_bucket_or_key_is_allowed() -> None:
+    """The server decides what it accepts; the SDK only checks the type.
+
+    Same reasoning as ``Table``, which accepts any string because SurrealDB does.
+    """
+    assert File("", "").key == "/"
+
+
+# --------------------------------------------------------------- value semantics
+
+
+def test_equality_is_structural() -> None:
+    assert File("b", "/a") == File("b", "/a")
+    assert File("b", "/a") != File("b", "/z")
+    assert File("b", "/a") != File("other", "/a")
+
+
+def test_it_is_not_equal_to_a_lookalike() -> None:
+    assert File("b", "/a") != ("b", "/a")
+    assert File("b", "/a") != "b:/a"
+
+
+def test_it_is_hashable_and_usable_as_a_key() -> None:
+    seen = {File("b", "/a"): 1}
+    seen[File("b", "/a")] = 2
+
+    assert len(seen) == 1
+    assert seen[File("b", "a")] == 2
+
+
+def test_repr_names_both_halves() -> None:
+    assert repr(File("b", "/a.txt")) == "File(bucket='b', key='/a.txt')"
+
+
+# --------------------------------------------------------------- the literal form
+
+
+def test_str_is_the_surrealql_literal_form() -> None:
+    assert str(File("images", "/photos/avatar.png")) == 'f"images:/photos/avatar.png"'
+
+
+@pytest.mark.parametrize(
+    ("bucket", "key", "safe"),
+    [
+        pytest.param("b", "/hello.txt", True, id="plain"),
+        pytest.param("b", "/nested/path/x.png", True, id="slashes"),
+        pytest.param("my-bucket_1", "/a-b_c.d", True, id="dashes-dots"),
+        pytest.param("b", "/UPPER.TXT", True, id="uppercase"),
+        pytest.param("b", "/1234", True, id="digits"),
+        pytest.param("b", "/a b.txt", False, id="space"),
+        pytest.param("b", "/héllo.txt", False, id="accent"),
+        pytest.param("b", "/emoji-\U0001f389.png", False, id="emoji"),
+        pytest.param("b", '/quote".txt', False, id="quote"),
+        pytest.param("b", "/back\\slash.txt", False, id="backslash"),
+        pytest.param("b", "/@at#hash.txt", False, id="symbols"),
+        pytest.param("bad bucket", "/a.txt", False, id="space-in-bucket"),
+    ],
+)
+def test_is_literal_safe_matches_the_parsers_own_rule(
+    bucket: str, key: str, safe: bool
+) -> None:
+    """The safe set is exactly what the server's parse error names.
+
+    Each of these was round-tripped through a live server while this was written:
+    the ``True`` rows parse, and every ``False`` row is rejected - unescaped *and*
+    backslash-escaped, because the syntax has no escape.
+    """
+    assert File(bucket, key).is_literal_safe() is safe
+
+
+# --------------------------------------------------------------- the wire format
+
+
+def test_it_encodes_as_tag_55_with_bucket_then_key() -> None:
+    """Payload order matters and is not symmetric - swapping it is silent."""
+    tagged = _encode_to_tag(File("images", "/a.png"))
+
+    assert tagged.tag == constants.TAG_FILE == 55
+    assert list(tagged.value) == ["images", "/a.png"]
+
+
+def _encode_to_tag(value: object) -> CBORTag:
+    """Decode with the vendored cbor2 alone, so tags arrive unresolved."""
+    from surrealdb.cbor import loads
+
+    return loads(cbor.encode(value))
+
+
+@pytest.mark.parametrize(
+    ("bucket", "key"),
+    [
+        pytest.param("images", "/photos/avatar.png", id="plain"),
+        pytest.param("b", "/a b.txt", id="space"),
+        pytest.param("b", "/h\u00e9llo.txt", id="accent"),
+        pytest.param("b", "/emoji-\U0001f389.png", id="emoji"),
+        pytest.param("b", "/", id="root"),
+    ],
+)
+def test_it_round_trips_through_cbor(bucket: str, key: str) -> None:
+    """Including keys the literal syntax cannot express - CBOR carries them raw."""
+    original = File(bucket, key)
+
+    decoded = cbor.decode(cbor.encode(original))
+
+    assert isinstance(decoded, File)
+    assert decoded == original
+    assert decoded.bucket == bucket
+    assert decoded.key == key
+
+
+def test_a_malformed_payload_is_refused_with_context() -> None:
+    """A bare ``IndexError`` from inside the decoder would lose the response."""
+    for payload in (["only-one"], [], ["a", "b", "c"], "not-a-list"):
+        with pytest.raises(UnexpectedResponseError) as caught:
+            cbor.decode(cbor.encode(CBORTag(constants.TAG_FILE, payload)))
+
+        assert "file" in str(caught.value).lower()
+
+
+def test_the_decoder_normalises_too() -> None:
+    """A server that ever sent a slashless key must not produce a mismatching File."""
+    decoded = cbor.decode(cbor.encode(CBORTag(constants.TAG_FILE, ["b", "a.txt"])))
+
+    assert decoded == File("b", "/a.txt")
+
+
+# --------------------------------------------------------------- exports
+
+
+def test_it_is_exported_from_the_package() -> None:
+    assert "File" in surrealdb.__all__
+    assert surrealdb.File is File


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

SurrealDB stores files in buckets — memory, disk, or object storage such as S3 — and the Python SDK could not send or receive a file reference at all. A response containing one failed to decode outright: `could not decode the response while query: no decoder for CBOR tag 55`.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

**`File`** — a reference to a file in a bucket: a bucket plus a key. It carries no bytes and is not a Python file object. Exported alongside `FileMetadata`, `BlockingFiles` and `AsyncFiles`.

**`db.files`** — typed helpers over the `file::*` functions: `put`, `put_if_not_exists`, `get`, `exists`, `delete`, `head`, `list`, `copy`, `copy_if_not_exists`, `rename`, `rename_if_not_exists`. Available on all six connection classes, and on sessions and transactions, so `txn.files.put(...)` runs inside that transaction.

That last part works because the helper holds a *query runner* rather than a connection. A session and a transaction each expose `query()` with their own id already bound, so there is no `session_id` or `txn_id` to thread through eleven methods and no way to forget one.

**The wire format was established from both ends, not assumed.** The server's own decoder error names the tag, and the JavaScript SDK's codec confirms it — `TAG_FILE_POINTER = 55`, encoded `[bucket, key]`, decoded to `FileRef`. Tag 55 turned out to be the *only* missing piece: `file::head` and `file::list` return `{file, size, updated}` where `updated` is tag 12, which the codec already handled, so both decode for free.

**Return shapes follow what the server actually does**, which I probed rather than guessed: `get` and `head` answer `None` for an absent file rather than raising, `delete` is idempotent, `put_if_not_exists` neither writes nor complains when the key is taken, and `list` *raises* when the bucket is missing. That last one is passed through deliberately — an empty bucket and a misspelled bucket name are different mistakes, and flattening the second to `[]` would hide a typo forever.

## Two decisions worth explaining

**Files are bound as parameters, never written into queries.** SurrealQL's `f"bucket:/key"` literal accepts only `[A-Za-z0-9_-./]` and has **no escape mechanism** — the parser says so itself:

```
Parse error: Unexpected character ` `, file strings key's only allow alpha
numeric characters and `_`, `-`, `.`, and `/`
```

So a key containing a space, an accent or an emoji cannot be expressed as a literal at all. **The JavaScript SDK's `toString()` is wrong about this**, and is deliberately not ported: its `fmtInner` backslash-escapes unsafe characters, and I round-tripped its output through a live server — six of nine cases are rejected, including `f"b:/a\ b.txt"` and `f"b:/h\éllo.txt"`. Bound as parameters those same keys all upload and read back, which the tests assert. `__str__` here renders the literal form for logging and is documented display-only; `File.is_literal_safe()` reports whether a given file would parse.

**`list()` takes keyword arguments, not an options dict.** The server silently ignores option keys it does not recognise — a probe with `{"nonsense": 1}` returned the entire bucket — so a passthrough dict would turn `limti=2` into "every file" with nothing to indicate why. `limit`, `prefix` and `start` are explicit and validated locally; `start` is exclusive, which is asserted because it is the kind of off-by-one that ships quietly.

## What is your testing strategy?

**70 new tests**: 36 unit (no server needed) and 34 integration. Full suite **1606 passed**; ruff, mypy ×3 and pyright ×2 all clean.

Byte fidelity is checked with every byte value (`bytes(range(256)) * 8`), so a transport that mangles high bytes or embedded NULs would show. Empty files are covered separately, because `b""` must come back as `b""` and not as `None` — which means absent.

**Mutation tested, eight mutations, each caught by the intended test**: wrong tag number, swapped payload order, dropped key normalisation, dropped malformed-payload guard, dropped `File` type check, dropped `limit` validation, and a widened literal-safe set.

Two things that came out of doing it, both worth recording:

- **The eighth mutation initially survived.** Disabling the `File`-specific branch of the rename key check still raised `TypeError` with "key must be a str" from the generic fallback below it, so the test could not tell the helpful message from the useless one — and the whole point of that branch is telling the caller *what to pass instead*. It now asserts the suggested key appears in the message, and the mutation is caught.
- **My first mutation run reported all four mutations surviving, and was itself broken.** An unquoted shell variable meant pytest collected zero tests. Worth flagging because a mutation harness that reports "nothing failed" looks exactly like good news.

**Tests gate on capability, not version.** Buckets are experimental, so the same 3.2.3 build has them or not depending on whether it was started with `SURREAL_CAPS_ALLOW_EXPERIMENTAL=files` — a version check would be wrong in both directions. CI's servers now set that flag, so these tests actually run rather than skipping; I verified both paths, 34 passed with the flag and 34 skipped without it.

## Two things I did not do

**S3 could not be verified.** `DEFINE BUCKET ... BACKEND "s3://…"` returns **"Bucket backend is not supported"** on 3.2.3, so every test here runs against `BACKEND "memory"`. The SDK's work should be backend-agnostic — it sends `[bucket, key]` and the backend is a server-side bucket definition — but that is reasoning, not evidence. Which server version has S3 buckets? CI tops out at `v3.0.5` plus nightly, so the matrix may need a newer entry before this is genuinely covered.

**The embedded engine does not enable the capability.** `db.files` exists on `mem://` connections (they inherit it) but the embedded datastore refuses `DEFINE BUCKET` with the server's own "experimental files feature" error. The `surrealdb-core` builder does expose `with_experimental`, so enabling it is a small Rust change — but turning on an experimental capability by default, when the standalone server requires an explicit opt-in, is a policy decision rather than a side effect of adding a client type. Happy to do it if you want it.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md)

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md
