### PR TITLE
Fix what the file-surface audit found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `File` is a member of the public `Value` union. It was omitted when file
+  support landed, so `db.create(table, {"attachment": File(...)})` - the main
+  reason the type exists - failed a type check on code that worked at runtime,
+  and a returned `File` narrowed to unreachable. The same omission had already
+  shipped once for `set`, so there is now a test asserting the general rule:
+  everything the encoder dispatches on has to be in the union. (`BoundIncluded`
+  and `BoundExcluded` are excluded deliberately - they exist only inside a
+  `Range`, and the server rejects a bare one.)
+
 - File support. SurrealDB stores files in buckets - in memory, on disk, or on
   object storage such as S3 - and `File` is a reference to one: a bucket plus a
   key. It carries no bytes and is not a Python file object.
 
-  `db.files` provides typed helpers over the `file::*` functions on all six
-  connection classes, and on sessions and transactions too, so
-  `txn.files.put(...)` runs inside that transaction:
+  `db.files` provides typed helpers over the `file::*` functions on the four
+  remote connection classes, and on sessions and transactions opened from them.
+  The embedded classes inherit it, but the embedded engine does not enable the
+  experimental files capability. Note that file writes are **not** transactional:
+  `file::*` writes to the bucket backend rather than the transaction, so a write
+  inside one is visible immediately and survives `cancel()`. That is the server's
+  behaviour, not the SDK's, and there is a test pinning it.
 
   ```python
   from surrealdb import File

--- a/README.md
+++ b/README.md
@@ -990,7 +990,9 @@ with Surreal("ws://localhost:8000/rpc") as db:
 
     avatar = File("images", "/photos/avatar.png")
 
-    db.files.put(avatar, png_bytes)          # upload, replacing anything there
+    with open("avatar.png", "rb") as handle:
+        db.files.put(avatar, handle.read())  # bytes, not the handle itself
+
     png_bytes = db.files.get(avatar)         # -> bytes, or None if absent
 
     meta = db.files.head(avatar)             # -> FileMetadata | None
@@ -1000,9 +1002,18 @@ with Surreal("ws://localhost:8000/rpc") as db:
         print(entry.file.key, entry.size)
 ```
 
-`db.files` is available on all six connection classes, and on sessions and
-transactions too - `txn.files.put(...)` runs inside that transaction. The async
-classes take the same calls with `await`.
+`db.files` is available on the four remote connection classes — websocket and
+HTTP, blocking and async — and on sessions and transactions opened from them. The
+async classes take the same calls with `await`. The two embedded classes inherit
+`db.files`, but the embedded engine does not enable the experimental files
+capability, so every call reports that.
+
+**File writes are not transactional.** `txn.files.put(...)` is routed through the
+transaction's session, but `file::*` writes to the bucket backend rather than the
+transaction, so the write is visible to other connections immediately and
+survives `txn.cancel()` — while a `CREATE` in the same transaction rolls back as
+you would expect. That is SurrealDB's behaviour rather than the SDK's, and it is
+worth knowing before you pair a file write with a record write.
 
 | Method | Returns |
 | --- | --- |

--- a/src/surrealdb/connections/files.py
+++ b/src/surrealdb/connections/files.py
@@ -1,10 +1,17 @@
 """Typed helpers over SurrealDB's ``file::*`` functions.
 
-Reached as ``db.files`` on any connection, and on a session or transaction too -
-``txn.files.put(...)`` runs inside that transaction. That works because these
-helpers hold a *query runner* rather than a connection: a session and a
-transaction each expose ``query()`` with their own id already bound, so nothing
-here has to thread ``session_id`` or ``txn_id`` through eleven methods.
+Reached as ``db.files`` on any connection, and on a session or transaction too.
+That works because these helpers hold a *query runner* rather than a connection:
+a session and a transaction each expose ``query()`` with their own id already
+bound, so nothing here has to thread ``session_id`` or ``txn_id`` through eleven
+methods.
+
+Being routed through a transaction is not the same as being *in* one. ``file::*``
+writes to the bucket backend rather than to the transaction, so a write made
+through ``txn.files`` is visible to other connections immediately and survives
+``txn.cancel()``, while a ``CREATE`` in the same transaction rolls back. That is
+the server's behaviour, not something the SDK chooses, and there is a test
+pinning it so it cannot change silently.
 
 Every method binds the ``File`` as a parameter rather than writing it into the
 query. That is not a style preference: SurrealQL's ``f"bucket:/key"`` literal
@@ -197,12 +204,13 @@ class BlockingFiles:
         prefix: str | None = None,
         start: str | None = None,
     ) -> list[FileMetadata]:
-        """Every file in ``bucket``, newest options applied server-side.
+        """Every file in ``bucket``, with any filtering applied server-side.
 
-        ``start`` is exclusive - listing from ``"/b.txt"`` returns what follows
-        it, not itself. Raises if the bucket does not exist, which is the
-        server's behaviour and worth surfacing rather than flattening to ``[]``:
-        an empty bucket and a missing one are different mistakes.
+        Ordered by key, not by time - there is no recency ordering to ask for.
+        ``start`` is exclusive: listing from ``"/b.txt"`` returns what follows it,
+        not itself. Raises if the bucket does not exist, which is the server's
+        behaviour and worth surfacing rather than flattening to ``[]`` - an empty
+        bucket and a misspelled one are different mistakes.
         """
         if not isinstance(bucket, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"bucket must be a str, not {type(bucket).__name__}")
@@ -292,7 +300,7 @@ class AsyncFiles:
         prefix: str | None = None,
         start: str | None = None,
     ) -> list[FileMetadata]:
-        """Every file in ``bucket``. ``start`` is exclusive."""
+        """Every file in ``bucket``, ordered by key. ``start`` is exclusive."""
         if not isinstance(bucket, str):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(f"bucket must be a str, not {type(bucket).__name__}")
         options = _list_options(limit, prefix, start)

--- a/src/surrealdb/types.py
+++ b/src/surrealdb/types.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 from surrealdb.data.types.datetime import Datetime
 from surrealdb.data.types.duration import Duration
+from surrealdb.data.types.file import File
 from surrealdb.data.types.geometry import (
     GeometryCollection,
     GeometryLine,
@@ -45,6 +46,12 @@ Value = (
     | Table
     | Range
     | RecordID
+    # A reference to a file in a storage bucket. Encodable since file support
+    # landed, and returned by the decoder, so leaving it out made storing one
+    # in a record - the main thing it is for - fail a type check on code that
+    # works. Exactly the omission the `set` note below records having already
+    # shipped once.
+    | File
     | Duration
     | Datetime
     | GeometryPoint

--- a/tests/unit_tests/connections/files/test_files.py
+++ b/tests/unit_tests/connections/files/test_files.py
@@ -415,6 +415,76 @@ async def test_the_async_http_transport_agrees(
     assert await async_http_connection.files.exists(f) is True
 
 
+# --------------------------------------------------- the whole async surface
+
+
+async def test_every_async_method_is_exercised(
+    async_ws_connection: AsyncWsSurrealConnection, bucket: str
+) -> None:
+    """All eleven, not just the four the transport tests happen to touch.
+
+    Before this, seven of ``AsyncFiles``' methods - put_if_not_exists, delete,
+    head, copy, copy_if_not_exists, rename, rename_if_not_exists - could all be
+    gutted to ``return None`` and the suite still passed. The blocking surface was
+    covered method by method and the async one rode on three smoke tests, so a
+    divergence between the two would not have shown up.
+    """
+    files = async_ws_connection.files
+    source = File(bucket, _key("async-src-"))
+    target = File(bucket, _key("async-dst-"))
+
+    await files.put(source, b"one")
+    assert await files.get(source) == b"one"
+    assert await files.exists(source) is True
+
+    # put_if_not_exists must not overwrite
+    await files.put_if_not_exists(source, b"two")
+    assert await files.get(source) == b"one"
+
+    meta = await files.head(source)
+    assert meta is not None
+    assert meta.size == 3
+    assert meta.file == source
+
+    await files.copy(source, target)
+    assert await files.get(target) == b"one"
+
+    # copy_if_not_exists must not overwrite the now-occupied target
+    await files.put(target, b"occupied")
+    await files.copy_if_not_exists(source, target)
+    assert await files.get(target) == b"occupied"
+
+    renamed_key = _key("async-moved-")
+    await files.rename(target, renamed_key)
+    assert await files.exists(target) is False
+    assert await files.get(File(bucket, renamed_key)) == b"occupied"
+
+    # rename_if_not_exists must not clobber an occupied key
+    await files.rename_if_not_exists(source, renamed_key)
+    assert await files.get(File(bucket, renamed_key)) == b"occupied"
+    assert await files.get(source) == b"one"
+
+    listed = await files.list(bucket, prefix="/async-")
+    assert {entry.file.key for entry in listed} >= {source.key, renamed_key}
+
+    await files.delete(source)
+    assert await files.exists(source) is False
+    assert await files.get(source) is None
+    assert await files.head(source) is None
+
+
+async def test_the_async_surface_matches_the_blocking_one(
+    async_ws_connection: AsyncWsSurrealConnection,
+) -> None:
+    """A method on one and not the other is a divergence users would hit."""
+    from surrealdb.connections.files import AsyncFiles, BlockingFiles
+
+    def public(cls: type) -> set[str]:
+        return {n for n in dir(cls) if not n.startswith("_")}
+
+    assert public(AsyncFiles) == public(BlockingFiles)
+
+
 # --------------------------------------------------------------- sessions and txns
 
 
@@ -440,7 +510,7 @@ def test_a_session_carries_its_own_context(
         session.close_session()
 
 
-def test_writes_inside_a_transaction_are_visible_after_commit(
+def test_writes_routed_through_a_transaction_reach_the_bucket(
     blocking_ws_connection: BlockingWsSurrealConnection,
     bucket: str,
     connection_params: dict[str, Any],
@@ -458,3 +528,98 @@ def test_writes_inside_a_transaction_are_visible_after_commit(
         assert blocking_ws_connection.files.get(f) == b"in a transaction"
     finally:
         session.close_session()
+
+
+def test_file_writes_are_not_transactional_and_survive_cancel(
+    blocking_ws_connection: BlockingWsSurrealConnection,
+    bucket: str,
+    connection_params: dict[str, Any],
+) -> None:
+    """Routed through a transaction is not the same as being *in* one.
+
+    ``file::*`` writes to the bucket backend rather than to the transaction, so a
+    file written inside one survives ``cancel()`` while a record written beside it
+    rolls back. This is the server's behaviour, not the SDK's - a raw
+    ``BEGIN; file::put(...); CANCEL;`` string with no SDK transaction object
+    anywhere behaves identically.
+
+    Pinned because the obvious test - "visible after commit", directly above -
+    passes whether or not the write is transactional, so it cannot tell the two
+    apart. The docs previously implied isolation on the strength of exactly that.
+    """
+    namespace = connection_params["namespace"]
+    database = connection_params["database_name"]
+    table = f"txnctl_{uuid.uuid4().hex[:8]}"
+    blocking_ws_connection.query(f"CREATE {table}:seed SET a = 0").execute()
+
+    session = blocking_ws_connection.new_session()
+    try:
+        session.use(namespace, database)
+        f = File(bucket, _key("cancelled-"))
+
+        transaction = session.begin_transaction()
+        transaction.files.put(f, b"survives")
+        transaction.query(f"CREATE {table}:rolled SET a = 1").execute()
+        transaction.cancel()
+    finally:
+        session.close_session()
+
+    rows = blocking_ws_connection.query(f"SELECT * FROM {table}").first()
+    assert [row["id"].id for row in rows] == ["seed"], "the record write must roll back"
+    assert blocking_ws_connection.files.get(f) == b"survives", (
+        "the file write is not transactional and must survive the cancel"
+    )
+
+
+# --------------------------------------------------------- the guarded variants
+
+
+def test_copy_if_not_exists_refuses_to_overwrite(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    """Swapping this for plain ``copy`` was invisible to the suite before."""
+    source, target = File(bucket, _key("src-")), File(bucket, _key("dst-"))
+    blocking_ws_connection.files.put(source, b"new")
+    blocking_ws_connection.files.put(target, b"existing")
+
+    blocking_ws_connection.files.copy_if_not_exists(source, target)
+
+    assert blocking_ws_connection.files.get(target) == b"existing"
+
+
+def test_copy_if_not_exists_writes_when_the_target_is_free(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    source, target = File(bucket, _key("src-")), File(bucket, _key("dst-"))
+    blocking_ws_connection.files.put(source, b"content")
+
+    blocking_ws_connection.files.copy_if_not_exists(source, target)
+
+    assert blocking_ws_connection.files.get(target) == b"content"
+
+
+def test_rename_if_not_exists_refuses_to_overwrite(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    source = File(bucket, _key("from-"))
+    taken_key = _key("taken-")
+    blocking_ws_connection.files.put(source, b"moving")
+    blocking_ws_connection.files.put(File(bucket, taken_key), b"already here")
+
+    blocking_ws_connection.files.rename_if_not_exists(source, taken_key)
+
+    assert blocking_ws_connection.files.get(File(bucket, taken_key)) == b"already here"
+    assert blocking_ws_connection.files.get(source) == b"moving", "source is untouched"
+
+
+def test_rename_if_not_exists_moves_when_the_key_is_free(
+    blocking_ws_connection: BlockingWsSurrealConnection, bucket: str
+) -> None:
+    source = File(bucket, _key("from-"))
+    free_key = _key("to-")
+    blocking_ws_connection.files.put(source, b"moving")
+
+    blocking_ws_connection.files.rename_if_not_exists(source, free_key)
+
+    assert blocking_ws_connection.files.get(File(bucket, free_key)) == b"moving"
+    assert blocking_ws_connection.files.exists(source) is False

--- a/tests/unit_tests/connections/test_readme_examples_run.py
+++ b/tests/unit_tests/connections/test_readme_examples_run.py
@@ -24,6 +24,7 @@ from typing import Any
 import pytest
 
 from surrealdb import AsyncSurreal, Surreal
+from surrealdb.connections.blocking_ws import BlockingWsSurrealConnection
 from surrealdb.data.types.record_id import RecordID
 from surrealdb.data.types.table import Table
 from surrealdb.errors import NotFoundError
@@ -161,3 +162,72 @@ async def test_the_async_usage_block_runs(connection_params: dict[str, Any]) -> 
         await db.signin({"username": "root", "password": "root"})
         await db.use(connection_params["namespace"], connection_params["database_name"])
         assert await db.query("RETURN 1").first() == 1
+
+
+def test_the_files_block_runs(
+    blocking_ws_connection: BlockingWsSurrealConnection, tmp_path: Any
+) -> None:
+    """The README's Files block, statement by statement, in its order.
+
+    It was not covered when file support landed - this harness reproduces blocks
+    by hand rather than exec-ing the markdown, so a new block is only covered
+    once someone adds it. The block shipped using ``png_bytes`` on the line
+    *before* it was assigned, which is a ``NameError`` for anyone who pastes it.
+    """
+    from surrealdb import File
+
+    bucket = f"readme_{uuid.uuid4().hex[:8]}"
+    try:
+        blocking_ws_connection.query(
+            f'DEFINE BUCKET IF NOT EXISTS {bucket} BACKEND "memory"'
+        ).execute()
+    except Exception:
+        pytest.skip("server has no bucket support")
+
+    source = tmp_path / "avatar.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n" + b"pixels")
+
+    # from surrealdb import File, Surreal  -- the connection is the fixture
+    avatar = File(bucket, "/photos/avatar.png")
+
+    with source.open("rb") as handle:
+        blocking_ws_connection.files.put(avatar, handle.read())
+
+    png_bytes = blocking_ws_connection.files.get(avatar)
+    assert png_bytes == source.read_bytes()
+
+    meta = blocking_ws_connection.files.head(avatar)
+    assert meta is not None
+    assert meta.size == len(png_bytes)
+    assert meta.updated is not None
+
+    listed = list(blocking_ws_connection.files.list(bucket, prefix="/photos", limit=50))
+    assert [(entry.file.key, entry.size) for entry in listed] == [
+        ("/photos/avatar.png", len(png_bytes))
+    ]
+
+
+def test_the_files_encoding_block_runs(
+    blocking_ws_connection: BlockingWsSurrealConnection, tmp_path: Any
+) -> None:
+    """The two-line block under "Why files are bound, not written into queries"."""
+    from surrealdb import File
+
+    bucket = f"readme_{uuid.uuid4().hex[:8]}"
+    try:
+        blocking_ws_connection.query(
+            f'DEFINE BUCKET IF NOT EXISTS {bucket} BACKEND "memory"'
+        ).execute()
+    except Exception:
+        pytest.skip("server has no bucket support")
+
+    readme, photo = File(bucket, "/readme.txt"), File(bucket, "/photo.bin")
+    source = tmp_path / "photo.bin"
+    source.write_bytes(b"binary")
+
+    blocking_ws_connection.files.put(readme, b"hello")
+    with source.open("rb") as handle:
+        blocking_ws_connection.files.put(photo, handle.read())
+
+    assert blocking_ws_connection.files.get(readme) == b"hello"
+    assert blocking_ws_connection.files.get(photo) == b"binary"

--- a/tests/unit_tests/data_types/test_file.py
+++ b/tests/unit_tests/data_types/test_file.py
@@ -18,6 +18,7 @@ literal at all, and any rendering of one is display-only. The JavaScript SDK's
 server rejects; that is why this type does not copy it.
 """
 
+import re
 from typing import Any
 
 import pytest
@@ -199,6 +200,52 @@ def test_the_decoder_normalises_too() -> None:
 
 
 # --------------------------------------------------------------- exports
+
+
+def test_it_is_a_member_of_the_public_value_union() -> None:
+    """``Value`` annotates every payload and every ``query().first()`` result.
+
+    Leaving ``File`` out made ``db.create(t, {"a": File(...)})`` fail a type check
+    on code that works at runtime, and made a returned one narrow to unreachable.
+    The same omission already shipped once for ``set`` - the union carries a
+    comment about it - so this checks the general rule instead of the one name:
+    everything the encoder accepts has to be in the union.
+    """
+    import typing
+
+    from surrealdb.types import Value
+
+    members = set()
+    for member in typing.get_args(Value):
+        members.add(getattr(member, "__origin__", member))
+
+    assert File in members, "File encodes and decodes, so Value must admit it"
+
+
+def test_every_encodable_type_is_in_the_value_union() -> None:
+    """The general form of the check above, so the next type cannot slip either."""
+    import inspect
+    import typing
+
+    from surrealdb.data import cbor
+    from surrealdb.types import Value
+
+    source = inspect.getsource(cbor.default_encoder)
+    encodable = set(re.findall(r"isinstance\(obj, ([A-Z]\w+)\)", source))
+    members = {
+        getattr(m, "__origin__", m).__name__
+        for m in typing.get_args(Value)
+        if hasattr(getattr(m, "__origin__", m), "__name__")
+    }
+    # `BoundIncluded`/`BoundExcluded` are encodable but are not values in their
+    # own right - they only exist inside a `Range`, and the server rejects a bare
+    # one with a parse error, so `Value` is right to leave them out. Checked
+    # against a live server rather than assumed, because adding them to the union
+    # would have advertised something you cannot actually store.
+    components_only = {"BoundIncluded", "BoundExcluded"}
+    missing = {name for name in encodable if name not in members} - components_only
+
+    assert missing == set(), f"encodable but absent from Value: {sorted(missing)}"
 
 
 def test_it_is_exported_from_the_package() -> None:


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

An adversarial audit of the file support merged in [#350](https://github.com/surrealdb/surrealdb.py/pull/350), before it is frozen into a stable release. Five lenses, refute-by-default verification: 25 claims, 4 confirmed. Two more came out of me checking the *refutations*, because "the SDK is not at fault" is not the same as "the docs are true".

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## What does this change do?

**`File` is now in the public `Value` union.** This is the one that had to be fixed before a freeze. `Value` annotates every `create`/`update`/`insert` payload and every `query().first()` result, so leaving `File` out meant this failed a type check on code that works at runtime:

```python
db.create("doc", {"attachment": File("images", "/a.png")})
# error: Dict entry 0 has incompatible type "str": "File"; expected ... [dict-item]
```

A returned `File` also narrowed to unreachable. Storing one in a record is the main reason the type exists, so a typed user had to reach for `# type: ignore`. It is the same omission that already shipped once for `set` — the union carries a comment about it — so the guard here checks the **general rule**: everything the encoder dispatches on must be in the union.

Writing that guard immediately flagged `BoundIncluded` and `BoundExcluded` as well. I checked against the server before "fixing" it: a bare bound is rejected with a parse error, and only `Range` — which contains them — round-trips. So the union is right to exclude them, and the guard records why rather than advertising something you cannot store.

**The transaction claim was wrong, and it was mine.** The docs said `txn.files.put(...)` "runs inside that transaction". Three lenses independently raised this and all three were refuted as "server behaviour, not an SDK defect" — which is true, and beside the point. I confirmed it by hand:

```
record write inside the txn, after cancel : rolled back
file write inside the txn, after cancel   : b'survives'
```

`file::*` writes to the bucket backend rather than the transaction, so the write is visible to other connections immediately and survives `cancel()`. The sentence promised isolation that does not exist. README, CHANGELOG and module docstring now say so plainly, and there is a test pinning it — **the previous test could not**, because "visible after commit" passes whether or not the write is transactional.

**Three smaller docs defects**, all confirmed by the audit: the README promised `db.files` on "all six connection classes" when the two embedded ones fail every call; its Files example used `png_bytes` a line *before* assigning it, so anyone pasting it got a `NameError`; and `list`'s docstring read "newest options applied server-side", implying a recency ordering the server does not have (it orders by key).

## What is your testing strategy?

**Three coverage gaps closed, each verified by a mutation that previously survived.** I re-ran the audit's mutation claims myself rather than taking them:

| mutation | before | now |
| --- | --- | --- |
| gut 7 of AsyncFiles' 11 methods to `return None` | 77 passed | `test_every_async_method_is_exercised` |
| `copy_if_not_exists` → plain `copy` (destructive) | 77 passed | `test_copy_if_not_exists_refuses_to_overwrite` + async |
| `rename_if_not_exists` → plain `rename` (destructive) | 77 passed | `test_rename_if_not_exists_refuses_to_overwrite` + async |

The two `*_if_not_exists` ones are the worst of these: those methods exist *specifically* not to overwrite, and swapping either for its destructive counterpart was invisible to the whole suite. The blocking surface had been covered method by method while the async surface rode on three smoke tests, so a divergence between them would not have shown either — there is now a test asserting the two classes expose the same public names.

**The README's Files blocks are now run by the example harness.** That harness reproduces blocks statement by statement by hand rather than exec-ing markdown, so a new block is only covered once someone adds it — which is exactly how the `png_bytes` `NameError` shipped.

**Guards mutation-tested too**: removing `| File` from the union fails both new union tests.

Full suite **1624 passed** (up from 1613), 95 addon tests, ruff, three mypy runs and two pyright runs all clean.

## What the audit refuted, for the record

21 of 25 claims did not survive verification, and the refutations were mostly good — several were correct observations whose *suggested fix* would have been worse than the defect. Worth naming two that are real but deliberately not addressed here: `files.put()` has no chunked or streaming path for very large payloads, and `list(prefix=...)` is a raw string prefix rather than a path prefix. Both are additive to fix later; neither needs a major version.

## Is this related to any issues?

Follows up #350.

## Have you read the [Contributing Guidelines]?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md)

[Contributing Guidelines]: https://github.com/surrealdb/surrealdb.py/blob/main/CONTRIBUTING.md
